### PR TITLE
Add friends system, Maps fix, launch scripts, emulator support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ main, user-manager ]
+    branches: [ main ]
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main, user-manager ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Run shared + server tests (JVM)
+        run: ./gradlew :shared:jvmTest :server:test
+
+      - name: Run Android unit tests
+        run: ./gradlew :android:testDebugUnitTest
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            **/build/reports/tests/
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# Where — Design Choices & Coding Standards
+
+## Project overview
+**Where** is a cross-platform real-time location sharing app (iOS, Android, Ktor server) built with Kotlin Multiplatform (KMP). The long-term goal is end-to-end encryption; v1 intentionally ships without it to validate the core data flow first.
+
+---
+
+## Architecture
+
+### Module layout
+| Module | Role |
+|---|---|
+| `shared/` | KMP library — data models, `LocationSyncClient` (WebSocket), platform `expect/actual` |
+| `android/` | Android app — Compose UI, FusedLocation foreground service, Google Maps |
+| `server/` | Ktor server — WebSocket hub, in-memory location store |
+| `ios/` | iOS app — SwiftUI + MapKit + CoreLocation, native URLSession WebSocket |
+
+### Data flow
+```
+[iOS / Android]
+  GPS → LocationService / LocationManager
+      → LocationSyncClient.sendLocation()  (KMP on Android, Swift on iOS)
+      → WS /ws?userId=<uuid>
+      → Ktor server broadcasts all locations
+      → clients update map pins
+```
+
+### Real-time transport
+- **WebSocket** on `/ws?userId=<uuid>` (Ktor `WebSockets` plugin, `ktor-server-websockets`).
+- Server fan-outs the full user list after every location update — simple, correct, scales fine for small groups.
+- Clients reconnect automatically with a 3-second backoff.
+
+### User identity
+- A random UUID is generated on first launch and persisted (`SharedPreferences` on Android, `UserDefaults` on iOS).
+- No accounts, no auth in v1.
+
+---
+
+## Key design decisions
+
+### Shared vs. platform-specific networking
+- **Android**: uses `LocationSyncClient` from the shared KMP module (Ktor WebSocket client over OkHttp).
+- **iOS**: uses a native Swift `LocationSyncService` backed by `URLSessionWebSocketTask`. Bridging Kotlin coroutines + Ktor to Swift 6 strict concurrency adds friction; native URLSession is simpler and idiomatic.
+- The shared module still owns all serializable data models (`UserLocation`, `WsMessage`).
+
+### Maps
+- **Android**: `maps-compose` (Google Maps Compose). Requires a `MAPS_API_KEY` in `local.properties`.
+- **iOS**: `MapKit` via `UIViewRepresentable` — no API key needed.
+
+### Battery efficiency
+- **Android**: `FusedLocationProviderClient` with `PRIORITY_BALANCED_POWER_ACCURACY`, 30s interval, run inside a foreground service so the OS does not kill it.
+- **iOS**: `distanceFilter = 50m` + `desiredAccuracy = kCLLocationAccuracyHundredMeters`; `startMonitoringSignificantLocationChanges()` when backgrounded.
+
+### Server state
+- In-memory `ConcurrentHashMap`s for locations and sessions. State is lost on restart — intentional for v1. Persistence (e.g. Redis or a DB) is deferred.
+
+---
+
+## Coding standards
+
+### Kotlin (shared + server)
+- **Kotlin 2.1 / JVM 17 (Android) / JVM 21 (server)**.
+- `kotlinx.serialization` for all JSON. Sealed `WsMessage` uses `classDiscriminator = "type"` and `@SerialName` on each subclass.
+- Coroutines: use `SupervisorJob()` so one failed child doesn't cancel siblings. Prefer `StateFlow` over `LiveData`.
+- No mutable global state except the intentional `LocationRepository` singleton (bridge between service and ViewModel).
+- New platform targets require an `actual fun` in `androidMain`, `iosMain`, and `jvmMain`.
+
+### Swift (iOS)
+- **Swift 6 strict concurrency** — all `ObservableObject` classes marked `@MainActor`.
+- Use `async/await` for async WebSocket receive loops (`URLSessionWebSocketTask.receive()`).
+- No KMP bridging for networking; native `URLSession` only.
+- `Codable` structs mirror the Kotlin `@Serializable` data classes exactly (same field names).
+
+### Android
+- Jetpack Compose only — no XML layouts.
+- ViewModels use `AndroidViewModel` when `Application` context is needed.
+- `LocationRepository` is the single source of truth between the foreground `Service` and `ViewModel`.
+
+### Dependency management
+- All versions in `gradle/libs.versions.toml` (version catalog). Never hardcode versions inline.
+- Add new dependencies to the catalog first, then reference via `libs.*` alias.
+
+---
+
+## Local development
+
+### Server
+```bash
+./gradlew :server:run
+curl localhost:8080/health   # → ok
+curl localhost:8080/locations # → []
+```
+
+### Android (emulator)
+- Server URL in `LocationViewModel` is `ws://10.0.2.2:8080/ws` (emulator loopback to host).
+- Add your Maps API key: `echo "MAPS_API_KEY=your_key" >> local.properties`
+- Build: `./gradlew :android:assembleDebug`
+
+### iOS (simulator)
+- Server URL in `LocationSyncService` is `ws://localhost:8080/ws`.
+- Generate Xcode project: `cd ios && xcoderun xcodegen` (or `xcodegen` in nix shell).
+- Build KMP framework first: `./gradlew :shared:embedAndSignAppleFrameworkForXcode`
+
+---
+
+## Planned future work
+- End-to-end encryption (E2EE) — protocol TBD
+- Persistent server storage
+- User-controlled sharing (groups, time-limited sharing)
+- Push notifications when a friend's location changes significantly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,8 @@
 ### Shared vs. platform-specific networking
 - **Android**: uses `LocationSyncClient` from the shared KMP module (Ktor WebSocket client over OkHttp).
 - **iOS**: uses a native Swift `LocationSyncService` backed by `URLSessionWebSocketTask`. Bridging Kotlin coroutines + Ktor to Swift 6 strict concurrency adds friction; native URLSession is simpler and idiomatic.
-- The shared module still owns all serializable data models (`UserLocation`, `WsMessage`).
+- **All protocol data models are in the shared KMP module** — `UserLocation`, `WsMessage`, and all subclasses. iOS imports the `Shared` framework and uses these types directly; there are no duplicate Swift structs mirroring the Kotlin models.
+- **`LocationMessageCodec`** (in `shared/`) is a Swift-friendly singleton that handles all `kotlinx.serialization` encoding/decoding for iOS. iOS calls `LocationMessageCodec.shared.encodeLocationUpdate(...)` / `decodeUsers(text:)` instead of using Swift `Codable`.
 
 ### Maps
 - **Android**: `maps-compose` (Google Maps Compose). Requires a `MAPS_API_KEY` in `local.properties`.
@@ -68,8 +69,8 @@
 ### Swift (iOS)
 - **Swift 6 strict concurrency** — all `ObservableObject` classes marked `@MainActor`.
 - Use `async/await` for async WebSocket receive loops (`URLSessionWebSocketTask.receive()`).
-- No KMP bridging for networking; native `URLSession` only.
-- `Codable` structs mirror the Kotlin `@Serializable` data classes exactly (same field names).
+- Native `URLSession` for WebSocket networking; no Ktor/coroutine bridging.
+- Use KMP types (`UserLocation`, etc.) directly — no duplicate Swift structs. All protocol JSON encoding/decoding goes through `LocationMessageCodec.shared`.
 
 ### Android
 - Jetpack Compose only — no XML layouts.
@@ -98,8 +99,8 @@ curl localhost:8080/locations # → []
 
 ### iOS (simulator)
 - Server URL in `LocationSyncService` is `ws://localhost:8080/ws`.
-- Generate Xcode project: `cd ios && xcoderun xcodegen` (or `xcodegen` in nix shell).
-- Build KMP framework first: `./gradlew :shared:embedAndSignAppleFrameworkForXcode`
+- Generate Xcode project: `cd ios && xcodegen` (or `xcoderun xcodegen` in nix shell). The project calls `embedAndSignAppleFrameworkForXcode` as a pre-build script automatically.
+- To build the KMP framework manually: `./gradlew :shared:embedAndSignAppleFrameworkForXcode`
 
 ---
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -22,6 +22,8 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "0.1.0"
+        val mapsKey = project.findProperty("MAPS_API_KEY")?.toString() ?: ""
+        manifestPlaceholders["MAPS_API_KEY"] = mapsKey
     }
 
     buildFeatures {
@@ -40,5 +42,9 @@ dependencies {
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons.extended)
     implementation(libs.activity.compose)
+    implementation(libs.maps.compose)
+    implementation(libs.play.services.location)
+    implementation(libs.accompanist.permissions)
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -16,6 +16,14 @@ kotlin {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
         }
     }
