### PR TITLE
Fix immediate location update reliability after QR pairing

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -25,6 +25,15 @@ class LocationService : Service() {
                     LocationRepository.onLocation(loc.latitude, loc.longitude)
                 }
             }
+
+        try {
+            fusedClient.lastLocation.addOnSuccessListener { loc ->
+                if (loc != null) {
+                    LocationRepository.onLocation(loc.latitude, loc.longitude)
+                }
+            }
+        } catch (_: SecurityException) {
+        }
     }
 
     override fun onStartCommand(

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -123,7 +123,8 @@ class LocationViewModel(app: Application) : AndroidViewModel(app) {
     private fun isRapidPolling(): Boolean {
         val now = System.currentTimeMillis()
         // Alice is pairing if she has a pending invite QR or Bob's KeyExchangeInit waiting for naming
-        val isPairing = _pendingInviteQr.value != null || _pendingInitPayload.value != null
+        // Bob is pairing if he has scanned a QR but not yet named the friend
+        val isPairing = _pendingInviteQr.value != null || _pendingInitPayload.value != null || _pendingQrForNaming.value != null
         // Bob is pairing if he recently scanned a QR (within 5 minutes)
         val recentlyTriggered = now - lastRapidPollTrigger < 5 * 60_000L
         return isPairing || recentlyTriggered
@@ -184,6 +185,7 @@ class LocationViewModel(app: Application) : AndroidViewModel(app) {
         }
         Log.d(TAG, "processQrUrl: parsed qr, suggestedName=${qr.suggestedName}")
         _pendingQrForNaming.value = qr
+        triggerRapidPoll()
         return true
     }
 

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -160,7 +160,7 @@ final class LocationSyncService: ObservableObject {
 
     private func isRapidPolling() async -> Bool {
         let now = Date()
-        let isPairing = e2eeStore.pendingQrPayload != nil || pendingInitPayload != nil
+        let isPairing = e2eeStore.pendingQrPayload != nil || pendingInitPayload != nil || pendingQrForNaming != nil
         let recentlyTriggered = now.timeIntervalSince(lastRapidPollTrigger) < 5 * 60
         return isPairing || recentlyTriggered
     }
@@ -222,12 +222,15 @@ final class LocationSyncService: ObservableObject {
             return false
         }
         pendingQrForNaming = qr
+        triggerRapidPoll()
+        startPolling()
         return true
     }
 
     func confirmQrScan(qr: Shared.QrPayload, friendName: String) {
         pendingQrForNaming = nil
         triggerRapidPoll()
+        startPolling()
         let qrWithName = Shared.QrPayload(
             ekPub: qr.ekPub,
             suggestedName: friendName,
@@ -284,6 +287,7 @@ final class LocationSyncService: ObservableObject {
         pendingInviteQr = nil
         autoClearedInvite = false
         triggerRapidPoll()
+        startPolling()
         // processKeyExchangeInit sets pendingInvite=null internally; call it immediately
         // so nothing can clear pendingInvite before it runs.
         let entry = try? e2eeStore.processKeyExchangeInit(payload: payload, bobName: name)


### PR DESCRIPTION
This change improves the reliability of the "immediate" location ping after two devices pair via QR code.

Previously, if a device was in its long-polling (60s) state, it might not see the handshake or send its own location for up to a minute, making the pairing feel laggy or broken.

Key fixes:
1. Android now primes its location repository with the last known location from the system provider immediately on service start.
2. Both Android and iOS now treat the "naming" phase (after scanning but before saving) as part of the rapid-polling 'pairing' state.
3. iOS now explicitly restarts its polling Task during key pairing transitions (scan, confirm, handshake) to ensure it switches from 60s to 2s intervals immediately.
4. Android bob-side now triggers its rapid polling window as soon as a QR is processed.

---
*PR created automatically by Jules for task [6873842877218663350](https://jules.google.com/task/6873842877218663350) started by @danmarg*