### PR TITLE
Address reviewer feedback on PR#9

### DIFF
--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -37,97 +37,23 @@ private func urlToQrPayload(_ url: String) -> Shared.QrPayload? {
 // MARK: - HTTP mailbox helpers
 
 @MainActor
-private func postToMailbox(token: String, bodyData: Data) async {
+private func postToMailbox(token: String, payload: Shared.MailboxPayload) async {
     guard let url = URL(string: "\(ServerConfig.httpBaseUrl)/inbox/\(token)") else { return }
+    let jsonString = Shared.LocationMessageCodec.shared.encodeMailboxPayload(payload: payload)
     var req = URLRequest(url: url)
     req.httpMethod = "POST"
     req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    req.httpBody = bodyData
+    req.httpBody = jsonString.data(using: .utf8)
     _ = try? await URLSession.shared.data(for: req)
 }
 
 @MainActor
-private func pollMailbox(token: String) async -> [[String: Any]] {
+private func pollMailbox(token: String) async -> [Shared.MailboxPayload] {
     guard let url = URL(string: "\(ServerConfig.httpBaseUrl)/inbox/\(token)") else { return [] }
     guard let (data, _) = try? await URLSession.shared.data(from: url),
-          let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+          let jsonString = String(data: data, encoding: .utf8)
     else { return [] }
-    return arr
-}
-
-// MARK: - Wire serialization helpers for new payload types
-
-private func preKeyBundleBody(_ bundle: Shared.PreKeyBundlePayload) -> [String: Any] {
-    let keys = bundle.keys.map { opk -> [String: Any] in
-        ["id": opk.id, "pub": toSwiftData(opk.pub).base64EncodedString()]
-    }
-    return [
-        "type": "PreKeyBundle",
-        "keys": keys,
-        "mac": toSwiftData(bundle.mac).base64EncodedString(),
-    ]
-}
-
-private func epochRotationBody(_ payload: Shared.EpochRotationPayload) -> [String: Any] {
-    return [
-        "type": "EpochRotation",
-        "epoch": payload.epoch,
-        "opk_id": payload.opkId,
-        "new_ek_pub": toSwiftData(payload.newEkPub).base64EncodedString(),
-        "ts": payload.ts,
-        "ct": toSwiftData(payload.ct).base64EncodedString(),
-    ]
-}
-
-private func ratchetAckBody(_ payload: Shared.RatchetAckPayload) -> [String: Any] {
-    return [
-        "type": "RatchetAck",
-        "epoch_seen": payload.epochSeen,
-        "ts": payload.ts,
-        "ct": toSwiftData(payload.ct).base64EncodedString(),
-    ]
-}
-
-// JSONSerialization always produces `Int` (64-bit on iOS) for JSON integers,
-// never `Int32` or `Int64` directly.  Cast to `Int` first, then narrow.
-private func parseEpochRotation(_ msg: [String: Any]) -> Shared.EpochRotationPayload? {
-    guard (msg["type"] as? String) == "EpochRotation",
-          let epochInt = msg["epoch"] as? Int,
-          let opkIdInt = msg["opk_id"] as? Int,
-          let newEkPubB64 = msg["new_ek_pub"] as? String, let newEkPubData = Data(base64Encoded: newEkPubB64),
-          let tsInt = msg["ts"] as? Int,
-          let ctB64 = msg["ct"] as? String, let ctData = Data(base64Encoded: ctB64)
-    else { return nil }
-    return Shared.EpochRotationPayload(
-        epoch: Int32(epochInt), opkId: Int32(opkIdInt),
-        newEkPub: kotlinByteArray(from: newEkPubData),
-        ts: Int64(tsInt), ct: kotlinByteArray(from: ctData)
-    )
-}
-
-private func parsePreKeyBundle(_ msg: [String: Any]) -> Shared.PreKeyBundlePayload? {
-    guard (msg["type"] as? String) == "PreKeyBundle",
-          let keysArr = msg["keys"] as? [[String: Any]],
-          let macB64 = msg["mac"] as? String, let macData = Data(base64Encoded: macB64)
-    else { return nil }
-    var opkWires: [Shared.OPKWire] = []
-    for k in keysArr {
-        guard let idInt = k["id"] as? Int,
-              let pubB64 = k["pub"] as? String,
-              let pubData = Data(base64Encoded: pubB64)
-        else { return nil }
-        opkWires.append(Shared.OPKWire(id: Int32(idInt), pub: kotlinByteArray(from: pubData)))
-    }
-    return Shared.PreKeyBundlePayload(keys: opkWires, mac: kotlinByteArray(from: macData))
-}
-
-private func parseRatchetAck(_ msg: [String: Any]) -> Shared.RatchetAckPayload? {
-    guard (msg["type"] as? String) == "RatchetAck",
-          let epochSeenInt = msg["epoch_seen"] as? Int,
-          let tsInt = msg["ts"] as? Int,
-          let ctB64 = msg["ct"] as? String, let ctData = Data(base64Encoded: ctB64)
-    else { return nil }
-    return Shared.RatchetAckPayload(epochSeen: Int32(epochSeenInt), ts: Int64(tsInt), ct: kotlinByteArray(from: ctData))
+    return Shared.LocationMessageCodec.shared.decodeMailboxPayloads(text: jsonString) ?? []
 }
 
 // MARK: - LocationSyncService
@@ -206,10 +132,7 @@ final class LocationSyncService: ObservableObject {
                 if e2eeStore.shouldRotateEpoch(friendId: friend.id) {
                     let oldToken = toHex(friend.session.routingToken)
                     if let rotPayload = e2eeStore.initiateEpochRotation(friendId: friend.id) {
-                        let body = epochRotationBody(rotPayload)
-                        if let bodyData = try? JSONSerialization.data(withJSONObject: body) {
-                            await postToMailbox(token: oldToken, bodyData: bodyData)
-                        }
+                        await postToMailbox(token: oldToken, payload: rotPayload)
                     }
                 }
 
@@ -223,15 +146,12 @@ final class LocationSyncService: ObservableObject {
                 let ct = result.second!
                 e2eeStore.updateSession(id: friend.id, newSession: newSession)
                 let hexToken = toHex(current.session.routingToken)
-                let payload: [String: Any] = [
-                    "type": "EncryptedLocation",
-                    "epoch": Int(newSession.epoch),
-                    "seq": String(newSession.sendSeq),
-                    "ct": toSwiftData(ct).base64EncodedString(),
-                ]
-                if let bodyData = try? JSONSerialization.data(withJSONObject: payload) {
-                    await postToMailbox(token: hexToken, bodyData: bodyData)
-                }
+                let payload = Shared.EncryptedLocationPayload(
+                    epoch: newSession.epoch,
+                    seq: String(newSession.sendSeq),
+                    ct: ct
+                )
+                await postToMailbox(token: hexToken, payload: payload)
             }
         }
     }
@@ -266,19 +186,16 @@ final class LocationSyncService: ObservableObject {
         friends = e2eeStore.listFriends()
 
         let discoveryHex = toHex(qrWithName.discoveryToken())
-        let payload: [String: Any] = [
-            "type": "KeyExchangeInit",
-            "token": initPayload.token,
-            "ekPub": toSwiftData(initPayload.ekPub).base64EncodedString(),
-            "key_confirmation": toSwiftData(initPayload.keyConfirmation).base64EncodedString(),
-            "suggested_name": initPayload.suggestedName,
-        ]
-        
-        if let bodyData = try? JSONSerialization.data(withJSONObject: payload) {
-            Task {
-                await postToMailbox(token: discoveryHex, bodyData: bodyData)
-                await postOpkBundle(friend: bobEntry)
-            }
+        let payload = Shared.KeyExchangeInitPayload(
+            token: initPayload.token,
+            ekPub: initPayload.ekPub,
+            keyConfirmation: initPayload.keyConfirmation,
+            suggestedName: initPayload.suggestedName
+        )
+
+        Task {
+            await postToMailbox(token: discoveryHex, payload: payload)
+            await postOpkBundle(friend: bobEntry)
         }
     }
 
@@ -310,10 +227,7 @@ final class LocationSyncService: ObservableObject {
     private func postOpkBundle(friend: Shared.FriendEntry) async {
         guard let bundle = e2eeStore.generateOpkBundle(friendId: friend.id, count: 10) else { return }
         let hexToken = toHex(friend.session.routingToken)
-        let body = preKeyBundleBody(bundle)
-        if let bodyData = try? JSONSerialization.data(withJSONObject: body) {
-            await postToMailbox(token: hexToken, bodyData: bodyData)
-        }
+        await postToMailbox(token: hexToken, payload: bundle)
     }
 
     // MARK: - Private polling
@@ -333,37 +247,30 @@ final class LocationSyncService: ObservableObject {
 
             // --- Epoch rotation first: changes session/token ---
             for msg in messages {
-                guard let rotPayload = parseEpochRotation(msg) else { continue }
+                guard let rotPayload = msg as? Shared.EpochRotationPayload else { continue }
                 if let ack = try? e2eeStore.processEpochRotation(friendId: friend.id, payload: rotPayload) {
                     guard let newEntry = e2eeStore.getFriend(id: friend.id) else { continue }
                     let newToken = toHex(newEntry.session.routingToken)
-                    let body = ratchetAckBody(ack)
-                    if let bodyData = try? JSONSerialization.data(withJSONObject: body) {
-                        await postToMailbox(token: newToken, bodyData: bodyData)
-                    }
+                    await postToMailbox(token: newToken, payload: ack)
                     await postOpkBundle(friend: newEntry)
                 }
             }
 
             // --- Cache incoming OPK bundles ---
             for msg in messages {
-                guard let bundle = parsePreKeyBundle(msg) else { continue }
-                e2eeStore.storeOpkBundle(friendId: friend.id, bundle: bundle)
+                guard let bundle = msg as? Shared.PreKeyBundlePayload else { continue }
+                _ = e2eeStore.storeOpkBundle(friendId: friend.id, bundle: bundle)
             }
 
             // --- Decrypt location updates ---
             var session = (e2eeStore.getFriend(id: friend.id) ?? friend).session
             var sessionChanged = false
             for msg in messages {
-                guard (msg["type"] as? String) == "EncryptedLocation",
-                      let seqStr = msg["seq"] as? String,
-                      let seq = Int64(seqStr),
-                      let ctB64 = msg["ct"] as? String,
-                      let ctData = Data(base64Encoded: ctB64)
+                guard let locPayload = msg as? Shared.EncryptedLocationPayload,
+                      let seq = Int64(locPayload.seq)
                 else { continue }
-                let ct = kotlinByteArray(from: ctData)
                 if let result = Shared.Session.shared.decryptLocation(
-                    state: session, ct: ct, seq: seq, senderFp: senderFp, recipientFp: recipientFp
+                    state: session, ct: locPayload.ct, seq: seq, senderFp: senderFp, recipientFp: recipientFp
                 ) {
                     session = result.first!
                     let loc = result.second!
@@ -377,8 +284,8 @@ final class LocationSyncService: ObservableObject {
 
             // --- Validate RatchetAck ---
             for msg in messages {
-                guard let ack = parseRatchetAck(msg) else { continue }
-                e2eeStore.processRatchetAck(friendId: friend.id, payload: ack)
+                guard let ack = msg as? Shared.RatchetAckPayload else { continue }
+                _ = e2eeStore.processRatchetAck(friendId: friend.id, payload: ack)
             }
 
             // --- Bob: proactively replenish OPKs if running low ---
@@ -394,18 +301,7 @@ final class LocationSyncService: ObservableObject {
         let discoveryHex = toHex(qr.discoveryToken())
         let messages = await pollMailbox(token: discoveryHex)
         for msg in messages {
-            guard (msg["type"] as? String) == "KeyExchangeInit",
-                  let token = msg["token"] as? String,
-                  let ekPubB64 = msg["ekPub"] as? String, let ekPub = Data(base64Encoded: ekPubB64),
-                  let keyConfB64 = msg["key_confirmation"] as? String, let keyConfData = Data(base64Encoded: keyConfB64)
-            else { continue }
-            let suggestedName = msg["suggested_name"] as? String ?? ""
-            let initPayload = Shared.KeyExchangeInitPayload(
-                token: token,
-                ekPub: kotlinByteArray(from: ekPub),
-                keyConfirmation: kotlinByteArray(from: keyConfData),
-                suggestedName: suggestedName
-            )
+            guard let initPayload = msg as? Shared.KeyExchangeInitPayload else { continue }
 
             // Found init payload! Show naming dialog instead of processing immediately.
             pendingInitPayload = initPayload

--- a/shared/src/commonMain/kotlin/net/af0/where/LocationMessageCodec.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/LocationMessageCodec.kt
@@ -1,11 +1,12 @@
 package net.af0.where
 
 import kotlinx.serialization.json.Json
+import net.af0.where.e2ee.MailboxPayload
 import net.af0.where.model.UserLocation
 import net.af0.where.model.WsMessage
 
 /**
- * Swift-friendly codec for the WebSocket protocol. iOS uses URLSession for networking
+ * Swift-friendly codec for the WebSocket and E2EE protocols. iOS uses URLSession for networking
  * but delegates all JSON encoding/decoding to this object so the protocol stays in KMP.
  */
 object LocationMessageCodec {
@@ -32,4 +33,15 @@ object LocationMessageCodec {
         val msg = runCatching { json.decodeFromString<WsMessage>(text) }.getOrNull() ?: return null
         return (msg as? WsMessage.LocationsBroadcast)?.users
     }
+
+    // ---------------------------------------------------------------------------
+    // E2EE Mailbox Payloads (§9)
+    // ---------------------------------------------------------------------------
+
+    /** Encode any MailboxPayload to a JSON string for POSTing to /inbox/{token}. */
+    fun encodeMailboxPayload(payload: MailboxPayload): String = json.encodeToString(MailboxPayload.serializer(), payload)
+
+    /** Decode a list of MailboxPayloads from a GET /inbox/{token} response. */
+    fun decodeMailboxPayloads(text: String): List<MailboxPayload>? =
+        runCatching { json.decodeFromString<List<MailboxPayload>>(text) }.getOrNull()
 }

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/CryptoPrimitives.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/CryptoPrimitives.kt
@@ -9,11 +9,28 @@ package net.af0.where.e2ee
 /** SHA-256 hash. Returns 32 bytes. */
 internal expect fun sha256(data: ByteArray): ByteArray
 
-/** HMAC-SHA-256. Returns 32 bytes. */
-internal expect fun hmacSha256(
+/** HMAC-SHA-256 (RFC 2104). Returns 32 bytes. */
+internal fun hmacSha256(
     key: ByteArray,
     data: ByteArray,
-): ByteArray
+): ByteArray {
+    val blockSeparator = 64
+    var k = if (key.size > blockSeparator) {
+        sha256(key)
+    } else {
+        key
+    }
+
+    if (k.size < blockSeparator) {
+        k = k.copyOf(blockSeparator)
+    }
+
+    val ipad = ByteArray(blockSeparator) { i -> (k[i].toInt() xor 0x36).toByte() }
+    val opad = ByteArray(blockSeparator) { i -> (k[i].toInt() xor 0x5c).toByte() }
+
+    val innerHash = sha256(ipad + data)
+    return sha256(opad + innerHash)
+}
 
 /** Generate a fresh X25519 keypair from the platform CSPRNG. */
 expect fun generateX25519KeyPair(): RawKeyPair

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -64,7 +64,12 @@ object Session {
                 sendChainKey = step.newChainKey,
                 sendSeq = seq,
             )
+
+        // Security (§5.5, §11): zero out ephemeral keys after use
         step.messageKey.fill(0)
+        step.messageNonce.fill(0)
+        plaintext.fill(0)
+
         return newState to ct
     }
 
@@ -112,14 +117,21 @@ object Session {
 
         val aad = buildLocationAad(senderFp, recipientFp, state.epoch, seq)
         val plaintext = aeadDecrypt(finalStep.messageKey, finalStep.messageNonce, ct, aad)
-        val location = decodeLocation(unpad(plaintext))
+        val unpadded = unpad(plaintext)
+        val location = decodeLocation(unpadded)
 
         val newState =
             state.copy(
                 recvChainKey = chainKey,
                 recvSeq = seq,
             )
+
+        // Security (§5.5, §11): zero out ephemeral keys after use
         finalStep.messageKey.fill(0)
+        finalStep.messageNonce.fill(0)
+        plaintext.fill(0)
+        unpadded.fill(0)
+
         return newState to location
     }
 
@@ -149,7 +161,7 @@ object Session {
         val dhOut = x25519(aliceNewEkPriv, bobOpkPub)
         val ratchetStep = kdfRk(state.rootKey, dhOut)
         val newToken = deriveRoutingToken(ratchetStep.newRootKey, newEpoch, senderFp, recipientFp)
-        return state.copy(
+        val newState = state.copy(
             rootKey = ratchetStep.newRootKey,
             sendChainKey = ratchetStep.newChainKey, // Alice's new send chain
             // recvChainKey is unchanged — Bob's outgoing chain has not rotated
@@ -158,6 +170,11 @@ object Session {
             myEkPriv = aliceNewEkPriv.copyOf(),
             myEkPub = aliceNewEkPub.copyOf(),
         )
+
+        // Security (§5.5, §11): zero out ephemeral keys after use
+        dhOut.fill(0)
+
+        return newState
     }
 
     /**
@@ -184,7 +201,7 @@ object Session {
         val dhOut = x25519(bobOpkPriv, aliceNewEkPub)
         val ratchetStep = kdfRk(state.rootKey, dhOut)
         val newToken = deriveRoutingToken(ratchetStep.newRootKey, newEpoch, senderFp, recipientFp)
-        return state.copy(
+        val newState = state.copy(
             rootKey = ratchetStep.newRootKey,
             recvChainKey = ratchetStep.newChainKey, // Bob's new recv chain (= Alice's new send)
             // sendChainKey is unchanged — Bob's own outgoing chain has not rotated
@@ -192,6 +209,11 @@ object Session {
             epoch = newEpoch,
             theirEkPub = aliceNewEkPub.copyOf(),
         )
+
+        // Security (§5.5, §11): zero out ephemeral keys after use
+        dhOut.fill(0)
+
+        return newState
     }
 
     // ---------------------------------------------------------------------------

--- a/shared/src/iosMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
+++ b/shared/src/iosMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
@@ -17,32 +17,6 @@ internal actual fun sha256(data: ByteArray): ByteArray {
 }
 
 // ---------------------------------------------------------------------------
-// HMAC-SHA-256
-// ---------------------------------------------------------------------------
-
-internal actual fun hmacSha256(
-    key: ByteArray,
-    data: ByteArray,
-): ByteArray {
-    val blockSeparator = 64
-    var k = if (key.size > blockSeparator) {
-        sha256(key)
-    } else {
-        key
-    }
-
-    if (k.size < blockSeparator) {
-        k = k.copyOf(blockSeparator)
-    }
-
-    val ipad = ByteArray(blockSeparator) { i -> (k[i].toInt() xor 0x36).toByte() }
-    val opad = ByteArray(blockSeparator) { i -> (k[i].toInt() xor 0x5c).toByte() }
-
-    val innerHash = sha256(ipad + data)
-    return sha256(opad + innerHash)
-}
-
-// ---------------------------------------------------------------------------
 // X25519
 // ---------------------------------------------------------------------------
 

--- a/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
+++ b/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
@@ -17,32 +17,6 @@ internal actual fun sha256(data: ByteArray): ByteArray {
 }
 
 // ---------------------------------------------------------------------------
-// HMAC-SHA-256
-// ---------------------------------------------------------------------------
-
-internal actual fun hmacSha256(
-    key: ByteArray,
-    data: ByteArray,
-): ByteArray {
-    val blockSeparator = 64
-    var k = if (key.size > blockSeparator) {
-        sha256(key)
-    } else {
-        key
-    }
-
-    if (k.size < blockSeparator) {
-        k = k.copyOf(blockSeparator)
-    }
-
-    val ipad = ByteArray(blockSeparator) { i -> (k[i].toInt() xor 0x36).toByte() }
-    val opad = ByteArray(blockSeparator) { i -> (k[i].toInt() xor 0x5c).toByte() }
-
-    val innerHash = sha256(ipad + data)
-    return sha256(opad + innerHash)
-}
-
-// ---------------------------------------------------------------------------
 // X25519
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
I have addressed the reviewer feedback on PR#9 by centralizing protocol serialization logic, eliminating code duplication across platforms, and hardening the security of cryptographic operations.

Key changes:
1.  **Centralized E2EE Serialization**: Restored `encodeMailboxPayload` and `decodeMailboxPayloads` to the KMP `LocationMessageCodec`. The iOS `LocationSyncService` now uses these methods via the Shared framework, removing the need for manual Swift dictionary building and JSON parsing for the E2EE protocol.
2.  **Memory Security Hardening**: Updated `Session.kt` to explicitly zero out (`fill(0)`) sensitive intermediate material, including plaintext buffers, message keys, nonces, and Diffie-Hellman secrets, immediately after their use. This ensures compliance with project security standards for minimizing the lifetime of secrets in memory.
3.  **Refactored HMAC Implementation**: Moved the manual RFC 2104-compliant HMAC-SHA-256 implementation from platform-specific blocks to `commonMain` in `CryptoPrimitives.kt`. This eliminates code duplication while maintaining standard compliance and auditability.
4.  **Security Verification**: Confirmed that the server's constant-time mailbox lookup logic (using the `dummyQueue` for unknown tokens) is intact and protects against timing side-channel attacks.
5.  **Verified Cross-Platform Compatibility**: Ensured that all unit tests pass across the shared, server, and Android modules using `./gradlew :shared:jvmTest :server:test :android:testDebugUnitTest`.

---
*PR created automatically by Jules for task [136048620527172415](https://jules.google.com/task/136048620527172415) started by @danmarg*