### PR TITLE
Persist friend last seen time and location

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -99,6 +99,21 @@ class LocationViewModel(app: Application) : AndroidViewModel(app) {
 
     init {
         Log.d(TAG, "LocationViewModel init: server=${BuildConfig.SERVER_HTTP_URL}, userId=$userId")
+        val savedFriends = e2eeStore.listFriends()
+        val initialLocations = mutableMapOf<String, UserLocation>()
+        val initialLastPing = mutableMapOf<String, Long>()
+        for (friend in savedFriends) {
+            val lat = friend.lastLat
+            val lng = friend.lastLng
+            val ts = friend.lastTs
+            if (lat != null && lng != null && ts != null) {
+                initialLocations[friend.id] = UserLocation(friend.id, lat, lng, ts)
+                initialLastPing[friend.id] = ts * 1000L
+            }
+        }
+        friendLocations.value = initialLocations
+        _friendLastPing.value = initialLastPing
+
         viewModelScope.launch { pollLoop() }
         viewModelScope.launch {
             var prevSharing = _isSharingLocation.value
@@ -293,7 +308,9 @@ class LocationViewModel(app: Application) : AndroidViewModel(app) {
             Log.d(TAG, "Got ${updates.size} location updates")
             for (update in updates) {
                 friendLocations.value += (update.userId to update)
-                _friendLastPing.value += (update.userId to System.currentTimeMillis())
+                val now = System.currentTimeMillis()
+                _friendLastPing.value += (update.userId to now)
+                e2eeStore.updateLastLocation(update.userId, update.lat, update.lng, now / 1000L)
             }
             pollPendingInvite()
             // Ensure friends list is up to date in case it changed elsewhere

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -150,6 +150,16 @@ final class LocationSyncService: ObservableObject {
 
         Task {
             friends = e2eeStore.listFriends()
+            var initialLocations: [String: (lat: Double, lng: Double, ts: Int64)] = [:]
+            var initialLastPing: [String: Date] = [:]
+            for friend in friends {
+                if let lat = friend.lastLat?.doubleValue, let lng = friend.lastLng?.doubleValue, let ts = friend.lastTs?.longLongValue {
+                    initialLocations[friend.id] = (lat: lat, lng: lng, ts: ts)
+                    initialLastPing[friend.id] = Date(timeIntervalSince1970: TimeInterval(ts))
+                }
+            }
+            self.friendLocations = initialLocations
+            self.friendLastPing = initialLastPing
         }
         startPolling()
     }
@@ -335,7 +345,9 @@ final class LocationSyncService: ObservableObject {
             logger.debug("Got \(updates.count) location updates")
             for update in updates {
                 friendLocations[update.userId] = (lat: update.lat, lng: update.lng, ts: update.timestamp)
-                friendLastPing[update.userId] = Date()
+                let now = Date()
+                friendLastPing[update.userId] = now
+                e2eeStore.updateLastLocation(id: update.userId, lat: update.lat, lng: update.lng, ts: Int64(now.timeIntervalSince1970))
             }
             updateStatus(nil)
         } catch {

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -33,6 +33,9 @@ data class FriendEntry(
     val myOpkPrivs: Map<Int, ByteArray> = emptyMap(),
     val theirOpkPubs: Map<Int, ByteArray> = emptyMap(),
     val nextOpkId: Int = 1,
+    val lastLat: Double? = null,
+    val lastLng: Double? = null,
+    val lastTs: Long? = null,
 ) {
     /** Computed friend ID: hex(SHA-256(EK_A.pub)) — full 64 hex chars. */
     val id: String get() = session.aliceFp.toHex()
@@ -48,7 +51,10 @@ data class FriendEntry(
             isInitiator == other.isInitiator &&
             myOpkPrivs.contentEquals(other.myOpkPrivs) &&
             theirOpkPubs.contentEquals(other.theirOpkPubs) &&
-            nextOpkId == other.nextOpkId
+            nextOpkId == other.nextOpkId &&
+            lastLat == other.lastLat &&
+            lastLng == other.lastLng &&
+            lastTs == other.lastTs
     }
 
     override fun hashCode(): Int {
@@ -56,6 +62,9 @@ data class FriendEntry(
         result = 31 * result + session.hashCode()
         result = 31 * result + isInitiator.hashCode()
         result = 31 * result + nextOpkId
+        result = 31 * result + (lastLat?.hashCode() ?: 0)
+        result = 31 * result + (lastLng?.hashCode() ?: 0)
+        result = 31 * result + (lastTs?.hashCode() ?: 0)
         return result
     }
 }
@@ -98,6 +107,9 @@ class E2eeStore(
                             myOpkPrivs = s.myOpkPrivs.associate { it.id to it.key },
                             theirOpkPubs = s.theirOpkPubs.associate { it.id to it.key },
                             nextOpkId = s.nextOpkId,
+                            lastLat = s.lastLat,
+                            lastLng = s.lastLng,
+                            lastTs = s.lastTs,
                         )
                     entry.id to entry
                 }.toMutableMap()
@@ -122,6 +134,9 @@ class E2eeStore(
                             myOpkPrivs = f.myOpkPrivs.map { (id, key) -> SerializedOpkEntry(id, key) },
                             theirOpkPubs = f.theirOpkPubs.map { (id, key) -> SerializedOpkEntry(id, key) },
                             nextOpkId = f.nextOpkId,
+                            lastLat = f.lastLat,
+                            lastLng = f.lastLng,
+                            lastTs = f.lastTs,
                         )
                     },
                 pendingInvite = pendingInvite,
@@ -238,6 +253,17 @@ class E2eeStore(
     ) {
         val entry = friends[id] ?: return
         friends[id] = entry.copy(session = newSession)
+        save()
+    }
+
+    fun updateLastLocation(
+        id: String,
+        lat: Double,
+        lng: Double,
+        ts: Long,
+    ) {
+        val entry = friends[id] ?: return
+        friends[id] = entry.copy(lastLat = lat, lastLng = lng, lastTs = ts)
         save()
     }
 
@@ -662,6 +688,9 @@ internal data class SerializedFriendEntry(
     val myOpkPrivs: List<SerializedOpkEntry> = emptyList(),
     val theirOpkPubs: List<SerializedOpkEntry> = emptyList(),
     val nextOpkId: Int = 1,
+    val lastLat: Double? = null,
+    val lastLng: Double? = null,
+    val lastTs: Long? = null,
 )
 
 @Serializable


### PR DESCRIPTION
The issue was that friend locations and last-seen times were kept only in memory and lost when the app was closed. This PR introduces persistence for these values by adding them to the `FriendEntry` in the `E2eeStore`, which is already saved to disk (SharedPreferences on Android, UserDefaults on iOS).

Key changes:
- Updated `FriendEntry` and `SerializedFriendEntry` in the `shared` module to include `lastLat`, `lastLng`, and `lastTs`.
- Added `E2eeStore.updateLastLocation` to save these fields.
- Updated Android `LocationViewModel` to load these values during `init` and save them during `doPoll`.
- Updated iOS `LocationSyncService` to load these values during `init` and save them during `pollAll`.
- Fixed a Kotlin compilation issue on Android related to smart-casting properties from a different module.

---
*PR created automatically by Jules for task [12979207922638535621](https://jules.google.com/task/12979207922638535621) started by @danmarg*