### PR TITLE
Add WhereApplication, refactor LocationViewModel, and support APK builds

### DIFF
--- a/android/src/androidMain/AndroidManifest.xml
+++ b/android/src/androidMain/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
+        android:name=".WhereApplication"
         android:label="Where"
         android:theme="@style/Theme.Where">
 

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -29,10 +29,8 @@ import net.af0.where.e2ee.Session
 import net.af0.where.e2ee.discoveryToken
 import net.af0.where.model.UserLocation
 
-class LocationViewModel(
-    app: Application,
-    private val locationSource: LocationSource = LocationRepository,
-) : AndroidViewModel(app) {
+class LocationViewModel(app: Application) : AndroidViewModel(app) {
+    private val locationSource: LocationSource = LocationRepository
     private val e2eeStore = E2eeStore(SharedPrefsE2eeStorage(app))
 
     private val sharingPrefs = app.getSharedPreferences("where_prefs", Context.MODE_PRIVATE)

--- a/build-nix.sh
+++ b/build-nix.sh
@@ -14,6 +14,7 @@ export TMPDIR="${TMPDIR:-/tmp}"
 # Parse arguments
 SERVER_URL=""
 BUILD_FLAVOR="debug"
+ANDROID_FORMAT="aab"  # aab or apk
 while [[ $# -gt 0 ]]; do
   case $1 in
     --server-url)
@@ -23,6 +24,10 @@ while [[ $# -gt 0 ]]; do
     --flavor)
       BUILD_FLAVOR="$2"
       shift 2
+      ;;
+    --apk)
+      ANDROID_FORMAT="apk"
+      shift
       ;;
     *)
       echo "Unknown option: $1"
@@ -58,11 +63,19 @@ fi
 echo "✓ Server built"
 echo ""
 
-# Build Android AAB (App Bundle)
+# Build Android APK or AAB
 if [[ "$BUILD_FLAVOR" == "debug" ]]; then
-  GRADLE_TASK="bundleDebug"
+  if [[ "$ANDROID_FORMAT" == "apk" ]]; then
+    GRADLE_TASK="assembleDebug"
+  else
+    GRADLE_TASK="bundleDebug"
+  fi
 else
-  GRADLE_TASK="bundleRelease"
+  if [[ "$ANDROID_FORMAT" == "apk" ]]; then
+    GRADLE_TASK="assembleRelease"
+  else
+    GRADLE_TASK="bundleRelease"
+  fi
   # Prompt for signing credentials for release builds
   echo "=== Release Build Signing ==="
   read -sp "Enter keystore password: " KEYSTORE_PASSWORD
@@ -71,12 +84,12 @@ else
   export KEYSTORE_PASSWORD
   export KEY_PASSWORD=$KEYSTORE_PASSWORD  # Same as keystore password
 fi
-echo "=== Building Android $BUILD_FLAVOR AAB ==="
+echo "=== Building Android $BUILD_FLAVOR ${ANDROID_FORMAT^^} ==="
 if ! nix develop --command bash -c "KEYSTORE_FILE='$KEYSTORE_FILE' KEYSTORE_PASSWORD='$KEYSTORE_PASSWORD' KEY_PASSWORD='$KEY_PASSWORD' ./gradlew :android:$GRADLE_TASK"; then
   echo "Android build failed."
   exit 1
 fi
-echo "✓ Android AAB built ($BUILD_FLAVOR)"
+echo "✓ Android ${ANDROID_FORMAT^^} built ($BUILD_FLAVOR)"
 echo ""
 
 # Build iOS for real device (iphoneos)
@@ -123,10 +136,16 @@ echo "=== Build complete ==="
 echo ""
 echo "Server: ./gradlew :server:run"
 echo ""
-echo "Android AAB location:"
 android_build_dir=$(nix develop --command ./gradlew -q :android:printBuildDir 2>/dev/null || echo "android/build")
-echo "  $android_build_dir/outputs/bundle/$BUILD_FLAVOR/android-$BUILD_FLAVOR.aab"
-echo "  Upload to Google Play Store or use bundletool to test"
+if [[ "$ANDROID_FORMAT" == "apk" ]]; then
+  echo "Android APK location:"
+  echo "  $android_build_dir/outputs/apk/$BUILD_FLAVOR/android-$BUILD_FLAVOR.apk"
+  echo "  Install directly with: adb install <path>"
+else
+  echo "Android AAB location:"
+  echo "  $android_build_dir/outputs/bundle/$BUILD_FLAVOR/android-$BUILD_FLAVOR.aab"
+  echo "  Upload to Google Play Store or use bundletool to test"
+fi
 echo ""
 echo "iOS app location (device):"
 echo "  ios/build/Build/Products/$XCODE_CONFIGURATION-iphoneos/Where.app"


### PR DESCRIPTION
- Register WhereApplication in AndroidManifest
- Refactor LocationViewModel to make locationSource a property instead of constructor parameter
- Add --apk flag to build-nix.sh for flexible Android package format selection (APK or AAB)