+
+    sourceSets {
+        androidUnitTest.dependencies {
+            implementation(kotlin("test"))
+            implementation(libs.robolectric)
+            implementation(libs.androidx.test.core)
+        }
+    }
 }
 
 android {
@@ -49,8 +57,6 @@ android {
 }
 
 dependencies {
-    testImplementation(libs.robolectric)
-    testImplementation(kotlin("test"))
     implementation(project(":shared"))
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,7 +1,13 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.compose.compiler)
+}
+
+val localProperties = Properties().also { props ->
+    rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use(props::load)
 }
 
 kotlin {
@@ -22,12 +28,14 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "0.1.0"
-        val mapsKey = project.findProperty("MAPS_API_KEY")?.toString() ?: ""
-        manifestPlaceholders["MAPS_API_KEY"] = mapsKey
+        manifestPlaceholders["MAPS_API_KEY"] = localProperties.getProperty("MAPS_API_KEY") ?: ""
+        buildConfigField("String", "SERVER_WS_URL",
+            "\"${localProperties.getProperty("SERVER_WS_URL") ?: "ws://10.0.2.2:8080/ws"}\"")
     }
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     compileOptions {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -42,9 +42,15 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
 }
 
 dependencies {
+    testImplementation(libs.robolectric)
+    testImplementation(kotlin("test"))
     implementation(project(":shared"))
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)

--- a/android/src/androidMain/AndroidManifest.xml
+++ b/android/src/androidMain/AndroidManifest.xml
@@ -1,8 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:label="Where"
         android:theme="@style/Theme.Where">
+
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="${MAPS_API_KEY}" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true">
@@ -11,5 +25,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".LocationService"
+            android:foregroundServiceType="location"
+            android:exported="false" />
+
     </application>
 </manifest>

--- a/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
@@ -1,0 +1,139 @@
+package net.af0.where
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FriendsSheet(
+    userId: String,
+    friendIds: Set<String>,
+    onAdd: (String) -> Unit,
+    onRemove: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val clipboard: ClipboardManager = LocalClipboardManager.current
+    var copiedRecently by remember { mutableStateOf(false) }
+    var newId by remember { mutableStateOf("") }
+
+    LaunchedEffect(copiedRecently) {
+        if (copiedRecently) {
+            delay(2000)
+            copiedRecently = false
+        }
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text("Friends", style = MaterialTheme.typography.titleLarge)
+
+            // Your ID section
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier.padding(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text("Your ID", style = MaterialTheme.typography.labelMedium)
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            text = userId,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = FontFamily.Monospace,
+                            modifier = Modifier.weight(1f),
+                        )
+                        FilledTonalButton(
+                            onClick = {
+                                clipboard.setText(AnnotatedString(userId))
+                                copiedRecently = true
+                            },
+                        ) {
+                            Icon(Icons.Default.ContentCopy, contentDescription = null, modifier = Modifier.size(16.dp))
+                            Spacer(Modifier.width(4.dp))
+                            Text(if (copiedRecently) "Copied!" else "Copy")
+                        }
+                    }
+                    Text(
+                        "Share this with friends so they can add you.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // Add a friend
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(
+                    value = newId,
+                    onValueChange = { newId = it },
+                    label = { Text("Paste a friend's ID") },
+                    modifier = Modifier.weight(1f),
+                    singleLine = true,
+                    textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                )
+                FilledTonalButton(
+                    onClick = { onAdd(newId); newId = "" },
+                    enabled = newId.isNotBlank(),
+                ) {
+                    Icon(Icons.Default.PersonAdd, contentDescription = "Add")
+                }
+            }
+
+            // Friends list
+            if (friendIds.isNotEmpty()) {
+                Text("Friends (${friendIds.size})", style = MaterialTheme.typography.labelMedium)
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    items(friendIds.toList()) { id ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(id.take(8), style = MaterialTheme.typography.bodyMedium, fontFamily = FontFamily.Monospace)
+                                Text(id, style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                            IconButton(onClick = { onRemove(id) }) {
+                                Icon(Icons.Default.Delete, contentDescription = "Remove", tint = MaterialTheme.colorScheme.error)
+                            }
+                        }
+                    }
+                }
+            } else {
+                Text(
+                    "No friends added yet.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
@@ -1,5 +1,6 @@
 package net.af0.where
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -26,6 +27,7 @@ fun FriendsSheet(
     onAdd: (String) -> Unit,
     onRemove: (String) -> Unit,
     onDismiss: () -> Unit,
+    onZoomTo: (String) -> Unit = {},
 ) {
     val clipboard: ClipboardManager = LocalClipboardManager.current
     var copiedRecently by remember { mutableStateOf(false) }
@@ -112,7 +114,9 @@ fun FriendsSheet(
                 LazyColumn(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     items(friendIds.toList()) { id ->
                         Row(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onZoomTo(id); onDismiss() },
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {

--- a/android/src/androidMain/kotlin/net/af0/where/FriendsStore.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/FriendsStore.kt
@@ -29,8 +29,9 @@ class FriendsStore(context: Context, private val ownUserId: String) {
     }
 
     fun toggleSharing() {
-        _isSharingLocation.update { !it }
-        prefs.edit().putBoolean("is_sharing", _isSharingLocation.value).apply()
+        _isSharingLocation.update { prev ->
+            (!prev).also { new -> prefs.edit().putBoolean("is_sharing", new).apply() }
+        }
     }
 
     private fun loadFriends(): Set<String> =

--- a/android/src/androidMain/kotlin/net/af0/where/FriendsStore.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/FriendsStore.kt
@@ -1,0 +1,41 @@
+package net.af0.where
+
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FriendsStore(context: Context, private val ownUserId: String) {
+
+    private val prefs = context.getSharedPreferences("where_friends", Context.MODE_PRIVATE)
+
+    private val _friendIds = MutableStateFlow(loadFriends())
+    val friendIds: StateFlow<Set<String>> = _friendIds.asStateFlow()
+
+    private val _isSharingLocation = MutableStateFlow(true)
+    val isSharingLocation: StateFlow<Boolean> = _isSharingLocation.asStateFlow()
+
+    fun add(id: String) {
+        val trimmed = id.trim()
+        if (trimmed.isEmpty() || trimmed == ownUserId) return
+        val updated = _friendIds.value + trimmed
+        _friendIds.value = updated
+        persist(updated)
+    }
+
+    fun remove(id: String) {
+        val updated = _friendIds.value - id
+        _friendIds.value = updated
+        persist(updated)
+    }
+
+    fun toggleSharing() {
+        _isSharingLocation.value = !_isSharingLocation.value
+    }
+
+    private fun loadFriends(): Set<String> =
+        prefs.getStringSet("ids", emptySet())?.toSet() ?: emptySet()
+
+    private fun persist(ids: Set<String>) =
+        prefs.edit().putStringSet("ids", ids).apply()
+}

--- a/android/src/androidMain/kotlin/net/af0/where/FriendsStore.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/FriendsStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 class FriendsStore(context: Context, private val ownUserId: String) {
 
@@ -28,9 +29,8 @@ class FriendsStore(context: Context, private val ownUserId: String) {
     }
 
     fun toggleSharing() {
-        val newValue = !_isSharingLocation.value
-        _isSharingLocation.value = newValue
-        prefs.edit().putBoolean("is_sharing", newValue).apply()
+        _isSharingLocation.update { !it }
+        prefs.edit().putBoolean("is_sharing", _isSharingLocation.value).apply()
     }
 
     private fun loadFriends(): Set<String> =

--- a/android/src/androidMain/kotlin/net/af0/where/FriendsStore.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/FriendsStore.kt
@@ -12,7 +12,7 @@ class FriendsStore(context: Context, private val ownUserId: String) {
     private val _friendIds = MutableStateFlow(loadFriends())
     val friendIds: StateFlow<Set<String>> = _friendIds.asStateFlow()
 
-    private val _isSharingLocation = MutableStateFlow(true)
+    private val _isSharingLocation = MutableStateFlow(prefs.getBoolean("is_sharing", true))
     val isSharingLocation: StateFlow<Boolean> = _isSharingLocation.asStateFlow()
 
     fun add(id: String) {
@@ -28,7 +28,9 @@ class FriendsStore(context: Context, private val ownUserId: String) {
     }
 
     fun toggleSharing() {
-        _isSharingLocation.value = !_isSharingLocation.value
+        val newValue = !_isSharingLocation.value
+        _isSharingLocation.value = newValue
+        prefs.edit().putBoolean("is_sharing", newValue).apply()
     }
 
     private fun loadFriends(): Set<String> =

--- a/android/src/androidMain/kotlin/net/af0/where/FriendsStore.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/FriendsStore.kt
@@ -18,15 +18,13 @@ class FriendsStore(context: Context, private val ownUserId: String) {
     fun add(id: String) {
         val trimmed = id.trim()
         if (trimmed.isEmpty() || trimmed == ownUserId) return
-        val updated = _friendIds.value + trimmed
-        _friendIds.value = updated
-        persist(updated)
+        _friendIds.update { it + trimmed }
+        persist(_friendIds.value)
     }
 
     fun remove(id: String) {
-        val updated = _friendIds.value - id
-        _friendIds.value = updated
-        persist(updated)
+        _friendIds.update { it - id }
+        persist(_friendIds.value)
     }
 
     fun toggleSharing() {

--- a/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
@@ -1,0 +1,26 @@
+package net.af0.where
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import net.af0.where.model.UserLocation
+
+/**
+ * Singleton that bridges the LocationService (which has no ViewModel access)
+ * with the LocationViewModel via simple StateFlows.
+ */
+object LocationRepository {
+    private val _lastLocation = MutableStateFlow<Pair<Double, Double>?>(null)
+    val lastLocation: StateFlow<Pair<Double, Double>?> = _lastLocation.asStateFlow()
+
+    private val _users = MutableStateFlow<List<UserLocation>>(emptyList())
+    val users: StateFlow<List<UserLocation>> = _users.asStateFlow()
+
+    fun onLocation(lat: Double, lng: Double) {
+        _lastLocation.value = Pair(lat, lng)
+    }
+
+    fun onUsersUpdate(users: List<UserLocation>) {
+        _users.value = users
+    }
+}

--- a/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
@@ -5,22 +5,30 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import net.af0.where.model.UserLocation
 
+/** Minimal interface over the shared location state, making it injectable for tests. */
+interface LocationSource {
+    val lastLocation: StateFlow<Pair<Double, Double>?>
+    val users: StateFlow<List<UserLocation>>
+    fun onLocation(lat: Double, lng: Double)
+    fun onUsersUpdate(users: List<UserLocation>)
+}
+
 /**
  * Singleton that bridges the LocationService (which has no ViewModel access)
  * with the LocationViewModel via simple StateFlows.
  */
-object LocationRepository {
+object LocationRepository : LocationSource {
     private val _lastLocation = MutableStateFlow<Pair<Double, Double>?>(null)
-    val lastLocation: StateFlow<Pair<Double, Double>?> = _lastLocation.asStateFlow()
+    override val lastLocation: StateFlow<Pair<Double, Double>?> = _lastLocation.asStateFlow()
 
     private val _users = MutableStateFlow<List<UserLocation>>(emptyList())
-    val users: StateFlow<List<UserLocation>> = _users.asStateFlow()
+    override val users: StateFlow<List<UserLocation>> = _users.asStateFlow()
 
-    fun onLocation(lat: Double, lng: Double) {
+    override fun onLocation(lat: Double, lng: Double) {
         _lastLocation.value = Pair(lat, lng)
     }
 
-    fun onUsersUpdate(users: List<UserLocation>) {
+    override fun onUsersUpdate(users: List<UserLocation>) {
         _users.value = users
     }
 }

--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -1,0 +1,69 @@
+package net.af0.where
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import com.google.android.gms.location.*
+
+class LocationService : Service() {
+
+    private lateinit var fusedClient: FusedLocationProviderClient
+    private lateinit var locationCallback: LocationCallback
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+        startForeground(NOTIFICATION_ID, buildNotification())
+
+        fusedClient = LocationServices.getFusedLocationProviderClient(this)
+        locationCallback = object : LocationCallback() {
+            override fun onLocationResult(result: LocationResult) {
+                val loc = result.lastLocation ?: return
+                LocationRepository.onLocation(loc.latitude, loc.longitude)
+            }
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val request = LocationRequest.Builder(
+            Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+            30_000L // 30 seconds
+        ).setMinUpdateIntervalMillis(15_000L).build()
+
+        try {
+            fusedClient.requestLocationUpdates(request, locationCallback, mainLooper)
+        } catch (_: SecurityException) {
+            stopSelf()
+        }
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        fusedClient.removeLocationUpdates(locationCallback)
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID, "Where Location", NotificationManager.IMPORTANCE_LOW
+        )
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(): Notification =
+        Notification.Builder(this, CHANNEL_ID)
+            .setContentTitle("Where")
+            .setContentText("Sharing your location")
+            .setSmallIcon(android.R.drawable.ic_menu_mylocation)
+            .build()
+
+    companion object {
+        private const val CHANNEL_ID = "where_location"
+        private const val NOTIFICATION_ID = 1
+    }
+}

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -1,7 +1,10 @@
 package net.af0.where
 
+import android.Manifest
 import android.app.Application
 import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.SharingStarted
@@ -33,7 +36,7 @@ class LocationViewModel(app: Application) : AndroidViewModel(app) {
     init {
         syncClient.connect()
         viewModelScope.launch {
-            var prevSharing = true
+            var prevSharing = friendsStore.isSharingLocation.value
             combine(
                 LocationRepository.lastLocation,
                 friendsStore.isSharingLocation,
@@ -45,9 +48,15 @@ class LocationViewModel(app: Application) : AndroidViewModel(app) {
                 }
                 if (prevSharing != sharing) {
                     val intent = Intent(getApplication(), LocationService::class.java)
-                    if (sharing) {
+                    val hasLocationPermission = ContextCompat.checkSelfPermission(
+                        getApplication(), Manifest.permission.ACCESS_FINE_LOCATION
+                    ) == PackageManager.PERMISSION_GRANTED ||
+                    ContextCompat.checkSelfPermission(
+                        getApplication(), Manifest.permission.ACCESS_COARSE_LOCATION
+                    ) == PackageManager.PERMISSION_GRANTED
+                    if (sharing && hasLocationPermission) {
                         getApplication<Application>().startForegroundService(intent)
-                    } else {
+                    } else if (!sharing) {
                         getApplication<Application>().stopService(intent)
                     }
                 }

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -24,7 +24,7 @@ class LocationViewModel(app: Application) : AndroidViewModel(app) {
     }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val syncClient = LocationSyncClient(
-        serverWsUrl = SERVER_WS_URL,
+        serverWsUrl = BuildConfig.SERVER_WS_URL,
         userId = userId,
         onLocationsUpdate = { LocationRepository.onUsersUpdate(it) },
     )
@@ -32,13 +32,17 @@ class LocationViewModel(app: Application) : AndroidViewModel(app) {
     init {
         syncClient.connect()
         viewModelScope.launch {
+            var prevSharing = true
             combine(
                 LocationRepository.lastLocation,
                 friendsStore.isSharingLocation,
             ) { loc, sharing -> Pair(loc, sharing) }.collect { (loc, sharing) ->
                 if (loc != null && sharing) {
                     syncClient.sendLocation(loc.first, loc.second)
+                } else if (prevSharing && !sharing) {
+                    syncClient.sendLocationRemove()
                 }
+                prevSharing = sharing
             }
         }
     }
@@ -46,9 +50,5 @@ class LocationViewModel(app: Application) : AndroidViewModel(app) {
     override fun onCleared() {
         syncClient.disconnect()
         super.onCleared()
-    }
-
-    companion object {
-        private const val SERVER_WS_URL = "ws://10.0.2.2:8080/ws"
     }
 }

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -14,14 +14,24 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import net.af0.where.model.UserLocation
 
-class LocationViewModel(app: Application) : AndroidViewModel(app) {
+class LocationViewModel(
+    app: Application,
+    private val locationSource: LocationSource = LocationRepository,
+) : AndroidViewModel(app) {
 
     val userId: String = UserPrefs.getUserId(app)
-    val friendsStore = FriendsStore(app, userId)
+    private val friendsStore = FriendsStore(app, userId)
+
+    val friendIds: StateFlow<Set<String>> = friendsStore.friendIds
+    val isSharingLocation: StateFlow<Boolean> = friendsStore.isSharingLocation
+
+    fun addFriend(id: String) = friendsStore.add(id)
+    fun removeFriend(id: String) = friendsStore.remove(id)
+    fun toggleSharing() = friendsStore.toggleSharing()
 
     // All users from server, filtered to self + friends
     val visibleUsers: StateFlow<List<UserLocation>> = combine(
-        LocationRepository.users,
+        locationSource.users,
         friendsStore.friendIds,
     ) { users, friends ->
         users.filter { it.userId == userId || friends.contains(it.userId) }
@@ -30,7 +40,7 @@ class LocationViewModel(app: Application) : AndroidViewModel(app) {
     private val syncClient = LocationSyncClient(
         serverWsUrl = BuildConfig.SERVER_WS_URL,
         userId = userId,
-        onLocationsUpdate = { LocationRepository.onUsersUpdate(it) },
+        onLocationsUpdate = { locationSource.onUsersUpdate(it) },
     )
 
     init {
@@ -38,7 +48,7 @@ class LocationViewModel(app: Application) : AndroidViewModel(app) {
         viewModelScope.launch {
             var prevSharing = friendsStore.isSharingLocation.value
             combine(
-                LocationRepository.lastLocation,
+                locationSource.lastLocation,
                 friendsStore.isSharingLocation,
             ) { loc, sharing -> Pair(loc, sharing) }.collect { (loc, sharing) ->
                 if (loc != null && sharing) {

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -1,6 +1,7 @@
 package net.af0.where
 
 import android.app.Application
+import android.content.Intent
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.SharingStarted
@@ -41,6 +42,14 @@ class LocationViewModel(app: Application) : AndroidViewModel(app) {
                     syncClient.sendLocation(loc.first, loc.second)
                 } else if (prevSharing && !sharing) {
                     syncClient.sendLocationRemove()
+                }
+                if (prevSharing != sharing) {
+                    val intent = Intent(getApplication(), LocationService::class.java)
+                    if (sharing) {
+                        getApplication<Application>().startForegroundService(intent)
+                    } else {
+                        getApplication<Application>().stopService(intent)
+                    }
                 }
                 prevSharing = sharing
             }

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -1,0 +1,54 @@
+package net.af0.where
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import net.af0.where.model.UserLocation
+
+class LocationViewModel(app: Application) : AndroidViewModel(app) {
+
+    val userId: String = UserPrefs.getUserId(app)
+    val friendsStore = FriendsStore(app, userId)
+
+    // All users from server, filtered to self + friends
+    val visibleUsers: StateFlow<List<UserLocation>> = combine(
+        LocationRepository.users,
+        friendsStore.friendIds,
+    ) { users, friends ->
+        users.filter { it.userId == userId || friends.contains(it.userId) }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    private val syncClient = LocationSyncClient(
+        serverWsUrl = SERVER_WS_URL,
+        userId = userId,
+        onLocationsUpdate = { LocationRepository.onUsersUpdate(it) },
+    )
+
+    init {
+        syncClient.connect()
+        viewModelScope.launch {
+            combine(
+                LocationRepository.lastLocation,
+                friendsStore.isSharingLocation,
+            ) { loc, sharing -> Pair(loc, sharing) }.collect { (loc, sharing) ->
+                if (loc != null && sharing) {
+                    syncClient.sendLocation(loc.first, loc.second)
+                }
+            }
+        }
+    }
+
+    override fun onCleared() {
+        syncClient.disconnect()
+        super.onCleared()
+    }
+
+    companion object {
+        private const val SERVER_WS_URL = "ws://10.0.2.2:8080/ws"
+    }
+}

--- a/android/src/androidMain/kotlin/net/af0/where/MainActivity.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MainActivity.kt
@@ -13,9 +13,12 @@ class MainActivity : ComponentActivity() {
 
     private val viewModel: LocationViewModel by viewModels()
 
+    fun startLocationService() {
+        startForegroundService(Intent(this, LocationService::class.java))
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        startForegroundService(Intent(this, LocationService::class.java))
 
         setContent {
             MaterialTheme {
@@ -30,6 +33,7 @@ class MainActivity : ComponentActivity() {
                     onToggleSharing = { viewModel.friendsStore.toggleSharing() },
                     onAddFriend = { viewModel.friendsStore.add(it) },
                     onRemoveFriend = { viewModel.friendsStore.remove(it) },
+                    onLocationPermissionGranted = ::startLocationService,
                 )
             }
         }

--- a/android/src/androidMain/kotlin/net/af0/where/MainActivity.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MainActivity.kt
@@ -1,6 +1,8 @@
 package net.af0.where
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -8,13 +10,22 @@ import androidx.activity.viewModels
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.core.content.ContextCompat
 
 class MainActivity : ComponentActivity() {
 
     private val viewModel: LocationViewModel by viewModels()
 
     fun startLocationService() {
-        startForegroundService(Intent(this, LocationService::class.java))
+        val hasPermission = ContextCompat.checkSelfPermission(
+            this, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED ||
+        ContextCompat.checkSelfPermission(
+            this, Manifest.permission.ACCESS_COARSE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+        if (hasPermission) {
+            startForegroundService(Intent(this, LocationService::class.java))
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -23,16 +34,16 @@ class MainActivity : ComponentActivity() {
         setContent {
             MaterialTheme {
                 val users by viewModel.visibleUsers.collectAsState()
-                val friendIds by viewModel.friendsStore.friendIds.collectAsState()
-                val isSharing by viewModel.friendsStore.isSharingLocation.collectAsState()
+                val friendIds by viewModel.friendIds.collectAsState()
+                val isSharing by viewModel.isSharingLocation.collectAsState()
                 MapScreen(
                     userId = viewModel.userId,
                     users = users,
                     friendIds = friendIds,
                     isSharing = isSharing,
-                    onToggleSharing = { viewModel.friendsStore.toggleSharing() },
-                    onAddFriend = { viewModel.friendsStore.add(it) },
-                    onRemoveFriend = { viewModel.friendsStore.remove(it) },
+                    onToggleSharing = { viewModel.toggleSharing() },
+                    onAddFriend = { viewModel.addFriend(it) },
+                    onRemoveFriend = { viewModel.removeFriend(it) },
                     onLocationPermissionGranted = ::startLocationService,
                 )
             }

--- a/android/src/androidMain/kotlin/net/af0/where/MainActivity.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MainActivity.kt
@@ -1,15 +1,37 @@
 package net.af0.where
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.material3.Text
+import androidx.activity.viewModels
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 
 class MainActivity : ComponentActivity() {
+
+    private val viewModel: LocationViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        startForegroundService(Intent(this, LocationService::class.java))
+
         setContent {
-            Text(text = Greeting().greet())
+            MaterialTheme {
+                val users by viewModel.visibleUsers.collectAsState()
+                val friendIds by viewModel.friendsStore.friendIds.collectAsState()
+                val isSharing by viewModel.friendsStore.isSharingLocation.collectAsState()
+                MapScreen(
+                    userId = viewModel.userId,
+                    users = users,
+                    friendIds = friendIds,
+                    isSharing = isSharing,
+                    onToggleSharing = { viewModel.friendsStore.toggleSharing() },
+                    onAddFriend = { viewModel.friendsStore.add(it) },
+                    onRemoveFriend = { viewModel.friendsStore.remove(it) },
+                )
+            }
         }
     }
 }

--- a/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
@@ -15,6 +15,7 @@ import com.google.accompanist.permissions.*
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.maps.android.compose.*
 import net.af0.where.model.UserLocation
 
@@ -28,6 +29,7 @@ fun MapScreen(
     onToggleSharing: () -> Unit,
     onAddFriend: (String) -> Unit,
     onRemoveFriend: (String) -> Unit,
+    onLocationPermissionGranted: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val locationPermissions = rememberMultiplePermissionsState(
@@ -40,6 +42,12 @@ fun MapScreen(
     LaunchedEffect(Unit) {
         if (!locationPermissions.allPermissionsGranted) {
             locationPermissions.launchMultiplePermissionRequest()
+        }
+    }
+
+    LaunchedEffect(locationPermissions.allPermissionsGranted) {
+        if (locationPermissions.allPermissionsGranted) {
+            onLocationPermissionGranted()
         }
     }
 
@@ -56,6 +64,7 @@ fun MapScreen(
     }
 
     var showFriends by remember { mutableStateOf(false) }
+    var zoomToUserId by remember { mutableStateOf<String?>(null) }
 
     val defaultPosition = remember { CameraPosition.fromLatLngZoom(LatLng(37.33, -122.03), 10f) }
     val cameraPositionState = rememberCameraPositionState { position = defaultPosition }
@@ -67,6 +76,17 @@ fun MapScreen(
                 LatLng(ownLocation.lat, ownLocation.lng), 14f
             )
         }
+    }
+
+    LaunchedEffect(zoomToUserId) {
+        val id = zoomToUserId ?: return@LaunchedEffect
+        val user = users.find { it.userId == id }
+        if (user != null) {
+            cameraPositionState.animate(
+                CameraUpdateFactory.newLatLngZoom(LatLng(user.lat, user.lng), 15f)
+            )
+        }
+        zoomToUserId = null
     }
 
     Box(modifier.fillMaxSize()) {
@@ -143,6 +163,7 @@ fun MapScreen(
             onAdd = onAddFriend,
             onRemove = onRemoveFriend,
             onDismiss = { showFriends = false },
+            onZoomTo = { zoomToUserId = it },
         )
     }
 }

--- a/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
@@ -1,5 +1,6 @@
 package net.af0.where
 
+import android.os.Build
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOff
@@ -39,6 +40,12 @@ fun MapScreen(
         )
     )
 
+    // Background location must be requested separately on Android 10+.
+    val backgroundLocationPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        rememberPermissionState(android.Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+    } else null
+    var showBackgroundRationale by remember { mutableStateOf(false) }
+
     LaunchedEffect(Unit) {
         if (!locationPermissions.allPermissionsGranted) {
             locationPermissions.launchMultiplePermissionRequest()
@@ -48,7 +55,33 @@ fun MapScreen(
     LaunchedEffect(locationPermissions.allPermissionsGranted) {
         if (locationPermissions.allPermissionsGranted) {
             onLocationPermissionGranted()
+            // Show disclosure before requesting background location (required by Play Store).
+            if (backgroundLocationPermission != null && !backgroundLocationPermission.status.isGranted) {
+                showBackgroundRationale = true
+            }
         }
+    }
+
+    if (showBackgroundRationale) {
+        AlertDialog(
+            onDismissRequest = { showBackgroundRationale = false },
+            title = { Text("Background Location") },
+            text = {
+                Text(
+                    "Allow Where to access your location in the background so friends can " +
+                    "see your position even when the app is not open."
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showBackgroundRationale = false
+                    backgroundLocationPermission?.launchPermissionRequest()
+                }) { Text("Allow") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showBackgroundRationale = false }) { Text("Skip") }
+            },
+        )
     }
 
     if (!locationPermissions.allPermissionsGranted) {

--- a/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
@@ -1,0 +1,148 @@
+package net.af0.where
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOff
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.permissions.*
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.*
+import net.af0.where.model.UserLocation
+
+@OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class)
+@Composable
+fun MapScreen(
+    userId: String,
+    users: List<UserLocation>,
+    friendIds: Set<String>,
+    isSharing: Boolean,
+    onToggleSharing: () -> Unit,
+    onAddFriend: (String) -> Unit,
+    onRemoveFriend: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val locationPermissions = rememberMultiplePermissionsState(
+        listOf(
+            android.Manifest.permission.ACCESS_FINE_LOCATION,
+            android.Manifest.permission.ACCESS_COARSE_LOCATION,
+        )
+    )
+
+    LaunchedEffect(Unit) {
+        if (!locationPermissions.allPermissionsGranted) {
+            locationPermissions.launchMultiplePermissionRequest()
+        }
+    }
+
+    if (!locationPermissions.allPermissionsGranted) {
+        Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("Location permission is required")
+                Button(onClick = { locationPermissions.launchMultiplePermissionRequest() }) {
+                    Text("Grant Permission")
+                }
+            }
+        }
+        return
+    }
+
+    var showFriends by remember { mutableStateOf(false) }
+
+    val defaultPosition = remember { CameraPosition.fromLatLngZoom(LatLng(37.33, -122.03), 10f) }
+    val cameraPositionState = rememberCameraPositionState { position = defaultPosition }
+
+    val ownLocation = users.find { it.userId == userId }
+    LaunchedEffect(ownLocation) {
+        if (ownLocation != null && cameraPositionState.position == defaultPosition) {
+            cameraPositionState.position = CameraPosition.fromLatLngZoom(
+                LatLng(ownLocation.lat, ownLocation.lng), 14f
+            )
+        }
+    }
+
+    Box(modifier.fillMaxSize()) {
+        GoogleMap(
+            modifier = Modifier.fillMaxSize(),
+            cameraPositionState = cameraPositionState,
+        ) {
+            users.forEach { user ->
+                val isMe = user.userId == userId
+                Marker(
+                    state = MarkerState(position = LatLng(user.lat, user.lng)),
+                    title = if (isMe) "You" else user.userId.take(8),
+                    icon = BitmapDescriptorFactory.defaultMarker(
+                        if (isMe) BitmapDescriptorFactory.HUE_AZURE
+                        else BitmapDescriptorFactory.HUE_RED
+                    ),
+                )
+            }
+        }
+
+        // Bottom controls row
+        Row(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 16.dp, vertical = 24.dp)
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Pause / resume sharing
+            FilledTonalButton(
+                onClick = onToggleSharing,
+                colors = ButtonDefaults.filledTonalButtonColors(
+                    containerColor = if (isSharing) Color(0xFF1565C0) else Color(0xFF555555),
+                    contentColor = Color.White,
+                ),
+            ) {
+                Icon(
+                    if (isSharing) Icons.Default.LocationOn else Icons.Default.LocationOff,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(if (isSharing) "Sharing" else "Paused", style = MaterialTheme.typography.labelMedium)
+            }
+
+            // Your ID chip
+            Surface(
+                modifier = Modifier.weight(1f),
+                shape = MaterialTheme.shapes.medium,
+                color = Color.Black.copy(alpha = 0.7f),
+            ) {
+                Text(
+                    text = "You: ${userId.take(8)}",
+                    color = Color.White,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                    style = MaterialTheme.typography.labelSmall,
+                )
+            }
+
+            // Friends button
+            FilledTonalButton(onClick = { showFriends = true }) {
+                Icon(Icons.Default.People, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(Modifier.width(4.dp))
+                Text("${friendIds.size}", style = MaterialTheme.typography.labelMedium)
+            }
+        }
+    }
+
+    if (showFriends) {
+        FriendsSheet(
+            userId = userId,
+            friendIds = friendIds,
+            onAdd = onAddFriend,
+            onRemove = onRemoveFriend,
+            onDismiss = { showFriends = false },
+        )
+    }
+}

--- a/android/src/androidMain/kotlin/net/af0/where/UserPrefs.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/UserPrefs.kt
@@ -1,0 +1,18 @@
+package net.af0.where
+
+import android.content.Context
+import java.util.UUID
+
+object UserPrefs {
+    private const val PREFS_NAME = "where_prefs"
+    private const val KEY_USER_ID = "user_id"
+
+    fun getUserId(context: Context): String {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return prefs.getString(KEY_USER_ID, null) ?: run {
+            val newId = UUID.randomUUID().toString()
+            prefs.edit().putString(KEY_USER_ID, newId).apply()
+            newId
+        }
+    }
+}

--- a/android/src/androidUnitTest/kotlin/net/af0/where/FriendsStoreTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/FriendsStoreTest.kt
@@ -1,0 +1,77 @@
+package net.af0.where
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.robolectric.annotation.Config
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class FriendsStoreTest {
+
+    private val context: Application get() = ApplicationProvider.getApplicationContext()
+    private val ownId = "owner-id"
+
+    private fun store() = FriendsStore(context, ownId)
+
+    @Test
+    fun addFriendAppearsInSet() {
+        val s = store()
+        s.add("friend-1")
+        assertTrue(s.friendIds.value.contains("friend-1"))
+    }
+
+    @Test
+    fun addTrimsWhitespace() {
+        val s = store()
+        s.add("  friend-2  ")
+        assertTrue(s.friendIds.value.contains("friend-2"))
+        assertFalse(s.friendIds.value.contains("  friend-2  "))
+    }
+
+    @Test
+    fun addIgnoresBlankId() {
+        val s = store()
+        s.add("   ")
+        assertTrue(s.friendIds.value.isEmpty())
+    }
+
+    @Test
+    fun addIgnoresOwnId() {
+        val s = store()
+        s.add(ownId)
+        assertFalse(s.friendIds.value.contains(ownId))
+    }
+
+    @Test
+    fun removeFriendDisappearsFromSet() {
+        val s = store()
+        s.add("friend-3")
+        s.remove("friend-3")
+        assertFalse(s.friendIds.value.contains("friend-3"))
+    }
+
+    @Test
+    fun addMultipleFriendsAllPresent() {
+        val s = store()
+        s.add("a")
+        s.add("b")
+        s.add("c")
+        assertEquals(setOf("a", "b", "c"), s.friendIds.value)
+    }
+
+    @Test
+    fun toggleSharingFlipsState() {
+        val s = store()
+        assertTrue(s.isSharingLocation.value)
+        s.toggleSharing()
+        assertFalse(s.isSharingLocation.value)
+        s.toggleSharing()
+        assertTrue(s.isSharingLocation.value)
+    }
+}

--- a/android/src/androidUnitTest/kotlin/net/af0/where/FriendsStoreTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/FriendsStoreTest.kt
@@ -74,4 +74,16 @@ class FriendsStoreTest {
         s.toggleSharing()
         assertTrue(s.isSharingLocation.value)
     }
+
+    @Test
+    fun sharingStatePersistedAcrossInstances() {
+        val s1 = store()
+        assertTrue(s1.isSharingLocation.value)
+        s1.toggleSharing()
+        assertFalse(s1.isSharingLocation.value)
+
+        // A new instance should load the persisted value
+        val s2 = store()
+        assertFalse(s2.isSharingLocation.value)
+    }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,11 @@
             export SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
             # Prepend real Xcode tools so they shadow Nix stubs (xcrun, lipo, etc.)
             export PATH=/Applications/Xcode.app/Contents/Developer/usr/bin:/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:$PATH
+            # External Android SDK/AVD on /Volumes/Ext to save main disk space
+            export ANDROID_HOME=/Volumes/Ext/android-sdk
+            export ANDROID_SDK_ROOT=/Volumes/Ext/android-sdk
+            export ANDROID_AVD_HOME=/Volumes/Ext/android-avd
+            export PATH=/Volumes/Ext/android-sdk/cmdline-tools/latest/bin:/Volumes/Ext/android-sdk/platform-tools:/Volumes/Ext/android-sdk/emulator:$PATH
             # Write JDK path for Xcode build scripts (which run outside the Nix shell)
             echo "$JAVA_HOME" > .xcode-java-home
             echo "Where dev environment"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 android.useAndroidX=true
 kotlin.mpp.androidSourceSetLayoutV2AndroidStyleDirs.nowarn=true
+kotlin.native.ignoreDisabledTargets=true
 org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,11 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "kto
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
+ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+robolectric = { module = "org.robolectric:robolectric", version = "4.13" }
 
 # KotlinX
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,9 @@ kotlinx-serialization = "1.8.0"
 compose-bom = "2025.03.00"
 activity-compose = "1.10.1"
 logback = "1.5.18"
+maps-compose = "6.4.4"
+play-services-location = "21.3.0"
+accompanist-permissions = "0.37.3"
 
 [libraries]
 # Ktor server
@@ -22,6 +25,8 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
+ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
 
 # KotlinX
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
@@ -33,7 +38,11 @@ compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-
 compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
+compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
+maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "maps-compose" }
+play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "play-services-location" }
+accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist-permissions" }
 
 # Logging
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.re
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.13" }
+androidx-test-core = { module = "androidx.test:core", version = "1.6.1" }
 
 # KotlinX
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }

--- a/ios/Sources/Where/ContentView.swift
+++ b/ios/Sources/Where/ContentView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Combine
 import CoreLocation
+import Shared
 
 struct ContentView: View {
     @StateObject private var locationManager = LocationManager()
@@ -10,7 +11,7 @@ struct ContentView: View {
     @State private var zoomTarget: CLLocationCoordinate2D? = nil
 
     // Only show self + friends on the map
-    private var visibleUsers: [UserLocationData] {
+    private var visibleUsers: [UserLocation] {
         syncService.users.filter { user in
             user.userId == UserIdentity.userId || friendsStore.friendIds.contains(user.userId)
         }
@@ -112,6 +113,11 @@ struct ContentView: View {
         .onReceive(locationManager.$location) { newLocation in
             guard let loc = newLocation, friendsStore.isSharingLocation else { return }
             syncService.sendLocation(lat: loc.coordinate.latitude, lng: loc.coordinate.longitude)
+        }
+        .onChange(of: friendsStore.isSharingLocation) { newValue in
+            if !newValue {
+                syncService.sendLocationRemove()
+            }
         }
     }
 

--- a/ios/Sources/Where/ContentView.swift
+++ b/ios/Sources/Where/ContentView.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 import Combine
+import CoreLocation
 
 struct ContentView: View {
     @StateObject private var locationManager = LocationManager()
     @StateObject private var syncService = LocationSyncService(userId: UserIdentity.userId)
     @StateObject private var friendsStore = FriendsStore()
     @State private var showFriends = false
+    @State private var zoomTarget: CLLocationCoordinate2D? = nil
 
     // Only show self + friends on the map
     private var visibleUsers: [UserLocationData] {
@@ -16,7 +18,7 @@ struct ContentView: View {
 
     var body: some View {
         ZStack {
-            WhereMapView(users: visibleUsers, ownUserId: UserIdentity.userId)
+            WhereMapView(users: visibleUsers, ownUserId: UserIdentity.userId, zoomTarget: zoomTarget)
                 .ignoresSafeArea()
 
             VStack {
@@ -93,7 +95,12 @@ struct ContentView: View {
             }
         }
         .sheet(isPresented: $showFriends) {
-            FriendsSheet(store: friendsStore)
+            FriendsSheet(store: friendsStore) { friendId in
+                let user = syncService.users.first { $0.userId == friendId }
+                if let user {
+                    zoomTarget = CLLocationCoordinate2D(latitude: user.lat, longitude: user.lng)
+                }
+            }
         }
         .onAppear {
             locationManager.requestPermissionAndStart()

--- a/ios/Sources/Where/ContentView.swift
+++ b/ios/Sources/Where/ContentView.swift
@@ -19,8 +19,13 @@ struct ContentView: View {
 
     var body: some View {
         ZStack {
-            WhereMapView(users: visibleUsers, ownUserId: UserIdentity.userId, zoomTarget: zoomTarget)
-                .ignoresSafeArea()
+            WhereMapView(
+                users: visibleUsers,
+                ownUserId: UserIdentity.userId,
+                zoomTarget: zoomTarget,
+                onZoomConsumed: { zoomTarget = nil }
+            )
+            .ignoresSafeArea()
 
             VStack {
                 // Top bar: connection status + user count

--- a/ios/Sources/Where/ContentView.swift
+++ b/ios/Sources/Where/ContentView.swift
@@ -1,8 +1,126 @@
 import SwiftUI
-import Shared
+import Combine
 
 struct ContentView: View {
+    @StateObject private var locationManager = LocationManager()
+    @StateObject private var syncService = LocationSyncService(userId: UserIdentity.userId)
+    @StateObject private var friendsStore = FriendsStore()
+    @State private var showFriends = false
+
+    // Only show self + friends on the map
+    private var visibleUsers: [UserLocationData] {
+        syncService.users.filter { user in
+            user.userId == UserIdentity.userId || friendsStore.friendIds.contains(user.userId)
+        }
+    }
+
     var body: some View {
-        Text(Greeting().greet())
+        ZStack {
+            WhereMapView(users: visibleUsers, ownUserId: UserIdentity.userId)
+                .ignoresSafeArea()
+
+            VStack {
+                // Top bar: connection status + user count
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(statusColor)
+                        .frame(width: 8, height: 8)
+                    Text(statusText)
+                        .font(.caption)
+                        .foregroundStyle(.white)
+                    Spacer()
+                    if !friendsStore.friendIds.isEmpty {
+                        Text("\(visibleUsers.count) online")
+                            .font(.caption)
+                            .foregroundStyle(.white)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(.black.opacity(0.6))
+                .clipShape(Capsule())
+                .padding(.top, 12)
+                .padding(.horizontal, 16)
+
+                Spacer()
+
+                // Bottom controls
+                HStack(spacing: 12) {
+                    // Pause / resume sharing
+                    Button {
+                        friendsStore.isSharingLocation.toggle()
+                    } label: {
+                        Label(
+                            friendsStore.isSharingLocation ? "Sharing" : "Paused",
+                            systemImage: friendsStore.isSharingLocation ? "location.fill" : "location.slash.fill"
+                        )
+                        .font(.caption)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(friendsStore.isSharingLocation ? Color.blue.opacity(0.85) : Color.gray.opacity(0.85))
+                        .foregroundStyle(.white)
+                        .clipShape(Capsule())
+                    }
+
+                    Spacer()
+
+                    // Your ID chip
+                    Text("You: \(UserIdentity.userId.prefix(8))")
+                        .font(.caption)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(.black.opacity(0.7))
+                        .foregroundStyle(.white)
+                        .clipShape(Capsule())
+
+                    Spacer()
+
+                    // Friends button
+                    Button {
+                        showFriends = true
+                    } label: {
+                        Label("\(friendsStore.friendIds.count)", systemImage: "person.2.fill")
+                            .font(.caption)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 8)
+                            .background(Color.black.opacity(0.7))
+                            .foregroundStyle(.white)
+                            .clipShape(Capsule())
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 32)
+            }
+        }
+        .sheet(isPresented: $showFriends) {
+            FriendsSheet(store: friendsStore)
+        }
+        .onAppear {
+            locationManager.requestPermissionAndStart()
+            syncService.connect()
+        }
+        .onDisappear {
+            syncService.disconnect()
+        }
+        .onReceive(locationManager.$location) { newLocation in
+            guard let loc = newLocation, friendsStore.isSharingLocation else { return }
+            syncService.sendLocation(lat: loc.coordinate.latitude, lng: loc.coordinate.longitude)
+        }
+    }
+
+    private var statusColor: Color {
+        switch syncService.connectionState {
+        case .connected: return .green
+        case .connecting: return .yellow
+        case .disconnected: return .red
+        }
+    }
+
+    private var statusText: String {
+        switch syncService.connectionState {
+        case .connected: return "Connected"
+        case .connecting: return "Connecting…"
+        case .disconnected: return "Disconnected"
+        }
     }
 }

--- a/ios/Sources/Where/FriendsSheet.swift
+++ b/ios/Sources/Where/FriendsSheet.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct FriendsSheet: View {
     @ObservedObject var store: FriendsStore
+    var onZoomTo: (String) -> Void = { _ in }
     @State private var newId: String = ""
     @State private var showCopied = false
     @Environment(\.dismiss) private var dismiss
@@ -52,17 +53,26 @@ struct FriendsSheet: View {
                 if !store.friendIds.isEmpty {
                     Section("Friends") {
                         ForEach(Array(store.friendIds), id: \.self) { id in
-                            HStack {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(id.prefix(8))
-                                        .font(.system(.body, design: .monospaced))
-                                    Text(id)
-                                        .font(.system(.caption2, design: .monospaced))
+                            Button {
+                                onZoomTo(id)
+                                dismiss()
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(id.prefix(8))
+                                            .font(.system(.body, design: .monospaced))
+                                        Text(id)
+                                            .font(.system(.caption2, design: .monospaced))
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
+                                            .truncationMode(.middle)
+                                    }
+                                    Spacer()
+                                    Image(systemName: "location.fill")
                                         .foregroundStyle(.secondary)
-                                        .lineLimit(1)
-                                        .truncationMode(.middle)
+                                        .font(.caption)
                                 }
-                                Spacer()
+                                .foregroundStyle(.primary)
                             }
                         }
                         .onDelete { offsets in

--- a/ios/Sources/Where/FriendsSheet.swift
+++ b/ios/Sources/Where/FriendsSheet.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct FriendsSheet: View {
+    @ObservedObject var store: FriendsStore
+    @State private var newId: String = ""
+    @State private var showCopied = false
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    HStack {
+                        Text(UserIdentity.userId)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                        Button(showCopied ? "Copied!" : "Copy") {
+                            UIPasteboard.general.string = UserIdentity.userId
+                            showCopied = true
+                            Task {
+                                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                                showCopied = false
+                            }
+                        }
+                        .font(.caption)
+                        .buttonStyle(.bordered)
+                    }
+                } header: {
+                    Text("Your ID — share this with friends")
+                } footer: {
+                    Text("Anyone who adds your ID will see your location on their map.")
+                        .font(.caption2)
+                }
+
+                Section("Add a friend") {
+                    HStack {
+                        TextField("Paste their ID", text: $newId)
+                            .font(.system(.caption, design: .monospaced))
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                        Button("Add") {
+                            store.add(id: newId)
+                            newId = ""
+                        }
+                        .disabled(newId.trimmingCharacters(in: .whitespaces).isEmpty)
+                    }
+                }
+
+                if !store.friendIds.isEmpty {
+                    Section("Friends") {
+                        ForEach(Array(store.friendIds), id: \.self) { id in
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(id.prefix(8))
+                                        .font(.system(.body, design: .monospaced))
+                                    Text(id)
+                                        .font(.system(.caption2, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                }
+                                Spacer()
+                            }
+                        }
+                        .onDelete { offsets in
+                            let ids = Array(store.friendIds)
+                            offsets.forEach { store.remove(id: ids[$0]) }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Friends")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/ios/Sources/Where/FriendsStore.swift
+++ b/ios/Sources/Where/FriendsStore.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Combine
+
+@MainActor
+final class FriendsStore: ObservableObject {
+    @Published private(set) var friendIds: Set<String> = []
+    @Published var isSharingLocation: Bool = true
+
+    private let friendsKey = "where_friends"
+
+    init() {
+        let saved = UserDefaults.standard.stringArray(forKey: friendsKey) ?? []
+        friendIds = Set(saved)
+    }
+
+    func add(id: String) {
+        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != UserIdentity.userId else { return }
+        friendIds.insert(trimmed)
+        persist()
+    }
+
+    func remove(id: String) {
+        friendIds.remove(id)
+        persist()
+    }
+
+    private func persist() {
+        UserDefaults.standard.set(Array(friendIds), forKey: friendsKey)
+    }
+}

--- a/ios/Sources/Where/FriendsStore.swift
+++ b/ios/Sources/Where/FriendsStore.swift
@@ -4,13 +4,18 @@ import Combine
 @MainActor
 final class FriendsStore: ObservableObject {
     @Published private(set) var friendIds: Set<String> = []
-    @Published var isSharingLocation: Bool = true
+    @Published var isSharingLocation: Bool {
+        didSet { UserDefaults.standard.set(isSharingLocation, forKey: sharingKey) }
+    }
 
     private let friendsKey = "where_friends"
+    private let sharingKey = "where_is_sharing"
 
     init() {
         let saved = UserDefaults.standard.stringArray(forKey: friendsKey) ?? []
         friendIds = Set(saved)
+        let savedSharing = UserDefaults.standard.object(forKey: sharingKey)
+        isSharingLocation = savedSharing != nil ? UserDefaults.standard.bool(forKey: sharingKey) : true
     }
 
     func add(id: String) {

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -1,0 +1,52 @@
+import CoreLocation
+import Combine
+
+@MainActor
+final class LocationManager: NSObject, ObservableObject, @preconcurrency CLLocationManagerDelegate {
+    @Published var location: CLLocation?
+    @Published var authorizationStatus: CLAuthorizationStatus = .notDetermined
+
+    private let manager = CLLocationManager()
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        manager.distanceFilter = 50 // meters
+    }
+
+    func requestPermissionAndStart() {
+        switch manager.authorizationStatus {
+        case .notDetermined:
+            manager.requestAlwaysAuthorization()
+        case .authorizedWhenInUse:
+            manager.requestAlwaysAuthorization()
+            startUpdating()
+        case .authorizedAlways:
+            startUpdating()
+        default:
+            break
+        }
+    }
+
+    private func startUpdating() {
+        manager.startUpdatingLocation()
+        // Use significant-change in background for battery efficiency
+        manager.startMonitoringSignificantLocationChanges()
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let loc = locations.last else { return }
+        Task { @MainActor in self.location = loc }
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        Task { @MainActor in
+            self.authorizationStatus = status
+            if status == .authorizedWhenInUse || status == .authorizedAlways {
+                self.startUpdating()
+            }
+        }
+    }
+}

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -31,8 +31,6 @@ final class LocationManager: NSObject, ObservableObject, @preconcurrency CLLocat
 
     private func startUpdating() {
         manager.startUpdatingLocation()
-        // Use significant-change in background for battery efficiency
-        manager.startMonitoringSignificantLocationChanges()
     }
 
     nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -37,6 +37,12 @@ final class LocationSyncService: ObservableObject {
     }
 
     func connect() {
+        // Cancel any existing connection before creating a new one to prevent task leakage.
+        receiveLoop?.cancel()
+        receiveLoop = nil
+        webSocketTask?.cancel(with: .goingAway, reason: nil)
+        webSocketTask = nil
+
         connectionState = .connecting
         let urlString = "ws://localhost:8080/ws?userId=\(userId)"
         guard let url = URL(string: urlString) else { return }

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -10,7 +10,7 @@ final class LocationSyncService: ObservableObject {
     @Published var users: [UserLocation] = []
     @Published var connectionState: ConnectionState = .disconnected
 
-    private static let serverWsBaseUrl = "ws://localhost:8080/ws"
+    private static let serverWsBaseUrl = ServerConfig.wsBaseUrl
 
     private let userId: String
     private var webSocketTask: URLSessionWebSocketTask?
@@ -77,8 +77,7 @@ final class LocationSyncService: ObservableObject {
                     connectionState = .disconnected
                     try? await Task.sleep(nanoseconds: 3_000_000_000)
                     guard !Task.isCancelled else { break }
-                    let urlString = "\(Self.serverWsBaseUrl)?userId=\(userId)"
-                    guard let url = URL(string: urlString) else { break }
+                    guard let url = URL(string: "\(Self.serverWsBaseUrl)?userId=\(userId)") else { break }
                     let newTask = URLSession.shared.webSocketTask(with: url)
                     webSocketTask = newTask
                     connectionState = .connecting

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+struct UserLocationData: Codable, Identifiable {
+    let userId: String
+    let lat: Double
+    let lng: Double
+    let timestamp: Int64
+
+    var id: String { userId }
+}
+
+private struct OutgoingMessage: Codable {
+    let type: String
+    let location: UserLocationData
+}
+
+private struct IncomingMessage: Codable {
+    let type: String
+    let users: [UserLocationData]?
+}
+
+enum ConnectionState {
+    case disconnected, connecting, connected
+}
+
+@MainActor
+final class LocationSyncService: ObservableObject {
+    @Published var users: [UserLocationData] = []
+    @Published var connectionState: ConnectionState = .disconnected
+
+    private let userId: String
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var receiveLoop: Task<Void, Never>?
+
+    init(userId: String) {
+        self.userId = userId
+    }
+
+    func connect() {
+        connectionState = .connecting
+        let urlString = "ws://localhost:8080/ws?userId=\(userId)"
+        guard let url = URL(string: urlString) else { return }
+        let task = URLSession.shared.webSocketTask(with: url)
+        webSocketTask = task
+        task.resume()
+        startReceiving(task: task)
+    }
+
+    func disconnect() {
+        receiveLoop?.cancel()
+        receiveLoop = nil
+        webSocketTask?.cancel(with: .goingAway, reason: nil)
+        webSocketTask = nil
+        connectionState = .disconnected
+    }
+
+    func sendLocation(lat: Double, lng: Double) {
+        guard let task = webSocketTask else { return }
+        let msg = OutgoingMessage(
+            type: "location",
+            location: UserLocationData(
+                userId: userId,
+                lat: lat,
+                lng: lng,
+                timestamp: Int64(Date().timeIntervalSince1970 * 1000)
+            )
+        )
+        guard let data = try? JSONEncoder().encode(msg),
+              let text = String(data: data, encoding: .utf8) else { return }
+        task.send(.string(text)) { _ in }
+        connectionState = .connected
+    }
+
+    private func startReceiving(task: URLSessionWebSocketTask) {
+        receiveLoop = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                do {
+                    let message = try await task.receive()
+                    await MainActor.run { self.connectionState = .connected }
+                    if case .string(let text) = message,
+                       let data = text.data(using: .utf8),
+                       let msg = try? JSONDecoder().decode(IncomingMessage.self, from: data),
+                       msg.type == "locations",
+                       let users = msg.users {
+                        await MainActor.run { self.users = users }
+                    }
+                } catch {
+                    guard !Task.isCancelled else { break }
+                    await MainActor.run { self.connectionState = .disconnected }
+                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    await self.connect()
+                    break
+                }
+            }
+        }
+    }
+}

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -1,23 +1,5 @@
 import Foundation
-
-struct UserLocationData: Codable, Identifiable {
-    let userId: String
-    let lat: Double
-    let lng: Double
-    let timestamp: Int64
-
-    var id: String { userId }
-}
-
-private struct OutgoingMessage: Codable {
-    let type: String
-    let location: UserLocationData
-}
-
-private struct IncomingMessage: Codable {
-    let type: String
-    let users: [UserLocationData]?
-}
+import Shared
 
 enum ConnectionState {
     case disconnected, connecting, connected
@@ -25,8 +7,10 @@ enum ConnectionState {
 
 @MainActor
 final class LocationSyncService: ObservableObject {
-    @Published var users: [UserLocationData] = []
+    @Published var users: [UserLocation] = []
     @Published var connectionState: ConnectionState = .disconnected
+
+    private static let serverWsBaseUrl = "ws://localhost:8080/ws"
 
     private let userId: String
     private var webSocketTask: URLSessionWebSocketTask?
@@ -44,12 +28,12 @@ final class LocationSyncService: ObservableObject {
         webSocketTask = nil
 
         connectionState = .connecting
-        let urlString = "ws://localhost:8080/ws?userId=\(userId)"
+        let urlString = "\(Self.serverWsBaseUrl)?userId=\(userId)"
         guard let url = URL(string: urlString) else { return }
         let task = URLSession.shared.webSocketTask(with: url)
         webSocketTask = task
         task.resume()
-        startReceiving(task: task)
+        startReceiving(from: task)
     }
 
     func disconnect() {
@@ -62,41 +46,44 @@ final class LocationSyncService: ObservableObject {
 
     func sendLocation(lat: Double, lng: Double) {
         guard let task = webSocketTask else { return }
-        let msg = OutgoingMessage(
-            type: "location",
-            location: UserLocationData(
-                userId: userId,
-                lat: lat,
-                lng: lng,
-                timestamp: Int64(Date().timeIntervalSince1970 * 1000)
-            )
+        let timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        let text = LocationMessageCodec.shared.encodeLocationUpdate(
+            userId: userId, lat: lat, lng: lng, timestamp: timestamp
         )
-        guard let data = try? JSONEncoder().encode(msg),
-              let text = String(data: data, encoding: .utf8) else { return }
         task.send(.string(text)) { _ in }
         connectionState = .connected
     }
 
-    private func startReceiving(task: URLSessionWebSocketTask) {
+    func sendLocationRemove() {
+        guard let task = webSocketTask else { return }
+        let text = LocationMessageCodec.shared.encodeLocationRemove()
+        task.send(.string(text)) { _ in }
+    }
+
+    private func startReceiving(from initialTask: URLSessionWebSocketTask) {
         receiveLoop = Task { [weak self] in
             guard let self else { return }
+            var wsTask = initialTask
             while !Task.isCancelled {
                 do {
-                    let message = try await task.receive()
-                    await MainActor.run { self.connectionState = .connected }
+                    let message = try await wsTask.receive()
+                    connectionState = .connected
                     if case .string(let text) = message,
-                       let data = text.data(using: .utf8),
-                       let msg = try? JSONDecoder().decode(IncomingMessage.self, from: data),
-                       msg.type == "locations",
-                       let users = msg.users {
-                        await MainActor.run { self.users = users }
+                       let users = LocationMessageCodec.shared.decodeUsers(text: text) {
+                        self.users = users as! [UserLocation]
                     }
                 } catch {
                     guard !Task.isCancelled else { break }
-                    await MainActor.run { self.connectionState = .disconnected }
+                    connectionState = .disconnected
                     try? await Task.sleep(nanoseconds: 3_000_000_000)
-                    await self.connect()
-                    break
+                    guard !Task.isCancelled else { break }
+                    let urlString = "\(Self.serverWsBaseUrl)?userId=\(userId)"
+                    guard let url = URL(string: urlString) else { break }
+                    let newTask = URLSession.shared.webSocketTask(with: url)
+                    webSocketTask = newTask
+                    connectionState = .connecting
+                    newTask.resume()
+                    wsTask = newTask
                 }
             }
         }

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -50,8 +50,12 @@ final class LocationSyncService: ObservableObject {
         let text = LocationMessageCodec.shared.encodeLocationUpdate(
             userId: userId, lat: lat, lng: lng, timestamp: timestamp
         )
-        task.send(.string(text)) { _ in }
-        connectionState = .connected
+        task.send(.string(text)) { [weak self] error in
+            if let error {
+                print("[LocationSyncService] send error: \(error)")
+                Task { await self?.connect() }
+            }
+        }
     }
 
     func sendLocationRemove() {
@@ -69,8 +73,9 @@ final class LocationSyncService: ObservableObject {
                     let message = try await wsTask.receive()
                     connectionState = .connected
                     if case .string(let text) = message,
-                       let users = LocationMessageCodec.shared.decodeUsers(text: text) {
-                        self.users = users as! [UserLocation]
+                       let users = LocationMessageCodec.shared.decodeUsers(text: text),
+                       let typedUsers = users as? [UserLocation] {
+                        self.users = typedUsers
                     }
                 } catch {
                     guard !Task.isCancelled else { break }

--- a/ios/Sources/Where/ServerConfig.swift
+++ b/ios/Sources/Where/ServerConfig.swift
@@ -10,7 +10,7 @@ enum ServerConfig {
     #if targetEnvironment(simulator)
     static let wsBaseUrl = "ws://localhost:8080/ws"
     #else
-    // TODO: replace with your server's address for real-device builds
-    static let wsBaseUrl = "ws://localhost:8080/ws"
+    // TODO: replace with your server's LAN IP or deployed URL before running on a real device.
+    static let wsBaseUrl = "ws://REPLACE_ME:8080/ws"
     #endif
 }

--- a/ios/Sources/Where/ServerConfig.swift
+++ b/ios/Sources/Where/ServerConfig.swift
@@ -10,7 +10,9 @@ enum ServerConfig {
     #if targetEnvironment(simulator)
     static let wsBaseUrl = "ws://localhost:8080/ws"
     #else
-    // TODO: replace with your server's LAN IP or deployed URL before running on a real device.
-    static let wsBaseUrl = "ws://REPLACE_ME:8080/ws"
+    // Replace with your server's LAN IP or deployed URL before running on a real device.
+    static let wsBaseUrl: String = {
+        preconditionFailure("Replace with your server's LAN IP or deployed URL before running on a real device.")
+    }()
     #endif
 }

--- a/ios/Sources/Where/ServerConfig.swift
+++ b/ios/Sources/Where/ServerConfig.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Central place to configure the server URL.
+///
+/// - Simulator: use `localhost` (default).
+/// - Real device on the same network: change to your machine's LAN IP,
+///   e.g. `ws://192.168.1.10:8080/ws`.
+/// - Production: point to your deployed server URL.
+enum ServerConfig {
+    #if targetEnvironment(simulator)
+    static let wsBaseUrl = "ws://localhost:8080/ws"
+    #else
+    // TODO: replace with your server's address for real-device builds
+    static let wsBaseUrl = "ws://localhost:8080/ws"
+    #endif
+}

--- a/ios/Sources/Where/UserIdentity.swift
+++ b/ios/Sources/Where/UserIdentity.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum UserIdentity {
+    static let userId: String = {
+        let key = "where_user_id"
+        if let saved = UserDefaults.standard.string(forKey: key) {
+            return saved
+        }
+        let newId = UUID().uuidString
+        UserDefaults.standard.set(newId, forKey: key)
+        return newId
+    }()
+}

--- a/ios/Sources/Where/WhereApp.swift
+++ b/ios/Sources/Where/WhereApp.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Shared
 
 @main
 struct WhereApp: App {

--- a/ios/Sources/Where/WhereMapView.swift
+++ b/ios/Sources/Where/WhereMapView.swift
@@ -6,6 +6,7 @@ struct WhereMapView: UIViewRepresentable {
     let users: [UserLocation]
     let ownUserId: String
     var zoomTarget: CLLocationCoordinate2D? = nil
+    var onZoomConsumed: () -> Void = {}
 
     func makeUIView(context: Context) -> MKMapView {
         let mapView = MKMapView()
@@ -32,10 +33,11 @@ struct WhereMapView: UIViewRepresentable {
             }
         }
 
-        // Zoom to friend if requested
+        // Zoom to friend if requested, then clear the target so it doesn't re-trigger.
         if let target = zoomTarget {
             let region = MKCoordinateRegion(center: target, latitudinalMeters: 1000, longitudinalMeters: 1000)
             mapView.setRegion(region, animated: true)
+            DispatchQueue.main.async { onZoomConsumed() }
             return
         }
 

--- a/ios/Sources/Where/WhereMapView.swift
+++ b/ios/Sources/Where/WhereMapView.swift
@@ -4,6 +4,7 @@ import MapKit
 struct WhereMapView: UIViewRepresentable {
     let users: [UserLocationData]
     let ownUserId: String
+    var zoomTarget: CLLocationCoordinate2D? = nil
 
     func makeUIView(context: Context) -> MKMapView {
         let mapView = MKMapView()
@@ -22,17 +23,27 @@ struct WhereMapView: UIViewRepresentable {
             mapView.addAnnotation(annotation)
         }
 
-        // Center on own location if present
-        if let own = users.first(where: { $0.userId == ownUserId }) {
+        // Zoom to friend if requested
+        if let target = zoomTarget {
+            let region = MKCoordinateRegion(center: target, latitudinalMeters: 1000, longitudinalMeters: 1000)
+            mapView.setRegion(region, animated: true)
+            return
+        }
+
+        // Auto-center on own location the first time only
+        if !context.coordinator.hasCentered,
+           let own = users.first(where: { $0.userId == ownUserId }) {
             let coord = CLLocationCoordinate2D(latitude: own.lat, longitude: own.lng)
             let region = MKCoordinateRegion(center: coord, latitudinalMeters: 5000, longitudinalMeters: 5000)
             mapView.setRegion(region, animated: true)
+            context.coordinator.hasCentered = true
         }
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     final class Coordinator: NSObject, MKMapViewDelegate {
+        var hasCentered = false
         func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
             guard let userAnnotation = annotation as? UserAnnotation else { return nil }
             let id = "pin"

--- a/ios/Sources/Where/WhereMapView.swift
+++ b/ios/Sources/Where/WhereMapView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 import MapKit
+import Shared
 
 struct WhereMapView: UIViewRepresentable {
-    let users: [UserLocationData]
+    let users: [UserLocation]
     let ownUserId: String
     var zoomTarget: CLLocationCoordinate2D? = nil
 
@@ -14,13 +15,21 @@ struct WhereMapView: UIViewRepresentable {
     }
 
     func updateUIView(_ mapView: MKMapView, context: Context) {
-        // Remove old annotations
-        mapView.removeAnnotations(mapView.annotations)
+        let existing = mapView.annotations.compactMap { $0 as? UserAnnotation }
+        let existingById = Dictionary(uniqueKeysWithValues: existing.map { ($0.userId, $0) })
+        let newById = Dictionary(uniqueKeysWithValues: users.map { ($0.userId, $0) })
 
-        // Add one annotation per user
+        // Remove stale annotations
+        let toRemove = existing.filter { newById[$0.userId] == nil }
+        mapView.removeAnnotations(toRemove)
+
+        // Update existing or add new annotations
         for user in users {
-            let annotation = UserAnnotation(user: user, isOwn: user.userId == ownUserId)
-            mapView.addAnnotation(annotation)
+            if let pin = existingById[user.userId] {
+                pin.coordinate = CLLocationCoordinate2D(latitude: user.lat, longitude: user.lng)
+            } else {
+                mapView.addAnnotation(UserAnnotation(user: user, isOwn: user.userId == ownUserId))
+            }
         }
 
         // Zoom to friend if requested
@@ -59,11 +68,13 @@ struct WhereMapView: UIViewRepresentable {
 }
 
 final class UserAnnotation: NSObject, MKAnnotation {
-    let coordinate: CLLocationCoordinate2D
+    let userId: String
+    @objc dynamic var coordinate: CLLocationCoordinate2D
     let title: String?
     let isOwn: Bool
 
-    init(user: UserLocationData, isOwn: Bool) {
+    init(user: UserLocation, isOwn: Bool) {
+        self.userId = user.userId
         self.coordinate = CLLocationCoordinate2D(latitude: user.lat, longitude: user.lng)
         self.title = isOwn ? "You" : String(user.userId.prefix(8))
         self.isOwn = isOwn

--- a/ios/Sources/Where/WhereMapView.swift
+++ b/ios/Sources/Where/WhereMapView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import MapKit
+
+struct WhereMapView: UIViewRepresentable {
+    let users: [UserLocationData]
+    let ownUserId: String
+
+    func makeUIView(context: Context) -> MKMapView {
+        let mapView = MKMapView()
+        mapView.delegate = context.coordinator
+        mapView.showsUserLocation = false
+        return mapView
+    }
+
+    func updateUIView(_ mapView: MKMapView, context: Context) {
+        // Remove old annotations
+        mapView.removeAnnotations(mapView.annotations)
+
+        // Add one annotation per user
+        for user in users {
+            let annotation = UserAnnotation(user: user, isOwn: user.userId == ownUserId)
+            mapView.addAnnotation(annotation)
+        }
+
+        // Center on own location if present
+        if let own = users.first(where: { $0.userId == ownUserId }) {
+            let coord = CLLocationCoordinate2D(latitude: own.lat, longitude: own.lng)
+            let region = MKCoordinateRegion(center: coord, latitudinalMeters: 5000, longitudinalMeters: 5000)
+            mapView.setRegion(region, animated: true)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator: NSObject, MKMapViewDelegate {
+        func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+            guard let userAnnotation = annotation as? UserAnnotation else { return nil }
+            let id = "pin"
+            let view = mapView.dequeueReusableAnnotationView(withIdentifier: id) as? MKMarkerAnnotationView
+                ?? MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: id)
+            view.annotation = annotation
+            view.markerTintColor = userAnnotation.isOwn ? .systemBlue : .systemRed
+            view.glyphText = userAnnotation.isOwn ? "Me" : nil
+            view.canShowCallout = true
+            return view
+        }
+    }
+}
+
+final class UserAnnotation: NSObject, MKAnnotation {
+    let coordinate: CLLocationCoordinate2D
+    let title: String?
+    let isOwn: Bool
+
+    init(user: UserLocationData, isOwn: Bool) {
+        self.coordinate = CLLocationCoordinate2D(latitude: user.lat, longitude: user.lng)
+        self.title = isOwn ? "You" : String(user.userId.prefix(8))
+        self.isOwn = isOwn
+    }
+}

--- a/ios/Where.xcodeproj/project.pbxproj
+++ b/ios/Where.xcodeproj/project.pbxproj
@@ -7,43 +7,33 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		25C7C204409EE87B7316383F /* LocationSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B36665B05EA8E1F42A11EA /* LocationSyncService.swift */; };
+		296E222ADF2ED6BA05F597CC /* FriendsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DD2FC8358389E8C9F6ABE6 /* FriendsSheet.swift */; };
+		4A8A07DB9013B997E0C41EFB /* FriendsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F9371D289CC150DF786A96 /* FriendsStore.swift */; };
+		5EF9E5113CEBF25BACE77F5E /* WhereMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2421CE3D6966994F4875E311 /* WhereMapView.swift */; };
 		60D8A627443A5ADF3F5C00CB /* WhereApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1BBBBE8782378C8B03BB4C /* WhereApp.swift */; };
 		6CB91DD32C87A081852B00C4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43663670EB5FB46B5C7C4EA /* ContentView.swift */; };
-		D856CF3786D735F63CD21D1C /* Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38851FB1006A4C013C3B8A94 /* Shared.framework */; };
+		B60DEE3289B4F67659B77C8A /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADAF0FD19742D151B957FD9 /* LocationManager.swift */; };
+		CAA74FF2347CA0BA2A825A66 /* UserIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47183C59D3C1EE4A360DF7ED /* UserIdentity.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		38851FB1006A4C013C3B8A94 /* Shared.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Shared.framework; path = "../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)/Shared.framework"; sourceTree = "<group>"; };
+		2421CE3D6966994F4875E311 /* WhereMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhereMapView.swift; sourceTree = "<group>"; };
+		28DD2FC8358389E8C9F6ABE6 /* FriendsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsSheet.swift; sourceTree = "<group>"; };
+		3ADAF0FD19742D151B957FD9 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		47183C59D3C1EE4A360DF7ED /* UserIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdentity.swift; sourceTree = "<group>"; };
 		7A1BBBBE8782378C8B03BB4C /* WhereApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhereApp.swift; sourceTree = "<group>"; };
+		87F9371D289CC150DF786A96 /* FriendsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsStore.swift; sourceTree = "<group>"; };
 		D43663670EB5FB46B5C7C4EA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		D4B36665B05EA8E1F42A11EA /* LocationSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSyncService.swift; sourceTree = "<group>"; };
 		EA47D2499F3983EF98B459AB /* Where.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Where.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
-/* Begin PBXFrameworksBuildPhase section */
-		EFB0479BA721AAE049851BE1 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D856CF3786D735F63CD21D1C /* Shared.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
 /* Begin PBXGroup section */
-		04AE05A338521963D27F32FA /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				38851FB1006A4C013C3B8A94 /* Shared.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		177C19F85F562AB1BF838A33 = {
 			isa = PBXGroup;
 			children = (
 				B39C72AD8B5E1F0E3A409FD2 /* Where */,
-				04AE05A338521963D27F32FA /* Frameworks */,
 				C945058DA9DF7EA90A7EE8D7 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -52,7 +42,13 @@
 			isa = PBXGroup;
 			children = (
 				D43663670EB5FB46B5C7C4EA /* ContentView.swift */,
+				28DD2FC8358389E8C9F6ABE6 /* FriendsSheet.swift */,
+				87F9371D289CC150DF786A96 /* FriendsStore.swift */,
+				3ADAF0FD19742D151B957FD9 /* LocationManager.swift */,
+				D4B36665B05EA8E1F42A11EA /* LocationSyncService.swift */,
+				47183C59D3C1EE4A360DF7ED /* UserIdentity.swift */,
 				7A1BBBBE8782378C8B03BB4C /* WhereApp.swift */,
+				2421CE3D6966994F4875E311 /* WhereMapView.swift */,
 			);
 			name = Where;
 			path = Sources/Where;
@@ -73,9 +69,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 179750A609FCACFE5552F4E1 /* Build configuration list for PBXNativeTarget "Where" */;
 			buildPhases = (
-				624159653114A75804EC2379 /* Build KMP Shared Framework */,
 				E7ED0F8B6CA06472498EA266 /* Sources */,
-				EFB0479BA721AAE049851BE1 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -116,35 +110,19 @@
 		};
 /* End PBXProject section */
 
-/* Begin PBXShellScriptBuildPhase section */
-		624159653114A75804EC2379 /* Build KMP Shared Framework */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Build KMP Shared Framework";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -e\ncd \"$SRCROOT/..\"\n# Read JDK path written by `nix develop` shellHook\nif [ -f .xcode-java-home ]; then\n  export JAVA_HOME=$(cat .xcode-java-home)\n  export PATH=\"$JAVA_HOME/bin:$PATH\"\nfi\n./gradlew :shared:embedAndSignAppleFrameworkForXcode\n";
-		};
-/* End PBXShellScriptBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
 		E7ED0F8B6CA06472498EA266 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				6CB91DD32C87A081852B00C4 /* ContentView.swift in Sources */,
+				296E222ADF2ED6BA05F597CC /* FriendsSheet.swift in Sources */,
+				4A8A07DB9013B997E0C41EFB /* FriendsStore.swift in Sources */,
+				B60DEE3289B4F67659B77C8A /* LocationManager.swift in Sources */,
+				25C7C204409EE87B7316383F /* LocationSyncService.swift in Sources */,
+				CAA74FF2347CA0BA2A825A66 /* UserIdentity.swift in Sources */,
 				60D8A627443A5ADF3F5C00CB /* WhereApp.swift in Sources */,
+				5EF9E5113CEBF25BACE77F5E /* WhereMapView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -213,19 +191,17 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
-					"\"../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)\"",
-				);
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Where needs your location in the background to keep sharing it.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Where needs your location to show it on the map.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIBackgroundModes = location;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				OTHER_LDFLAGS = "$(inherited) -framework Shared";
 				PRODUCT_BUNDLE_IDENTIFIER = net.af0.where;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -237,19 +213,17 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
-					"\"../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)\"",
-				);
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Where needs your location in the background to keep sharing it.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Where needs your location to show it on the map.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIBackgroundModes = location;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				OTHER_LDFLAGS = "$(inherited) -framework Shared";
 				PRODUCT_BUNDLE_IDENTIFIER = net.af0.where;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/Where.xcodeproj/project.pbxproj
+++ b/ios/Where.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "$(inherited) -ld_classic";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -286,6 +287,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "$(inherited) -ld_classic";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -21,20 +21,6 @@ targets:
       GENERATE_INFOPLIST_FILE: YES
       INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
       INFOPLIST_KEY_UILaunchScreen_Generation: YES
-      FRAMEWORK_SEARCH_PATHS: $(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)
-      OTHER_LDFLAGS: $(inherited) -framework Shared
-    preBuildScripts:
-      - name: Build KMP Shared Framework
-        script: |
-          set -e
-          cd "$SRCROOT/.."
-          # Read JDK path written by `nix develop` shellHook
-          if [ -f .xcode-java-home ]; then
-            export JAVA_HOME=$(cat .xcode-java-home)
-            export PATH="$JAVA_HOME/bin:$PATH"
-          fi
-          ./gradlew :shared:embedAndSignAppleFrameworkForXcode
-        basedOnDependencyAnalysis: false
-    dependencies:
-      - framework: ../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)/Shared.framework
-        embed: false
+      INFOPLIST_KEY_NSLocationWhenInUseUsageDescription: "Where needs your location to show it on the map."
+      INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription: "Where needs your location in the background to keep sharing it."
+      INFOPLIST_KEY_UIBackgroundModes: location

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -17,6 +17,17 @@ targets:
     deploymentTarget: "17.0"
     sources:
       - path: Sources/Where
+    dependencies:
+      - framework: $(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)/Shared.framework
+        embed: false
+        codeSign: false
+        implicit: true
+    preBuildScripts:
+      - script: |
+          cd "$SRCROOT/.."
+          ./gradlew :shared:embedAndSignAppleFrameworkForXcode
+        name: Build KMP Shared Framework
+        basedOnDependencyAnalysis: false
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: net.af0.where
       GENERATE_INFOPLIST_FILE: YES
@@ -25,3 +36,4 @@ targets:
       INFOPLIST_KEY_NSLocationWhenInUseUsageDescription: "Where needs your location to show it on the map."
       INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription: "Where needs your location in the background to keep sharing it."
       INFOPLIST_KEY_UIBackgroundModes: location
+      FRAMEWORK_SEARCH_PATHS: $(inherited) $(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -8,6 +8,7 @@ options:
 settings:
   SWIFT_VERSION: "6.0"
   ENABLE_USER_SCRIPT_SANDBOXING: NO
+  OTHER_LDFLAGS: $(inherited) -ld_classic
 
 targets:
   Where:

--- a/run-android.sh
+++ b/run-android.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+export ANDROID_HOME=/Volumes/Ext/android-sdk
+export ANDROID_SDK_ROOT=/Volumes/Ext/android-sdk
+export ANDROID_AVD_HOME=/Volumes/Ext/android-avd
+export PATH=/Volumes/Ext/android-sdk/emulator:/Volumes/Ext/android-sdk/platform-tools:/Volumes/Ext/android-sdk/cmdline-tools/latest/bin:$PATH
+
+# Read ANDROID_ADB_HOST from local.properties if set
+ADB_HOST=$(grep "^ANDROID_ADB_HOST=" local.properties 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')
+
+if [ -n "$ADB_HOST" ]; then
+  ADB="adb -s $ADB_HOST:36869"
+  adb connect "$ADB_HOST:36869" 2>/dev/null || true
+else
+  ADB="adb"
+fi
+
+# Check for any connected device (physical or emulator)
+if $ADB devices | grep -q "device$"; then
+  echo "Device connected."
+else
+  echo "No device found. Starting emulator..."
+  emulator -avd pixel9 -no-audio -no-boot-anim -accel off &
+  echo "Waiting for emulator to boot..."
+  adb wait-for-device
+  adb shell input keyevent 82  # unlock screen
+  ADB="adb"
+fi
+
+echo "Building APK..."
+nix develop --command ./gradlew :android:assembleDebug
+
+echo "Installing APK..."
+$ADB install -r /Volumes/Ext/Build/where/android/outputs/apk/debug/android-debug.apk
+
+echo "Launching app..."
+$ADB shell am start -n net.af0.where/.MainActivity

--- a/run-android.sh
+++ b/run-android.sh
@@ -2,10 +2,23 @@
 set -e
 cd "$(dirname "$0")"
 
-export ANDROID_HOME=/Volumes/Ext/android-sdk
-export ANDROID_SDK_ROOT=/Volumes/Ext/android-sdk
-export ANDROID_AVD_HOME=/Volumes/Ext/android-avd
-export PATH=/Volumes/Ext/android-sdk/emulator:/Volumes/Ext/android-sdk/platform-tools:/Volumes/Ext/android-sdk/cmdline-tools/latest/bin:$PATH
+# Path defaults — override via environment variables or local.properties.
+ANDROID_SDK_BASE="${ANDROID_SDK_BASE:-/Volumes/Ext/android-sdk}"
+ANDROID_AVD_HOME="${ANDROID_AVD_HOME:-/Volumes/Ext/android-avd}"
+BUILD_DIR="${BUILD_DIR:-$(./gradlew -q :android:printBuildDir 2>/dev/null || echo "android/build")}"
+
+# Also read from local.properties if the env vars are not set
+if [ -f local.properties ]; then
+  _PROP_SDK=$(grep "^ANDROID_SDK_BASE=" local.properties 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')
+  _PROP_BUILD=$(grep "^BUILD_DIR=" local.properties 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')
+  [ -n "$_PROP_SDK" ] && ANDROID_SDK_BASE="$_PROP_SDK"
+  [ -n "$_PROP_BUILD" ] && BUILD_DIR="$_PROP_BUILD"
+fi
+
+export ANDROID_HOME="$ANDROID_SDK_BASE"
+export ANDROID_SDK_ROOT="$ANDROID_SDK_BASE"
+export ANDROID_AVD_HOME
+export PATH="$ANDROID_SDK_BASE/emulator:$ANDROID_SDK_BASE/platform-tools:$ANDROID_SDK_BASE/cmdline-tools/latest/bin:$PATH"
 
 # Read ANDROID_ADB_HOST from local.properties if set
 ADB_HOST=$(grep "^ANDROID_ADB_HOST=" local.properties 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')
@@ -22,7 +35,8 @@ if $ADB devices | grep -q "device$"; then
   echo "Device connected."
 else
   echo "No device found. Starting emulator..."
-  emulator -avd pixel9 -no-audio -no-boot-anim -accel off &
+  # Let the emulator auto-detect hardware acceleration (KVM on Linux, HAXM on macOS).
+  emulator -avd pixel9 -no-audio -no-boot-anim &
   echo "Waiting for emulator to boot..."
   adb wait-for-device
   adb shell input keyevent 82  # unlock screen
@@ -32,8 +46,9 @@ fi
 echo "Building APK..."
 nix develop --command ./gradlew :android:assembleDebug
 
-echo "Installing APK..."
-$ADB install -r /Volumes/Ext/Build/where/android/outputs/apk/debug/android-debug.apk
+APK_PATH="${BUILD_DIR}/android/outputs/apk/debug/android-debug.apk"
+echo "Installing APK from $APK_PATH..."
+$ADB install -r "$APK_PATH"
 
 echo "Launching app..."
 $ADB shell am start -n net.af0.where/.MainActivity

--- a/run-ios-pair.sh
+++ b/run-ios-pair.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+SIM1_ID="AA956031-5F12-4266-A0B5-7C4932D0BF14"  # iPhone 17
+SIM2_ID="11DCC254-3DC4-4CD1-AC51-DD9439F4FA64"  # iPhone 17 Pro
+APP_PATH="/Volumes/Ext/Build/Products/Debug-iphonesimulator/Where.app"
+
+boot_if_needed() {
+  local udid=$1 name=$2
+  if ! xcrun simctl list devices | grep "$udid" | grep -q Booted; then
+    echo "Booting $name..."
+    xcrun simctl boot "$udid"
+  fi
+}
+
+boot_if_needed "$SIM1_ID" "iPhone 17"
+boot_if_needed "$SIM2_ID" "iPhone 17 Pro"
+
+open -a Simulator
+
+echo "Building..."
+xcodebuild \
+  -project ios/Where.xcodeproj \
+  -scheme Where \
+  -destination "platform=iOS Simulator,name=iPhone 17" \
+  -configuration Debug \
+  build 2>&1 | grep -E "error:|BUILD SUCCEEDED|BUILD FAILED"
+
+echo "Installing on both simulators..."
+xcrun simctl install "$SIM1_ID" "$APP_PATH"
+xcrun simctl install "$SIM2_ID" "$APP_PATH"
+
+echo "Launching on both simulators..."
+xcrun simctl launch "$SIM1_ID" net.af0.where
+xcrun simctl launch "$SIM2_ID" net.af0.where
+
+echo ""
+echo "Tip: set different locations with:"
+echo "  xcrun simctl location $SIM1_ID set 37.7749,-122.4194  # San Francisco"
+echo "  xcrun simctl location $SIM2_ID set 37.3352,-122.0096  # Cupertino"

--- a/run-ios-pair.sh
+++ b/run-ios-pair.sh
@@ -2,9 +2,15 @@
 set -e
 cd "$(dirname "$0")"
 
+# Path defaults — override via environment variables or local.properties.
+APP_PATH="${APP_PATH:-/Volumes/Ext/Build/Products/Debug-iphonesimulator/Where.app}"
+if [ -f local.properties ]; then
+  _PROP=$(grep "^APP_PATH=" local.properties 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')
+  [ -n "$_PROP" ] && APP_PATH="$_PROP"
+fi
+
 SIM1_ID="AA956031-5F12-4266-A0B5-7C4932D0BF14"  # iPhone 17
 SIM2_ID="11DCC254-3DC4-4CD1-AC51-DD9439F4FA64"  # iPhone 17 Pro
-APP_PATH="/Volumes/Ext/Build/Products/Debug-iphonesimulator/Where.app"
 
 boot_if_needed() {
   local udid=$1 name=$2

--- a/run-ios.sh
+++ b/run-ios.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+SIMULATOR_ID="AA956031-5F12-4266-A0B5-7C4932D0BF14"  # iPhone 17
+DERIVED_DATA="/Volumes/Ext/DerivedData/Where"
+APP_PATH="/Volumes/Ext/Build/Products/Debug-iphonesimulator/Where.app"
+
+# Boot simulator if not already running
+if ! xcrun simctl list devices | grep "$SIMULATOR_ID" | grep -q Booted; then
+  echo "Booting iPhone 17 simulator..."
+  xcrun simctl boot "$SIMULATOR_ID"
+fi
+
+# Open Simulator.app so the window appears
+open -a Simulator
+
+echo "Building..."
+xcodebuild \
+  -project ios/Where.xcodeproj \
+  -scheme Where \
+  -destination "platform=iOS Simulator,name=iPhone 17" \
+  -configuration Debug \
+  build 2>&1 | grep -E "error:|BUILD SUCCEEDED|BUILD FAILED"
+
+echo "Installing..."
+xcrun simctl install "$SIMULATOR_ID" "$APP_PATH"
+
+echo "Launching..."
+xcrun simctl launch "$SIMULATOR_ID" net.af0.where

--- a/run-ios.sh
+++ b/run-ios.sh
@@ -2,9 +2,14 @@
 set -e
 cd "$(dirname "$0")"
 
+# Path defaults — override via environment variables or local.properties.
+APP_PATH="${APP_PATH:-/Volumes/Ext/Build/Products/Debug-iphonesimulator/Where.app}"
+if [ -f local.properties ]; then
+  _PROP=$(grep "^APP_PATH=" local.properties 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')
+  [ -n "$_PROP" ] && APP_PATH="$_PROP"
+fi
+
 SIMULATOR_ID="AA956031-5F12-4266-A0B5-7C4932D0BF14"  # iPhone 17
-DERIVED_DATA="/Volumes/Ext/DerivedData/Where"
-APP_PATH="/Volumes/Ext/Build/Products/Debug-iphonesimulator/Where.app"
 
 # Boot simulator if not already running
 if ! xcrun simctl list devices | grep "$SIMULATOR_ID" | grep -q Booted; then

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -22,4 +22,7 @@ dependencies {
     implementation(libs.ktor.server.websockets)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.logback.classic)
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(kotlin("test"))
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(libs.ktor.server.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.server.call.logging)
+    implementation(libs.ktor.server.websockets)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.logback.classic)
 }

--- a/server/src/main/kotlin/net/af0/where/Server.kt
+++ b/server/src/main/kotlin/net/af0/where/Server.kt
@@ -87,14 +87,15 @@ fun Application.module(state: ServerState = ServerState()) {
 }
 
 private suspend fun ServerState.broadcastLocations() {
+    // Encode once, but wrap in a fresh Frame.Text per send to avoid races on the
+    // ByteReadPacket cursor that is internal to Frame.
     val broadcast = json.encodeToString(
         WsMessage.serializer(),
         WsMessage.LocationsBroadcast(locations.values.toList())
     )
-    val frame = Frame.Text(broadcast)
     for ((_, session) in sessions) {
         session.launch {
-            runCatching { session.send(frame.copy()) }
+            runCatching { session.send(Frame.Text(broadcast)) }
         }
     }
 }

--- a/server/src/main/kotlin/net/af0/where/Server.kt
+++ b/server/src/main/kotlin/net/af0/where/Server.kt
@@ -64,6 +64,10 @@ fun Application.module() {
                             locations[userId] = msg.location
                             broadcastLocations()
                         }
+                        if (msg is WsMessage.LocationRemove) {
+                            locations.remove(userId)
+                            broadcastLocations()
+                        }
                     }
                 }
             } finally {

--- a/server/src/main/kotlin/net/af0/where/Server.kt
+++ b/server/src/main/kotlin/net/af0/where/Server.kt
@@ -19,17 +19,20 @@ import java.util.concurrent.ConcurrentHashMap
 
 private val json = Json { classDiscriminator = "type"; ignoreUnknownKeys = true }
 
-// Current known location per userId
-private val locations = ConcurrentHashMap<String, UserLocation>()
-
-// Active WebSocket sessions per userId
-private val sessions = ConcurrentHashMap<String, DefaultWebSocketServerSession>()
+/**
+ * Encapsulates all mutable server state so each module() invocation (including in tests)
+ * gets its own isolated state rather than sharing package-level globals.
+ */
+class ServerState {
+    val locations = ConcurrentHashMap<String, UserLocation>()
+    val sessions = ConcurrentHashMap<String, DefaultWebSocketServerSession>()
+}
 
 fun main() {
     embeddedServer(Netty, port = 8080, module = Application::module).start(wait = true)
 }
 
-fun Application.module() {
+fun Application.module(state: ServerState = ServerState()) {
     install(ContentNegotiation) { json(json) }
     install(CallLogging)
     install(WebSockets) {
@@ -42,7 +45,7 @@ fun Application.module() {
         }
 
         get("/locations") {
-            call.respond(locations.values.toList())
+            call.respond(state.locations.values.toList())
         }
 
         webSocket("/ws") {
@@ -53,7 +56,7 @@ fun Application.module() {
             }
 
             // Close any existing session for this userId before registering the new one.
-            sessions.put(userId, this)?.close(CloseReason(CloseReason.Codes.NORMAL, "replaced by new session"))
+            state.sessions.put(userId, this)?.close(CloseReason(CloseReason.Codes.NORMAL, "replaced by new session"))
             try {
                 for (frame in incoming) {
                     if (frame is Frame.Text) {
@@ -62,28 +65,28 @@ fun Application.module() {
                         }.getOrNull() ?: continue
 
                         if (msg is WsMessage.LocationUpdate && msg.location.userId == userId) {
-                            locations[userId] = msg.location
-                            broadcastLocations()
+                            state.locations[userId] = msg.location
+                            state.broadcastLocations()
                         }
                         if (msg is WsMessage.LocationRemove) {
-                            locations.remove(userId)
-                            broadcastLocations()
+                            state.locations.remove(userId)
+                            state.broadcastLocations()
                         }
                     }
                 }
             } finally {
                 // Only remove state if this session is still the active one for this userId.
                 // A newer session may have already replaced us in the map.
-                if (sessions.remove(userId, this)) {
-                    locations.remove(userId)
-                    broadcastLocations()
+                if (state.sessions.remove(userId, this)) {
+                    state.locations.remove(userId)
+                    state.broadcastLocations()
                 }
             }
         }
     }
 }
 
-private suspend fun broadcastLocations() {
+private suspend fun ServerState.broadcastLocations() {
     val broadcast = json.encodeToString(
         WsMessage.serializer(),
         WsMessage.LocationsBroadcast(locations.values.toList())

--- a/server/src/main/kotlin/net/af0/where/Server.kt
+++ b/server/src/main/kotlin/net/af0/where/Server.kt
@@ -52,7 +52,8 @@ fun Application.module() {
                 return@webSocket
             }
 
-            sessions[userId] = this
+            // Close any existing session for this userId before registering the new one.
+            sessions.put(userId, this)?.close(CloseReason(CloseReason.Codes.NORMAL, "replaced by new session"))
             try {
                 for (frame in incoming) {
                     if (frame is Frame.Text) {

--- a/server/src/main/kotlin/net/af0/where/Server.kt
+++ b/server/src/main/kotlin/net/af0/where/Server.kt
@@ -1,5 +1,7 @@
 package net.af0.where
 
+import io.ktor.serialization.kotlinx.*
+import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
@@ -7,19 +9,81 @@ import io.ktor.server.plugins.calllogging.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.ktor.serialization.kotlinx.json.*
+import io.ktor.server.websocket.*
+import io.ktor.websocket.*
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import net.af0.where.model.UserLocation
+import net.af0.where.model.WsMessage
+import java.util.concurrent.ConcurrentHashMap
+
+private val json = Json { classDiscriminator = "type"; ignoreUnknownKeys = true }
+
+// Current known location per userId
+private val locations = ConcurrentHashMap<String, UserLocation>()
+
+// Active WebSocket sessions per userId
+private val sessions = ConcurrentHashMap<String, DefaultWebSocketServerSession>()
 
 fun main() {
     embeddedServer(Netty, port = 8080, module = Application::module).start(wait = true)
 }
 
 fun Application.module() {
-    install(ContentNegotiation) { json() }
+    install(ContentNegotiation) { json(json) }
     install(CallLogging)
+    install(WebSockets) {
+        contentConverter = KotlinxWebsocketSerializationConverter(json)
+    }
 
     routing {
         get("/health") {
             call.respondText("ok")
+        }
+
+        get("/locations") {
+            call.respond(locations.values.toList())
+        }
+
+        webSocket("/ws") {
+            val userId = call.parameters["userId"]
+            if (userId == null) {
+                close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "userId required"))
+                return@webSocket
+            }
+
+            sessions[userId] = this
+            try {
+                for (frame in incoming) {
+                    if (frame is Frame.Text) {
+                        val msg = runCatching {
+                            json.decodeFromString<WsMessage>(frame.readText())
+                        }.getOrNull() ?: continue
+
+                        if (msg is WsMessage.LocationUpdate) {
+                            locations[userId] = msg.location
+                            broadcastLocations()
+                        }
+                    }
+                }
+            } finally {
+                sessions.remove(userId)
+                locations.remove(userId)
+                broadcastLocations()
+            }
+        }
+    }
+}
+
+private suspend fun broadcastLocations() {
+    val broadcast = json.encodeToString(
+        WsMessage.serializer(),
+        WsMessage.LocationsBroadcast(locations.values.toList())
+    )
+    val frame = Frame.Text(broadcast)
+    for ((_, session) in sessions) {
+        session.launch {
+            runCatching { session.send(frame.copy()) }
         }
     }
 }

--- a/server/src/main/kotlin/net/af0/where/Server.kt
+++ b/server/src/main/kotlin/net/af0/where/Server.kt
@@ -60,16 +60,19 @@ fun Application.module() {
                             json.decodeFromString<WsMessage>(frame.readText())
                         }.getOrNull() ?: continue
 
-                        if (msg is WsMessage.LocationUpdate) {
+                        if (msg is WsMessage.LocationUpdate && msg.location.userId == userId) {
                             locations[userId] = msg.location
                             broadcastLocations()
                         }
                     }
                 }
             } finally {
-                sessions.remove(userId)
-                locations.remove(userId)
-                broadcastLocations()
+                // Only remove state if this session is still the active one for this userId.
+                // A newer session may have already replaced us in the map.
+                if (sessions.remove(userId, this)) {
+                    locations.remove(userId)
+                    broadcastLocations()
+                }
             }
         }
     }

--- a/server/src/test/kotlin/net/af0/where/ServerTest.kt
+++ b/server/src/test/kotlin/net/af0/where/ServerTest.kt
@@ -1,0 +1,71 @@
+package net.af0.where
+
+import io.ktor.client.plugins.websocket.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import io.ktor.websocket.*
+import kotlinx.serialization.json.Json
+import net.af0.where.model.UserLocation
+import net.af0.where.model.WsMessage
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class ServerTest {
+
+    private val json = Json { classDiscriminator = "type"; ignoreUnknownKeys = true }
+
+    @Test
+    fun locationUpdateIsBroadcastBackToSender() = testApplication {
+        application { module() }
+        val client = createClient { install(WebSockets) }
+        client.webSocket("/ws?userId=alice") {
+            // userId in the location must match the connection's userId or the server drops it
+            val location = UserLocation("alice", 37.7749, -122.4194, 0L)
+            send(Frame.Text(json.encodeToString(WsMessage.serializer(), WsMessage.LocationUpdate(location))))
+            val frame = incoming.receive()
+            val broadcast = json.decodeFromString<WsMessage>((frame as Frame.Text).readText())
+            assertIs<WsMessage.LocationsBroadcast>(broadcast)
+            val users = (broadcast as WsMessage.LocationsBroadcast).users
+            assert(users.any { it.userId == "alice" }) { "Expected alice in broadcast" }
+        }
+    }
+
+    @Test
+    fun locationRemovedOnDisconnect() = testApplication {
+        application { module() }
+        val client = createClient { install(WebSockets) }
+        // Connect and send a location, then disconnect — server should remove it
+        client.webSocket("/ws?userId=carol") {
+            val location = UserLocation("carol", 1.0, 2.0, 0L)
+            send(Frame.Text(json.encodeToString(WsMessage.serializer(), WsMessage.LocationUpdate(location))))
+            // Receive the broadcast back
+            incoming.receive()
+            // Close the session
+            close(CloseReason(CloseReason.Codes.NORMAL, "done"))
+        }
+        // After disconnect, /locations should be empty for carol
+        val httpClient = createClient {}
+        val response = httpClient.get("/locations")
+        // The response body should not contain carol
+        assert(!response.bodyAsText().contains("carol"))
+    }
+
+    @Test
+    fun locationRemoveMessageClearsPin() = testApplication {
+        application { module() }
+        val client = createClient { install(WebSockets) }
+        client.webSocket("/ws?userId=dave") {
+            val location = UserLocation("dave", 5.0, 6.0, 0L)
+            send(Frame.Text(json.encodeToString(WsMessage.serializer(), WsMessage.LocationUpdate(location))))
+            incoming.receive() // consume broadcast
+            send(Frame.Text(json.encodeToString(WsMessage.serializer(), WsMessage.LocationRemove)))
+            val frame = incoming.receive()
+            val broadcast = json.decodeFromString<WsMessage>((frame as Frame.Text).readText())
+            assertIs<WsMessage.LocationsBroadcast>(broadcast)
+            val users = (broadcast as WsMessage.LocationsBroadcast).users
+            assert(users.none { it.userId == "dave" }) { "dave's location should be removed" }
+        }
+    }
+}

--- a/server/src/test/kotlin/net/af0/where/ServerTest.kt
+++ b/server/src/test/kotlin/net/af0/where/ServerTest.kt
@@ -18,7 +18,7 @@ class ServerTest {
 
     @Test
     fun locationUpdateIsBroadcastBackToSender() = testApplication {
-        application { module() }
+        application { module(ServerState()) }
         val client = createClient { install(WebSockets) }
         client.webSocket("/ws?userId=alice") {
             // userId in the location must match the connection's userId or the server drops it
@@ -34,7 +34,7 @@ class ServerTest {
 
     @Test
     fun locationRemovedOnDisconnect() = testApplication {
-        application { module() }
+        application { module(ServerState()) }
         val client = createClient { install(WebSockets) }
         // Connect and send a location, then disconnect — server should remove it
         client.webSocket("/ws?userId=carol") {
@@ -54,7 +54,7 @@ class ServerTest {
 
     @Test
     fun locationRemoveMessageClearsPin() = testApplication {
-        application { module() }
+        application { module(ServerState()) }
         val client = createClient { install(WebSockets) }
         client.webSocket("/ws?userId=dave") {
             val location = UserLocation("dave", 5.0, 6.0, 0L)

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -32,6 +32,7 @@ kotlin {
         commonMain.dependencies {
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.client.websockets)
             implementation(libs.ktor.serialization.kotlinx.json)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.serialization.json)

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -50,6 +50,15 @@ kotlin {
         commonTest.dependencies {
             implementation(kotlin("test"))
         }
+
+        jvmTest.dependencies {
+            implementation(libs.ktor.server.core)
+            implementation(libs.ktor.server.netty)
+            implementation(libs.ktor.server.websockets)
+            implementation(libs.ktor.client.cio)
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.logback.classic)
+        }
     }
 }
 

--- a/shared/src/androidMain/kotlin/net/af0/where/Platform.kt
+++ b/shared/src/androidMain/kotlin/net/af0/where/Platform.kt
@@ -1,0 +1,3 @@
+package net.af0.where
+
+actual fun currentTimeMillis(): Long = System.currentTimeMillis()

--- a/shared/src/commonMain/kotlin/net/af0/where/LocationMessageCodec.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/LocationMessageCodec.kt
@@ -1,0 +1,27 @@
+package net.af0.where
+
+import kotlinx.serialization.json.Json
+import net.af0.where.model.UserLocation
+import net.af0.where.model.WsMessage
+
+/**
+ * Swift-friendly codec for the WebSocket protocol. iOS uses URLSession for networking
+ * but delegates all JSON encoding/decoding to this object so the protocol stays in KMP.
+ */
+object LocationMessageCodec {
+    private val json = Json { classDiscriminator = "type"; ignoreUnknownKeys = true }
+
+    fun encodeLocationUpdate(userId: String, lat: Double, lng: Double, timestamp: Long): String {
+        val msg = WsMessage.LocationUpdate(UserLocation(userId, lat, lng, timestamp))
+        return json.encodeToString(WsMessage.serializer(), msg)
+    }
+
+    fun encodeLocationRemove(): String =
+        json.encodeToString(WsMessage.serializer(), WsMessage.LocationRemove)
+
+    /** Returns the list of users from a locations-broadcast message, or null if not applicable. */
+    fun decodeUsers(text: String): List<UserLocation>? {
+        val msg = runCatching { json.decodeFromString<WsMessage>(text) }.getOrNull() ?: return null
+        return (msg as? WsMessage.LocationsBroadcast)?.users
+    }
+}

--- a/shared/src/commonMain/kotlin/net/af0/where/LocationSyncClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/LocationSyncClient.kt
@@ -21,7 +21,7 @@ class LocationSyncClient(
     }
 
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-    private var session: DefaultClientWebSocketSession? = null
+    @Volatile internal var session: DefaultClientWebSocketSession? = null
     private var job: Job? = null
 
     fun connect() {
@@ -57,13 +57,19 @@ class LocationSyncClient(
         )
         val text = json.encodeToString(WsMessage.serializer(), msg)
         scope.launch {
-            session?.send(Frame.Text(text))
+            runCatching { session?.send(Frame.Text(text)) }
+        }
+    }
+
+    fun sendLocationRemove() {
+        val text = json.encodeToString(WsMessage.serializer(), WsMessage.LocationRemove)
+        scope.launch {
+            runCatching { session?.send(Frame.Text(text)) }
         }
     }
 
     fun disconnect() {
         job?.cancel()
-        client.close()
     }
 }
 

--- a/shared/src/commonMain/kotlin/net/af0/where/LocationSyncClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/LocationSyncClient.kt
@@ -25,6 +25,8 @@ class LocationSyncClient(
     private var job: Job? = null
 
     fun connect() {
+        // Cancel any in-flight connection before starting a new one to prevent overlapping loops.
+        job?.cancel()
         job = scope.launch {
             while (isActive) {
                 try {

--- a/shared/src/commonMain/kotlin/net/af0/where/LocationSyncClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/LocationSyncClient.kt
@@ -27,6 +27,9 @@ class LocationSyncClient(
     private var session: DefaultClientWebSocketSession? = null
     private var job: Job? = null
 
+    /** True while there is an active WebSocket session. Intended for testing. */
+    internal val isConnected: Boolean get() = session != null
+
     fun connect() {
         // Cancel any in-flight connection before starting a new one to prevent overlapping loops.
         job?.cancel()

--- a/shared/src/commonMain/kotlin/net/af0/where/LocationSyncClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/LocationSyncClient.kt
@@ -4,6 +4,8 @@ import io.ktor.client.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import net.af0.where.model.UserLocation
 import net.af0.where.model.WsMessage
@@ -21,7 +23,8 @@ class LocationSyncClient(
     }
 
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-    @Volatile internal var session: DefaultClientWebSocketSession? = null
+    private val sessionLock = Mutex()
+    private var session: DefaultClientWebSocketSession? = null
     private var job: Job? = null
 
     fun connect() {
@@ -31,22 +34,24 @@ class LocationSyncClient(
             while (isActive) {
                 try {
                     client.webSocket("$serverWsUrl?userId=$userId") {
-                        session = this
-                        for (frame in incoming) {
-                            if (frame is Frame.Text) {
-                                val msg = runCatching {
-                                    json.decodeFromString<WsMessage>(frame.readText())
-                                }.getOrNull() ?: continue
-                                if (msg is WsMessage.LocationsBroadcast) {
-                                    onLocationsUpdate(msg.users)
+                        sessionLock.withLock { session = this }
+                        try {
+                            for (frame in incoming) {
+                                if (frame is Frame.Text) {
+                                    val msg = runCatching {
+                                        json.decodeFromString<WsMessage>(frame.readText())
+                                    }.getOrNull() ?: continue
+                                    if (msg is WsMessage.LocationsBroadcast) {
+                                        onLocationsUpdate(msg.users)
+                                    }
                                 }
                             }
+                        } finally {
+                            sessionLock.withLock { session = null }
                         }
                     }
                 } catch (e: Exception) {
                     if (!isActive) break
-                } finally {
-                    session = null
                 }
                 delay(3_000) // reconnect backoff
             }
@@ -59,14 +64,14 @@ class LocationSyncClient(
         )
         val text = json.encodeToString(WsMessage.serializer(), msg)
         scope.launch {
-            runCatching { session?.send(Frame.Text(text)) }
+            sessionLock.withLock { runCatching { session?.send(Frame.Text(text)) } }
         }
     }
 
     fun sendLocationRemove() {
         val text = json.encodeToString(WsMessage.serializer(), WsMessage.LocationRemove)
         scope.launch {
-            runCatching { session?.send(Frame.Text(text)) }
+            sessionLock.withLock { runCatching { session?.send(Frame.Text(text)) } }
         }
     }
 

--- a/shared/src/commonMain/kotlin/net/af0/where/LocationSyncClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/LocationSyncClient.kt
@@ -1,0 +1,70 @@
+package net.af0.where
+
+import io.ktor.client.*
+import io.ktor.client.plugins.websocket.*
+import io.ktor.websocket.*
+import kotlinx.coroutines.*
+import kotlinx.serialization.json.Json
+import net.af0.where.model.UserLocation
+import net.af0.where.model.WsMessage
+
+@OptIn(kotlin.experimental.ExperimentalObjCRefinement::class)
+@kotlin.native.HiddenFromObjC
+class LocationSyncClient(
+    private val serverWsUrl: String,
+    private val userId: String,
+    private val onLocationsUpdate: (List<UserLocation>) -> Unit,
+) {
+    private val json = Json { classDiscriminator = "type"; ignoreUnknownKeys = true }
+    private val client = HttpClient {
+        install(WebSockets)
+    }
+
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private var session: DefaultClientWebSocketSession? = null
+    private var job: Job? = null
+
+    fun connect() {
+        job = scope.launch {
+            while (isActive) {
+                try {
+                    client.webSocket("$serverWsUrl?userId=$userId") {
+                        session = this
+                        for (frame in incoming) {
+                            if (frame is Frame.Text) {
+                                val msg = runCatching {
+                                    json.decodeFromString<WsMessage>(frame.readText())
+                                }.getOrNull() ?: continue
+                                if (msg is WsMessage.LocationsBroadcast) {
+                                    onLocationsUpdate(msg.users)
+                                }
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    if (!isActive) break
+                } finally {
+                    session = null
+                }
+                delay(3_000) // reconnect backoff
+            }
+        }
+    }
+
+    fun sendLocation(lat: Double, lng: Double) {
+        val msg = WsMessage.LocationUpdate(
+            UserLocation(userId, lat, lng, currentTimeMillis())
+        )
+        val text = json.encodeToString(WsMessage.serializer(), msg)
+        scope.launch {
+            session?.send(Frame.Text(text))
+        }
+    }
+
+    fun disconnect() {
+        job?.cancel()
+        client.close()
+    }
+}
+
+expect fun currentTimeMillis(): Long

--- a/shared/src/commonMain/kotlin/net/af0/where/model/UserLocation.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/model/UserLocation.kt
@@ -1,0 +1,11 @@
+package net.af0.where.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserLocation(
+    val userId: String,
+    val lat: Double,
+    val lng: Double,
+    val timestamp: Long,
+)

--- a/shared/src/commonMain/kotlin/net/af0/where/model/WsMessage.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/model/WsMessage.kt
@@ -14,4 +14,8 @@ sealed class WsMessage {
     @Serializable
     @SerialName("locations")
     data class LocationsBroadcast(val users: List<UserLocation>) : WsMessage()
+
+    @Serializable
+    @SerialName("location_remove")
+    object LocationRemove : WsMessage()
 }

--- a/shared/src/commonMain/kotlin/net/af0/where/model/WsMessage.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/model/WsMessage.kt
@@ -1,0 +1,17 @@
+package net.af0.where.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@OptIn(kotlin.experimental.ExperimentalObjCRefinement::class)
+@kotlin.native.HiddenFromObjC
+@Serializable
+sealed class WsMessage {
+    @Serializable
+    @SerialName("location")
+    data class LocationUpdate(val location: UserLocation) : WsMessage()
+
+    @Serializable
+    @SerialName("locations")
+    data class LocationsBroadcast(val users: List<UserLocation>) : WsMessage()
+}

--- a/shared/src/commonTest/kotlin/net/af0/where/LocationMessageCodecTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/LocationMessageCodecTest.kt
@@ -1,0 +1,68 @@
+package net.af0.where
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LocationMessageCodecTest {
+
+    @Test
+    fun encodeLocationUpdateProducesCorrectJson() {
+        val json = LocationMessageCodec.encodeLocationUpdate("alice", 37.7749, -122.4194, 1000L)
+        assertTrue(json.contains("\"type\":\"location\""), "Expected type=location in: $json")
+        assertTrue(json.contains("\"userId\":\"alice\""), "Expected userId in: $json")
+        assertTrue(json.contains("37.7749"), "Expected lat in: $json")
+        assertTrue(json.contains("-122.4194"), "Expected lng in: $json")
+    }
+
+    @Test
+    fun encodeLocationRemoveProducesCorrectJson() {
+        val json = LocationMessageCodec.encodeLocationRemove()
+        assertTrue(json.contains("\"type\":\"location_remove\""), "Expected type=location_remove in: $json")
+    }
+
+    @Test
+    fun decodeUsersReturnsUserListFromBroadcast() {
+        val broadcast = """{"type":"locations","users":[{"userId":"bob","lat":1.0,"lng":2.0,"timestamp":0}]}"""
+        val users = LocationMessageCodec.decodeUsers(broadcast)
+        assertNotNull(users)
+        assertEquals(1, users.size)
+        assertEquals("bob", users[0].userId)
+        assertEquals(1.0, users[0].lat)
+        assertEquals(2.0, users[0].lng)
+    }
+
+    @Test
+    fun decodeUsersReturnsNullForNonBroadcastMessage() {
+        val update = """{"type":"location","location":{"userId":"alice","lat":1.0,"lng":2.0,"timestamp":0}}"""
+        assertNull(LocationMessageCodec.decodeUsers(update))
+    }
+
+    @Test
+    fun decodeUsersReturnsNullForInvalidJson() {
+        assertNull(LocationMessageCodec.decodeUsers("not json"))
+    }
+
+    @Test
+    fun decodeUsersHandlesEmptyUserList() {
+        val broadcast = """{"type":"locations","users":[]}"""
+        val users = LocationMessageCodec.decodeUsers(broadcast)
+        assertNotNull(users)
+        assertEquals(0, users.size)
+    }
+
+    @Test
+    fun encodeLocationUpdateRoundTripsViaDecodeUsers() {
+        // Encode a location update (sent by client), then simulate a broadcast (sent by server)
+        // to verify the userId/lat/lng survive the round-trip through the codec.
+        val serverBroadcast = """{"type":"locations","users":[{"userId":"carol","lat":51.5,"lng":-0.1,"timestamp":9999}]}"""
+        val users = LocationMessageCodec.decodeUsers(serverBroadcast)
+        assertNotNull(users)
+        assertEquals("carol", users[0].userId)
+        assertEquals(51.5, users[0].lat)
+        assertEquals(-0.1, users[0].lng)
+        assertEquals(9999L, users[0].timestamp)
+    }
+}

--- a/shared/src/commonTest/kotlin/net/af0/where/model/WsMessageSerializationTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/model/WsMessageSerializationTest.kt
@@ -1,0 +1,62 @@
+package net.af0.where.model
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+private val json = Json { classDiscriminator = "type"; ignoreUnknownKeys = true }
+
+class WsMessageSerializationTest {
+
+    private val sampleLocation = UserLocation(
+        userId = "alice",
+        lat = 37.7749,
+        lng = -122.4194,
+        timestamp = 1711180800000L
+    )
+
+    @Test
+    fun locationUpdateRoundTrip() {
+        val original = WsMessage.LocationUpdate(sampleLocation)
+        val encoded = json.encodeToString(WsMessage.serializer(), original)
+        val decoded = json.decodeFromString<WsMessage>(encoded)
+        assertIs<WsMessage.LocationUpdate>(decoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun locationsBroadcastRoundTrip() {
+        val original = WsMessage.LocationsBroadcast(listOf(sampleLocation))
+        val encoded = json.encodeToString(WsMessage.serializer(), original)
+        val decoded = json.decodeFromString<WsMessage>(encoded)
+        assertIs<WsMessage.LocationsBroadcast>(decoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun locationUpdateTypeDiscriminator() {
+        val encoded = json.encodeToString(
+            WsMessage.serializer(),
+            WsMessage.LocationUpdate(sampleLocation)
+        )
+        assert(encoded.contains("\"type\":\"location\"")) { "Expected type=location in: $encoded" }
+    }
+
+    @Test
+    fun locationsBroadcastTypeDiscriminator() {
+        val encoded = json.encodeToString(
+            WsMessage.serializer(),
+            WsMessage.LocationsBroadcast(listOf(sampleLocation))
+        )
+        assert(encoded.contains("\"type\":\"locations\"")) { "Expected type=locations in: $encoded" }
+    }
+
+    @Test
+    fun ignoresUnknownKeys() {
+        val raw = """{"type":"locations","users":[{"userId":"bob","lat":1.0,"lng":2.0,"timestamp":0}],"extra":"ignored"}"""
+        val decoded = json.decodeFromString<WsMessage>(raw)
+        assertIs<WsMessage.LocationsBroadcast>(decoded)
+        assertEquals(1, (decoded as WsMessage.LocationsBroadcast).users.size)
+    }
+}

--- a/shared/src/commonTest/kotlin/net/af0/where/model/WsMessageSerializationTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/model/WsMessageSerializationTest.kt
@@ -59,4 +59,17 @@ class WsMessageSerializationTest {
         assertIs<WsMessage.LocationsBroadcast>(decoded)
         assertEquals(1, (decoded as WsMessage.LocationsBroadcast).users.size)
     }
+
+    @Test
+    fun locationRemoveRoundTrip() {
+        val encoded = json.encodeToString(WsMessage.serializer(), WsMessage.LocationRemove)
+        val decoded = json.decodeFromString<WsMessage>(encoded)
+        assertIs<WsMessage.LocationRemove>(decoded)
+    }
+
+    @Test
+    fun locationRemoveTypeDiscriminator() {
+        val encoded = json.encodeToString(WsMessage.serializer(), WsMessage.LocationRemove)
+        assert(encoded.contains("\"type\":\"location_remove\"")) { "Expected type=location_remove in: $encoded" }
+    }
 }

--- a/shared/src/iosMain/kotlin/net/af0/where/Platform.kt
+++ b/shared/src/iosMain/kotlin/net/af0/where/Platform.kt
@@ -1,0 +1,6 @@
+package net.af0.where
+
+import platform.Foundation.NSDate
+import platform.Foundation.timeIntervalSince1970
+
+actual fun currentTimeMillis(): Long = (NSDate().timeIntervalSince1970 * 1000).toLong()

--- a/shared/src/jvmMain/kotlin/net/af0/where/Platform.kt
+++ b/shared/src/jvmMain/kotlin/net/af0/where/Platform.kt
@@ -1,0 +1,3 @@
+package net.af0.where
+
+actual fun currentTimeMillis(): Long = System.currentTimeMillis()

--- a/shared/src/jvmTest/kotlin/net/af0/where/LocationSyncClientIntegrationTest.kt
+++ b/shared/src/jvmTest/kotlin/net/af0/where/LocationSyncClientIntegrationTest.kt
@@ -1,0 +1,151 @@
+package net.af0.where
+
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.routing.*
+import io.ktor.server.websocket.*
+import io.ktor.websocket.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import net.af0.where.model.UserLocation
+import net.af0.where.model.WsMessage
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for LocationSyncClient against a real in-process Ktor/Netty server.
+ * The server is defined inline here to avoid a circular dependency on the :server module.
+ *
+ * Uses runBlocking (not runTest) because the client runs on Dispatchers.Default and
+ * requires real wall-clock time for network I/O.
+ */
+class LocationSyncClientIntegrationTest {
+
+    private val json = Json { classDiscriminator = "type"; ignoreUnknownKeys = true }
+
+    private lateinit var server: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>
+    private var port: Int = 0
+
+    @BeforeTest
+    fun startServer() {
+        server = embeddedServer(Netty, configure = {
+            connector { port = 0 } // OS picks a free port
+        }) {
+            install(WebSockets)
+            routing {
+                webSocket("/ws") {
+                    val userId = call.parameters["userId"] ?: run {
+                        close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "userId required"))
+                        return@webSocket
+                    }
+                    // Minimal echo-broadcaster: LocationUpdate → broadcast with that user only;
+                    // LocationRemove → broadcast empty list.
+                    for (frame in incoming) {
+                        if (frame !is Frame.Text) continue
+                        val msg = runCatching {
+                            json.decodeFromString<WsMessage>(frame.readText())
+                        }.getOrNull() ?: continue
+
+                        val broadcast = when (msg) {
+                            is WsMessage.LocationUpdate -> WsMessage.LocationsBroadcast(listOf(msg.location))
+                            is WsMessage.LocationRemove -> WsMessage.LocationsBroadcast(emptyList())
+                            else -> continue
+                        }
+                        send(Frame.Text(json.encodeToString(WsMessage.serializer(), broadcast)))
+                    }
+                }
+            }
+        }
+        server.start(wait = false)
+        port = runBlocking { server.engine.resolvedConnectors().first().port }
+    }
+
+    @AfterTest
+    fun stopServer() {
+        server.stop(gracePeriodMillis = 0, timeoutMillis = 500)
+    }
+
+    @Test
+    fun connectAndReceivesBroadcastOnLocationUpdate() = runBlocking {
+        val received = Channel<List<UserLocation>>(capacity = Channel.UNLIMITED)
+        val client = LocationSyncClient(
+            serverWsUrl = "ws://127.0.0.1:$port/ws",
+            userId = "alice",
+            onLocationsUpdate = { received.trySend(it) },
+        )
+
+        client.connect()
+        awaitSession(client)
+
+        client.sendLocation(37.7749, -122.4194)
+
+        val update = withTimeout(5_000) { received.receive() }
+        assertEquals(1, update.size)
+        assertEquals("alice", update[0].userId)
+        assertEquals(37.7749, update[0].lat)
+        assertEquals(-122.4194, update[0].lng)
+
+        client.disconnect()
+    }
+
+    @Test
+    fun sendLocationRemoveResultsInEmptyBroadcast() = runBlocking {
+        val received = Channel<List<UserLocation>>(capacity = Channel.UNLIMITED)
+        val client = LocationSyncClient(
+            serverWsUrl = "ws://127.0.0.1:$port/ws",
+            userId = "bob",
+            onLocationsUpdate = { received.trySend(it) },
+        )
+
+        client.connect()
+        awaitSession(client)
+
+        client.sendLocation(51.5, -0.1)
+        withTimeout(5_000) { received.receive() } // drain location broadcast
+
+        client.sendLocationRemove()
+        val afterRemove = withTimeout(5_000) { received.receive() }
+        assertTrue(afterRemove.isEmpty(), "Expected empty broadcast after location_remove")
+
+        client.disconnect()
+    }
+
+    @Test
+    fun disconnectStopsReceivingUpdates() = runBlocking {
+        val received = Channel<List<UserLocation>>(capacity = Channel.UNLIMITED)
+        val client = LocationSyncClient(
+            serverWsUrl = "ws://127.0.0.1:$port/ws",
+            userId = "carol",
+            onLocationsUpdate = { received.trySend(it) },
+        )
+
+        client.connect()
+        awaitSession(client)
+
+        client.sendLocation(48.8566, 2.3522)
+        withTimeout(5_000) { received.receive() } // confirm connected and broadcasting
+
+        client.disconnect()
+
+        // Allow a brief window for any in-flight messages to drain, then verify silence
+        delay(300)
+        assertNull(received.tryReceive().getOrNull(), "No messages expected after disconnect")
+    }
+
+    /** Polls until the client has an active WebSocket session (up to 5s). */
+    private suspend fun awaitSession(client: LocationSyncClient) {
+        withTimeout(5_000) {
+            while (client.session == null) {
+                delay(50)
+            }
+        }
+    }
+}

--- a/shared/src/jvmTest/kotlin/net/af0/where/LocationSyncClientIntegrationTest.kt
+++ b/shared/src/jvmTest/kotlin/net/af0/where/LocationSyncClientIntegrationTest.kt
@@ -143,7 +143,7 @@ class LocationSyncClientIntegrationTest {
     /** Polls until the client has an active WebSocket session (up to 5s). */
     private suspend fun awaitSession(client: LocationSyncClient) {
         withTimeout(5_000) {
-            while (client.session == null) {
+            while (!client.isConnected) {
                 delay(50)
             }
         }


### PR DESCRIPTION
## Summary

- **Friend zoom**: tap a friend's name in the Friends sheet to dismiss and zoom the map to their location (Android + iOS)
- **Maps API key fix**: `project.findProperty()` doesn't read `local.properties`; switched to explicit `Properties().load()` — Maps tiles now render correctly
- **Android crash fix**: defer `LocationService` start until after location permission is granted (Android 14+ rejects foreground services with type `location` before permission)
- **Launch scripts**: `run-android.sh`, `run-ios.sh`, `run-ios-pair.sh` for one-command dev builds and deploys
- **ADB over network**: `ANDROID_ADB_HOST` in `local.properties` for Tailscale-connected Android devices (no USB required)
- **arm64 emulator**: switched from x86_64 to arm64-v8a system image (x86_64 unsupported on Apple Silicon host)
- **Xcode 26 beta linker fix**: added `-ld_classic` to work around `-objc_abi_version` rejection in new ld
- **Build artifacts on external volume**: Gradle init script + symlinks redirect caches and build dirs to `/Volumes/Ext` (machine-local, not committed)

## Test plan

- [ ] `./run-ios.sh` builds and launches on iPhone 17 simulator
- [ ] `./run-ios-pair.sh` launches on two simulators simultaneously
- [ ] `./run-android.sh` connects to ADB-over-network device and installs
- [ ] Map tiles load on Android (Maps API key present in manifest)
- [ ] App does not crash on first launch (permission requested before service starts)
- [ ] Tapping a friend in the Friends sheet zooms the map to their pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)