### PR TITLE
Fix E2EE crypto failures by implementing standard HMAC-SHA-256

### DIFF
--- a/shared/src/iosMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
+++ b/shared/src/iosMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
@@ -24,7 +24,22 @@ internal actual fun hmacSha256(
     key: ByteArray,
     data: ByteArray,
 ): ByteArray {
-    return Auth.authHmacSha256(data.toUByteArray(), key.toUByteArray()).toByteArray()
+    val blockSeparator = 64
+    var k = if (key.size > blockSeparator) {
+        sha256(key)
+    } else {
+        key
+    }
+
+    if (k.size < blockSeparator) {
+        k = k.copyOf(blockSeparator)
+    }
+
+    val ipad = ByteArray(blockSeparator) { i -> (k[i].toInt() xor 0x36).toByte() }
+    val opad = ByteArray(blockSeparator) { i -> (k[i].toInt() xor 0x5c).toByte() }
+
+    val innerHash = sha256(ipad + data)
+    return sha256(opad + innerHash)
 }
 
 // ---------------------------------------------------------------------------

--- a/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
+++ b/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
@@ -24,7 +24,22 @@ internal actual fun hmacSha256(
     key: ByteArray,
     data: ByteArray,
 ): ByteArray {
-    return Auth.authHmacSha256(data.toUByteArray(), key.toUByteArray()).toByteArray()
+    val blockSeparator = 64
+    var k = if (key.size > blockSeparator) {
+        sha256(key)
+    } else {
+        key
+    }
+
+    if (k.size < blockSeparator) {
+        k = k.copyOf(blockSeparator)
+    }
+
+    val ipad = ByteArray(blockSeparator) { i -> (k[i].toInt() xor 0x36).toByte() }
+    val opad = ByteArray(blockSeparator) { i -> (k[i].toInt() xor 0x5c).toByte() }
+
+    val innerHash = sha256(ipad + data)
+    return sha256(opad + innerHash)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixed failing CI tests by correcting the HMAC-SHA-256 implementation in the shared module. The previous implementation used a libsodium wrapper that required 32-byte keys, causing failures in HKDF and other protocols. The new implementation follows RFC 2104 and uses the platform's SHA-256 primitive.

---
*PR created automatically by Jules for task [13582931189573309458](https://jules.google.com/task/13582931189573309458) started by @danmarg*