### PR TITLE
Improve map markers and UI interactions on Android and iOS

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
@@ -2,15 +2,19 @@ package net.af0.where
 
 import android.os.Build
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOff
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.People
+import androidx.compose.material.icons.filled.Place
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.permissions.*
@@ -144,18 +148,34 @@ fun MapScreen(
         ) {
             users.forEach { user ->
                 val isMe = user.userId == userId
-                Marker(
-                    state = MarkerState(position = LatLng(user.lat, user.lng)),
-                    title = if (isMe) "You" else friends.find { it.id == user.userId }?.name ?: user.userId.take(8),
-                    icon =
-                        BitmapDescriptorFactory.defaultMarker(
-                            if (isMe) {
-                                BitmapDescriptorFactory.HUE_AZURE
-                            } else {
-                                BitmapDescriptorFactory.HUE_RED
-                            },
-                        ),
-                )
+                val name = if (isMe) "You" else friends.find { it.id == user.userId }?.name ?: user.userId.take(8)
+                key(user.userId) {
+                    MarkerComposable(
+                        state = MarkerState(position = LatLng(user.lat, user.lng)),
+                        anchor = Offset(0.5f, 1f),
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Surface(
+                                shape = MaterialTheme.shapes.small,
+                                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f),
+                                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                shadowElevation = 2.dp,
+                            ) {
+                                Text(
+                                    text = name,
+                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                                    style = MaterialTheme.typography.labelSmall,
+                                )
+                            }
+                            Icon(
+                                imageVector = Icons.Default.Place,
+                                contentDescription = null,
+                                tint = if (isMe) Color.Blue else Color.Red,
+                                modifier = Modifier.size(36.dp),
+                            )
+                        }
+                    }
+                }
             }
         }
 
@@ -189,7 +209,10 @@ fun MapScreen(
 
             // Your ID chip + Connection status
             Surface(
-                modifier = Modifier.weight(1f),
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .clickable { zoomToUserId = userId },
                 shape = MaterialTheme.shapes.medium,
                 color = Color.Black.copy(alpha = 0.7f),
             ) {

--- a/ios/Sources/Where/WhereMapView.swift
+++ b/ios/Sources/Where/WhereMapView.swift
@@ -28,18 +28,36 @@ struct WhereMapView: UIViewRepresentable {
         let existingById = Dictionary(uniqueKeysWithValues: existing.map { ($0.userId, $0) })
         let newById = Dictionary(uniqueKeysWithValues: users.map { ($0.userId, $0) })
 
+        // Group users by location to handle overlaps
+        var locationGroups: [String: [Shared.UserLocation]] = [:]
+        for user in users {
+            let key = String(format: "%.6f,%.6f", user.lat, user.lng)
+            locationGroups[key, default: []].append(user)
+        }
+
         // Remove stale annotations
         let toRemove = existing.filter { newById[$0.userId] == nil }
         mapView.removeAnnotations(toRemove)
 
         // Update existing or add new annotations
-        for user in users {
-            if let pin = existingById[user.userId] {
-                pin.coordinate = CLLocationCoordinate2D(latitude: user.lat, longitude: user.lng)
-            } else {
-                let friend = friends.first { $0.id == user.userId }
-                let friendName = friend?.name ?? String(user.userId.prefix(8))
-                mapView.addAnnotation(UserAnnotation(user: user, friendName: friendName, isOwn: user.userId == ownUserId))
+        for (_, group) in locationGroups {
+            for (index, user) in group.enumerated() {
+                var coord = CLLocationCoordinate2D(latitude: user.lat, longitude: user.lng)
+                if group.count > 1 {
+                    // Apply a small circular offset if multiple users are at the same spot
+                    let angle = 2.0 * .pi * Double(index) / Double(group.count)
+                    let radius = 0.00005 // Approx 5 meters at the equator
+                    coord.latitude += radius * cos(angle)
+                    coord.longitude += radius * sin(angle)
+                }
+
+                if let pin = existingById[user.userId] {
+                    pin.coordinate = coord
+                } else {
+                    let friend = friends.first { $0.id == user.userId }
+                    let friendName = friend?.name ?? String(user.userId.prefix(8))
+                    mapView.addAnnotation(UserAnnotation(user: user, coordinate: coord, friendName: friendName, isOwn: user.userId == ownUserId))
+                }
             }
         }
 
@@ -103,9 +121,9 @@ final class UserAnnotation: NSObject, MKAnnotation {
     let subtitle: String?
     let isOwn: Bool
 
-    init(user: Shared.UserLocation, friendName: String, isOwn: Bool) {
+    init(user: Shared.UserLocation, coordinate: CLLocationCoordinate2D, friendName: String, isOwn: Bool) {
         self.userId = user.userId
-        self.coordinate = CLLocationCoordinate2D(latitude: user.lat, longitude: user.lng)
+        self.coordinate = coordinate
         self.title = isOwn ? "You" : friendName
         self.subtitle = isOwn ? nil : user.userId.prefix(8).description
         self.isOwn = isOwn


### PR DESCRIPTION
I have addressed several UI/UX issues across the Android and iOS applications:

1. **Android Map Markers:** Replaced standard markers with `MarkerComposable` to display persistent name labels (friend names or "You") directly above the pushpins, matching the iOS experience.
2. **Android Zoom-to-Self:** Added a click listener to the "You" chip at the bottom of the map screen, allowing users to quickly center the map on their own location.
3. **iOS Marker Overlaps:** Modified the iOS map view to detect participants at the same geographic coordinates and apply a small circular jitter (approx. 5 meters). This ensures that multiple users at the same location are all visible and selectable, rather than being obscured by each other.

These changes have been verified through code inspection and by running the existing test suite, which passed successfully.

---
*PR created automatically by Jules for task [3962391803580630424](https://jules.google.com/task/3962391803580630424) started by @danmarg*