### PR TITLE
Fix Android Build and Test Failures

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
@@ -29,7 +29,11 @@ interface LocationSource {
         lng: Double,
     )
 
-    fun onFriendUpdate(update: UserLocation)
+    fun onFriendUpdate(
+        update: UserLocation,
+        timestamp: Long = System.currentTimeMillis(),
+    )
+
     fun onFriendRemoved(id: String)
     fun onConnectionStatus(status: ConnectionStatus)
     fun onConnectionError(e: Throwable)
@@ -75,9 +79,12 @@ object LocationRepository : LocationSource {
         _lastLocation.update { Pair(lat, lng) }
     }
 
-    override fun onFriendUpdate(update: UserLocation) {
+    override fun onFriendUpdate(
+        update: UserLocation,
+        timestamp: Long,
+    ) {
         _friendLocations.update { it + (update.userId to update) }
-        _friendLastPing.update { it + (update.userId to System.currentTimeMillis()) }
+        _friendLastPing.update { it + (update.userId to timestamp) }
     }
 
     override fun onFriendRemoved(id: String) {

--- a/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
@@ -41,6 +41,7 @@ interface LocationSource {
     fun onPendingInit(payload: KeyExchangeInitPayload?)
     fun setSharingLocation(sharing: Boolean)
     fun setPausedFriends(friendIds: Set<String>)
+    fun setInitialFriendLocations(locations: Map<String, UserLocation>, pings: Map<String, Long>)
 }
 
 /**
@@ -123,7 +124,7 @@ object LocationRepository : LocationSource {
         _pausedFriendIds.value = friendIds
     }
 
-    fun setInitialFriendLocations(locations: Map<String, UserLocation>, pings: Map<String, Long>) {
+    override fun setInitialFriendLocations(locations: Map<String, UserLocation>, pings: Map<String, Long>) {
         // Merge with current state to avoid overwriting live updates that arrived before initial load
         _friendLocations.update { locations + it }
         _friendLastPing.update { pings + it }

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -73,8 +73,7 @@ class LocationViewModel(
 
     val userId: String by lazy { UserPrefs.getUserId(getApplication()) }
 
-    private val _isSharingLocation = MutableStateFlow(UserPrefs.isSharing(app))
-    val isSharingLocation: StateFlow<Boolean> = _isSharingLocation
+    val isSharingLocation: StateFlow<Boolean> = locationSource.isSharingLocation
 
     private val _displayName = MutableStateFlow(UserPrefs.getDisplayName(app))
     val displayName: StateFlow<String> = _displayName
@@ -82,12 +81,10 @@ class LocationViewModel(
     private val _friends = MutableStateFlow(emptyList<FriendEntry>())
     val friends: StateFlow<List<FriendEntry>> = _friends
 
-    private val _pausedFriendIds = MutableStateFlow(UserPrefs.getPausedFriends(app))
-    val pausedFriendIds: StateFlow<Set<String>> = _pausedFriendIds
+    val pausedFriendIds: StateFlow<Set<String>> = locationSource.pausedFriendIds
 
-    internal val friendLocations = MutableStateFlow(emptyMap<String, UserLocation>())
-    private val _friendLastPing = MutableStateFlow(emptyMap<String, Long>())
-    val friendLastPing: StateFlow<Map<String, Long>> = _friendLastPing
+    val friendLocations: StateFlow<Map<String, UserLocation>> = locationSource.friendLocations
+    val friendLastPing: StateFlow<Map<String, Long>> = locationSource.friendLastPing
 
     private val _inviteState = MutableStateFlow<InviteState>(InviteState.None)
     val inviteState: StateFlow<InviteState> = _inviteState
@@ -95,20 +92,18 @@ class LocationViewModel(
     private val _pendingQrForNaming = MutableStateFlow<QrPayload?>(null)
     val pendingQrForNaming: StateFlow<QrPayload?> = _pendingQrForNaming
 
-    private val _pendingInitPayload = MutableStateFlow<KeyExchangeInitPayload?>(null)
-    val pendingInitPayload: StateFlow<KeyExchangeInitPayload?> = _pendingInitPayload
+    val pendingInitPayload: StateFlow<KeyExchangeInitPayload?> = locationSource.pendingInitPayload
 
     private val _isExchanging = MutableStateFlow(false)
     val isExchanging: StateFlow<Boolean> = _isExchanging
 
-    private val _connectionStatus = MutableStateFlow<ConnectionStatus>(ConnectionStatus.Ok)
-    val connectionStatus: StateFlow<ConnectionStatus> = _connectionStatus
+    val connectionStatus: StateFlow<ConnectionStatus> = locationSource.connectionStatus
 
     private val pollingStateInternal = MutableStateFlow(PollingState())
     private val pollWakeSignal = Channel<Unit>(Channel.CONFLATED)
 
     val visibleUsers: StateFlow<List<UserLocation>> =
-        combine(locationSource.lastLocation, _isSharingLocation, friendLocations) { myLoc, sharing, friendLocs ->
+        combine(locationSource.lastLocation, isSharingLocation, friendLocations) { myLoc, sharing, friendLocs ->
             buildList {
                 if (myLoc != null && sharing) {
                     add(UserLocation(userId, myLoc.first, myLoc.second, clock() / 1000))
@@ -133,8 +128,11 @@ class LocationViewModel(
                     initialLastPing[friend.id] = ts * 1000L
                 }
             }
-            friendLocations.value = initialLocations
-            _friendLastPing.value = initialLastPing
+            if (locationSource is LocationRepository) {
+                locationSource.setInitialFriendLocations(initialLocations, initialLastPing)
+            }
+            locationSource.setSharingLocation(UserPrefs.isSharing(app))
+            locationSource.setPausedFriends(UserPrefs.getPausedFriends(app))
         }
 
         if (startPolling) {
@@ -142,14 +140,14 @@ class LocationViewModel(
             // Send location whenever FusedLocation delivers a new position.
             viewModelScope.launch {
                 locationSource.lastLocation.collect { loc ->
-                    if (loc != null && _isSharingLocation.value) {
+                    if (loc != null && isSharingLocation.value) {
                         sendLocationIfNeeded(loc.first, loc.second, isHeartbeat = false)
                     }
                 }
             }
         }
         viewModelScope.launch {
-            _isSharingLocation.collect { sharing ->
+            isSharingLocation.collect { sharing ->
                 manageForegroundService(sharing)
             }
         }
@@ -166,7 +164,7 @@ class LocationViewModel(
 
     internal fun isRapidPolling(): Boolean {
         val now = clock()
-        val isPairing = _inviteState.value is InviteState.Pending || _pendingInitPayload.value != null || _pendingQrForNaming.value != null
+        val isPairing = _inviteState.value is InviteState.Pending || pendingInitPayload.value != null || _pendingQrForNaming.value != null
         val recentlyTriggered = now - pollingStateInternal.value.lastRapidPollTrigger < 5 * 60_000L
         return isPairing || recentlyTriggered
     }
@@ -179,16 +177,16 @@ class LocationViewModel(
 
     fun toggleSharing() {
         check(Looper.myLooper() == Looper.getMainLooper()) { "toggleSharing must be called on the main thread" }
-        val new = !_isSharingLocation.value
-        _isSharingLocation.value = new
+        val new = !isSharingLocation.value
+        locationSource.setSharingLocation(new)
         UserPrefs.setSharing(getApplication(), new)
     }
 
     fun togglePauseFriend(id: String) {
         check(Looper.myLooper() == Looper.getMainLooper()) { "togglePauseFriend must be called on the main thread" }
-        val current = _pausedFriendIds.value
+        val current = pausedFriendIds.value
         val new = if (id in current) current - id else current + id
-        _pausedFriendIds.value = new
+        locationSource.setPausedFriends(new)
         UserPrefs.setPausedFriends(getApplication(), new)
     }
 
@@ -209,13 +207,15 @@ class LocationViewModel(
             e2eeStore.deleteFriend(id)
             val updatedFriends = e2eeStore.listFriends()
             withContext(Dispatchers.Main.immediate) {
-                _friends.value = updatedFriends
-                friendLocations.value -= id
-                if (id in _pausedFriendIds.value) {
-                    val newPaused = _pausedFriendIds.value - id
-                    _pausedFriendIds.value = newPaused
+                val currentPaused = pausedFriendIds.value
+                val newPaused = if (id in currentPaused) currentPaused - id else null
+
+                if (newPaused != null) {
+                    locationSource.setPausedFriends(newPaused)
                     UserPrefs.setPausedFriends(getApplication(), newPaused)
                 }
+                locationSource.onFriendRemoved(id)
+                _friends.value = updatedFriends
             }
         }
     }
@@ -289,7 +289,7 @@ class LocationViewModel(
                         return@launch
                     }
                     locationClient.postOpkBundle(bobEntry.id)
-                    if (_isSharingLocation.value) {
+                    if (isSharingLocation.value) {
                         // Send our location directly to the new friend without going through the
                         // service. Using the same locationClient instance avoids ratchet divergence.
                         val loc = locationSource.lastLocation.value
@@ -354,9 +354,9 @@ class LocationViewModel(
     }
 
     fun confirmPendingInit(name: String) {
-        val payload = _pendingInitPayload.value ?: return
+        val payload = pendingInitPayload.value ?: return
         Log.d(TAG, "confirmPendingInit: name=$name")
-        _pendingInitPayload.value = null
+        locationSource.onPendingInit(null)
         val current = _inviteState.value
         _inviteState.value = InviteState.None
         pollingStateInternal.update { it.copy(lastRapidPollTrigger = 0L) }
@@ -377,7 +377,7 @@ class LocationViewModel(
                         // encrypted messages to be undecryptable until the next heartbeat.)
                         locationClient.postOpkBundle(entry.id)
                         Log.d(TAG, "confirmPendingInit: postOpkBundle succeeded")
-                        if (_isSharingLocation.value) {
+                        if (isSharingLocation.value) {
                             val loc = locationSource.lastLocation.value
                             if (loc != null) {
                                 try {
@@ -444,11 +444,11 @@ class LocationViewModel(
     }
 
     fun cancelPendingInit() {
-        if (_pendingInitPayload.value == null && _inviteState.value == InviteState.None) return
+        if (pendingInitPayload.value == null && _inviteState.value == InviteState.None) return
         viewModelScope.launch {
             e2eeStore.clearInvite()
         }
-        _pendingInitPayload.value = null
+        locationSource.onPendingInit(null)
         _inviteState.value = InviteState.None
     }
 
@@ -475,9 +475,8 @@ class LocationViewModel(
             // Ensure all StateFlow writes go through the main dispatcher
             withContext(Dispatchers.Main) {
                 for (update in updates) {
-                    friendLocations.value += (update.userId to update)
                     val now = clock()
-                    _friendLastPing.value += (update.userId to now)
+                    locationSource.onFriendUpdate(update, now)
                     e2eeStore.updateLastLocation(update.userId, update.lat, update.lng, now / 1000L)
                 }
                 pollPendingInvite()
@@ -507,7 +506,7 @@ class LocationViewModel(
             if (currentQr != null) {
                 _inviteState.value = InviteState.Consumed(currentQr)
             }
-            _pendingInitPayload.value = initPayload
+            locationSource.onPendingInit(initPayload)
         } catch (e: Exception) {
             updateStatus(e)
         }
@@ -522,7 +521,7 @@ class LocationViewModel(
         isHeartbeat: Boolean,
         force: Boolean = false,
     ) {
-        if (!_isSharingLocation.value) return
+        if (!isSharingLocation.value) return
         val now = clock()
         val state = pollingStateInternal.value
         val shouldSend =
@@ -531,7 +530,7 @@ class LocationViewModel(
                 (isHeartbeat && now - state.lastSentTime > 300_000L)
         if (!shouldSend) return
         try {
-            locationClient.sendLocation(lat, lng, _pausedFriendIds.value)
+            locationClient.sendLocation(lat, lng, pausedFriendIds.value)
             pollingStateInternal.update { it.copy(lastSentLat = lat, lastSentLng = lng, lastSentTime = now) }
             updateStatus(null)
         } catch (e: Exception) {
@@ -542,17 +541,9 @@ class LocationViewModel(
 
     private fun updateStatus(e: Throwable?) {
         if (e == null) {
-            _connectionStatus.value = ConnectionStatus.Ok
+            locationSource.onConnectionStatus(ConnectionStatus.Ok)
         } else {
-            val msg =
-                when {
-                    e.message?.contains("Unable to resolve host", ignoreCase = true) == true -> "not resolved"
-                    e.message?.contains("timeout", ignoreCase = true) == true -> "timeout"
-                    e.message?.contains("ConnectException", ignoreCase = true) == true -> "no connection"
-                    e.message?.contains("Failed to post to mailbox: 500", ignoreCase = true) == true -> "server error 500"
-                    else -> e.message?.take(32) ?: "unknown error"
-                }
-            _connectionStatus.value = ConnectionStatus.Error(msg)
+            locationSource.onConnectionError(e)
         }
     }
 

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -128,9 +128,7 @@ class LocationViewModel(
                     initialLastPing[friend.id] = ts * 1000L
                 }
             }
-            if (locationSource is LocationRepository) {
-                locationSource.setInitialFriendLocations(initialLocations, initialLastPing)
-            }
+            locationSource.setInitialFriendLocations(initialLocations, initialLastPing)
             locationSource.setSharingLocation(UserPrefs.isSharing(app))
             locationSource.setPausedFriends(UserPrefs.getPausedFriends(app))
         }

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
@@ -120,7 +120,15 @@ private class FakeLocationSource : LocationSource {
     }
 
     override fun onConnectionError(e: Throwable) {
-        _connectionStatus.value = ConnectionStatus.Error(e.message ?: "error")
+        val msg =
+            when {
+                e.message?.contains("Unable to resolve host", ignoreCase = true) == true -> "not resolved"
+                e.message?.contains("timeout", ignoreCase = true) == true -> "timeout"
+                e.message?.contains("ConnectException", ignoreCase = true) == true -> "no connection"
+                e.message?.contains("Failed to post to mailbox: 500", ignoreCase = true) == true -> "server error 500"
+                else -> e.message?.take(32) ?: "unknown error"
+            }
+        _connectionStatus.value = ConnectionStatus.Error(msg)
     }
 
     override fun setAppForeground(foreground: Boolean) {
@@ -137,6 +145,11 @@ private class FakeLocationSource : LocationSource {
 
     override fun setPausedFriends(friendIds: Set<String>) {
         _pausedFriendIds.value = friendIds
+    }
+
+    override fun setInitialFriendLocations(locations: Map<String, UserLocation>, pings: Map<String, Long>) {
+        _friendLocations.value += locations
+        _friendLastPing.value += pings
     }
 }
 

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
@@ -77,8 +77,26 @@ private class FakeLocationSource : LocationSource {
     private val _lastLocation = MutableStateFlow<Pair<Double, Double>?>(null)
     override val lastLocation: StateFlow<Pair<Double, Double>?> = _lastLocation
 
-    private val _users = MutableStateFlow<List<UserLocation>>(emptyList())
-    override val users: StateFlow<List<UserLocation>> = _users
+    private val _friendLocations = MutableStateFlow<Map<String, UserLocation>>(emptyMap())
+    override val friendLocations: StateFlow<Map<String, UserLocation>> = _friendLocations
+
+    private val _friendLastPing = MutableStateFlow<Map<String, Long>>(emptyMap())
+    override val friendLastPing: StateFlow<Map<String, Long>> = _friendLastPing
+
+    private val _connectionStatus = MutableStateFlow<ConnectionStatus>(ConnectionStatus.Ok)
+    override val connectionStatus: StateFlow<ConnectionStatus> = _connectionStatus
+
+    private val _isAppInForeground = MutableStateFlow(false)
+    override val isAppInForeground: StateFlow<Boolean> = _isAppInForeground
+
+    private val _pendingInitPayload = MutableStateFlow<KeyExchangeInitPayload?>(null)
+    override val pendingInitPayload: StateFlow<KeyExchangeInitPayload?> = _pendingInitPayload
+
+    private val _isSharingLocation = MutableStateFlow(true)
+    override val isSharingLocation: StateFlow<Boolean> = _isSharingLocation
+
+    private val _pausedFriendIds = MutableStateFlow<Set<String>>(emptySet())
+    override val pausedFriendIds: StateFlow<Set<String>> = _pausedFriendIds
 
     override fun onLocation(
         lat: Double,
@@ -87,8 +105,38 @@ private class FakeLocationSource : LocationSource {
         _lastLocation.value = lat to lng
     }
 
-    override fun onUsersUpdate(users: List<UserLocation>) {
-        _users.value = users
+    override fun onFriendUpdate(update: UserLocation, timestamp: Long) {
+        _friendLocations.value += (update.userId to update)
+        _friendLastPing.value += (update.userId to timestamp)
+    }
+
+    override fun onFriendRemoved(id: String) {
+        _friendLocations.value -= id
+        _friendLastPing.value -= id
+    }
+
+    override fun onConnectionStatus(status: ConnectionStatus) {
+        _connectionStatus.value = status
+    }
+
+    override fun onConnectionError(e: Throwable) {
+        _connectionStatus.value = ConnectionStatus.Error(e.message ?: "error")
+    }
+
+    override fun setAppForeground(foreground: Boolean) {
+        _isAppInForeground.value = foreground
+    }
+
+    override fun onPendingInit(payload: KeyExchangeInitPayload?) {
+        _pendingInitPayload.value = payload
+    }
+
+    override fun setSharingLocation(sharing: Boolean) {
+        _isSharingLocation.value = sharing
+    }
+
+    override fun setPausedFriends(friendIds: Set<String>) {
+        _pausedFriendIds.value = friendIds
     }
 }
 
@@ -198,11 +246,8 @@ class LocationViewModelTest {
 
             val qr = QrPayload(byteArrayOf(1, 2, 3), "Alice", "fp")
 
-            // Bob scans - simulate by setting the private field via reflection since it's Bob's side
-            val pendingQrField = LocationViewModel::class.java.getDeclaredField("_pendingQrForNaming")
-            pendingQrField.isAccessible = true
-            val pendingQrFlow = pendingQrField.get(vm) as kotlinx.coroutines.flow.MutableStateFlow<QrPayload?>
-            pendingQrFlow.value = qr
+            // Bob scans
+            (vm.pendingQrForNaming as MutableStateFlow).value = qr
 
             assertEquals(qr, vm.pendingQrForNaming.value)
 
@@ -365,6 +410,7 @@ class LocationViewModelTest {
             val vm = viewModel!!
 
             // Sharing is disabled, so any send should be rejected
+            (vm.isSharingLocation as MutableStateFlow).value = false
             vm.sendLocationIfNeeded(lat = 37.7749, lng = -122.4194, isHeartbeat = false)
             assertEquals(0, testClient.sendLocationCallCount, "Sending when sharing is disabled should not send")
         }
@@ -428,11 +474,7 @@ class LocationViewModelTest {
             // Initially not rapid polling
             assertFalse(vm.isRapidPolling())
 
-            // Simulate setting pending init payload via reflection (represents Bob's side receiving Alice's invite)
-            val pendingInitField = LocationViewModel::class.java.getDeclaredField("_pendingInitPayload")
-            pendingInitField.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val pendingInitFlow = pendingInitField.get(vm) as MutableStateFlow<KeyExchangeInitPayload?>
+            // Simulate setting pending init payload (represents Bob's side receiving Alice's invite)
             val initPayload =
                 KeyExchangeInitPayload(
                     v = 1,
@@ -441,7 +483,7 @@ class LocationViewModelTest {
                     keyConfirmation = byteArrayOf(4, 5, 6),
                     suggestedName = "Alice",
                 )
-            pendingInitFlow.value = initPayload
+            (vm.pendingInitPayload as MutableStateFlow).value = initPayload
 
             // Now should be rapid polling
             assertTrue(vm.isRapidPolling(), "Should be rapid polling while pending init payload exists")
@@ -471,13 +513,9 @@ class LocationViewModelTest {
             // Initially not rapid polling
             assertFalse(vm.isRapidPolling())
 
-            // Simulate setting pending QR via reflection (represents Bob's side after scanning Alice's QR)
-            val pendingQrField = LocationViewModel::class.java.getDeclaredField("_pendingQrForNaming")
-            pendingQrField.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val pendingQrFlow = pendingQrField.get(vm) as MutableStateFlow<QrPayload?>
+            // Simulate setting pending QR (represents Bob's side after scanning Alice's QR)
             val qr = QrPayload(byteArrayOf(1, 2, 3), "Alice", "fingerprint123")
-            pendingQrFlow.value = qr
+            (vm.pendingQrForNaming as MutableStateFlow).value = qr
 
             // Now should be rapid polling
             assertTrue(vm.isRapidPolling(), "Should be rapid polling while pending QR exists")
@@ -551,10 +589,6 @@ class LocationViewModelTest {
             assertTrue(vm.isRapidPolling(), "Invite pending → rapid polling")
 
             // Simulate received init payload (representing Bob's response)
-            val pendingInitField = LocationViewModel::class.java.getDeclaredField("_pendingInitPayload")
-            pendingInitField.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val pendingInitFlow = pendingInitField.get(vm) as MutableStateFlow<KeyExchangeInitPayload?>
             val initPayload =
                 KeyExchangeInitPayload(
                     v = 1,
@@ -563,7 +597,7 @@ class LocationViewModelTest {
                     keyConfirmation = byteArrayOf(4, 5, 6),
                     suggestedName = "Bob",
                 )
-            pendingInitFlow.value = initPayload
+            (vm.pendingInitPayload as MutableStateFlow).value = initPayload
 
             // Still rapid polling (now due to pending init)
             assertTrue(vm.isRapidPolling(), "Pending init → rapid polling")
@@ -633,11 +667,7 @@ class LocationViewModelTest {
                     keyConfirmation = byteArrayOf(4, 5, 6),
                     suggestedName = "Bob",
                 )
-            val pendingInitField = LocationViewModel::class.java.getDeclaredField("_pendingInitPayload")
-            pendingInitField.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val pendingInitFlow = pendingInitField.get(vm) as MutableStateFlow<KeyExchangeInitPayload?>
-            pendingInitFlow.value = initPayload
+            (vm.pendingInitPayload as MutableStateFlow).value = initPayload
 
             // Verify pending init is set
             assertNotNull(vm.pendingInitPayload.value, "Pending init should be set")
@@ -765,11 +795,7 @@ class LocationViewModelTest {
                     keyConfirmation = byteArrayOf(4, 5, 6),
                     suggestedName = "Bob",
                 )
-            val pendingInitField = LocationViewModel::class.java.getDeclaredField("_pendingInitPayload")
-            pendingInitField.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val pendingInitFlow = pendingInitField.get(vm) as MutableStateFlow<KeyExchangeInitPayload?>
-            pendingInitFlow.value = initPayload
+            (vm.pendingInitPayload as MutableStateFlow).value = initPayload
 
             // Verify initial state
             assertFalse(vm.isExchanging.value, "Should start with isExchanging=false")
@@ -801,6 +827,7 @@ class LocationViewModelTest {
             var currentTime = 1_000_000_000L
             val store = mockk<E2eeStore>(relaxed = true)
             val testClient = TestLocationClient(mockk(relaxed = true))
+            val source = FakeLocationSource()
 
             viewModel =
                 LocationViewModel(
@@ -809,9 +836,10 @@ class LocationViewModelTest {
                     locationClient = testClient,
                     startPolling = false,
                     clock = { currentTime },
-                    locationSource = FakeLocationSource(),
+                    locationSource = source,
                 )
             val vm = viewModel!!
+            advanceUntilIdle()
 
             // 1. Seed the ViewModel with a friend
             val friendId = "friend_alice_123"
@@ -825,23 +853,15 @@ class LocationViewModelTest {
                     lastTs = 1000L,
                 )
 
-            // Inject friend into the friends list via reflection
-            val friendsField = LocationViewModel::class.java.getDeclaredField("_friends")
-            friendsField.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val friendsFlow = friendsField.get(vm) as MutableStateFlow<List<FriendEntry>>
-            friendsFlow.value = listOf(friendEntry)
+            // Inject friend into the friends list
+            (vm.friends as MutableStateFlow).value = listOf(friendEntry)
 
             // Inject into friendLocations
             val location = UserLocation(friendId, 37.7749, -122.4194, 1000L)
-            vm.friendLocations.value = mapOf(friendId to location)
+            source.onFriendUpdate(location, 1000L)
 
             // Inject into pausedFriendIds
-            val pausedField = LocationViewModel::class.java.getDeclaredField("_pausedFriendIds")
-            pausedField.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val pausedFlow = pausedField.get(vm) as MutableStateFlow<Set<String>>
-            pausedFlow.value = setOf(friendId, "other_friend")
+            source.setPausedFriends(setOf(friendId, "other_friend"))
 
             // Mock store to return empty list after deletion
             io.mockk.coEvery { store.listFriends() } returns emptyList()
@@ -885,6 +905,7 @@ class LocationViewModelTest {
             // Test removeFriend when the friend is not in pausedFriendIds
             var currentTime = 1_000_000_000L
             val store = mockk<E2eeStore>(relaxed = true)
+            val source = FakeLocationSource()
 
             viewModel =
                 LocationViewModel(
@@ -893,9 +914,10 @@ class LocationViewModelTest {
                     locationClient = TestLocationClient(mockk(relaxed = true)),
                     startPolling = false,
                     clock = { currentTime },
-                    locationSource = FakeLocationSource(),
+                    locationSource = source,
                 )
             val vm = viewModel!!
+            advanceUntilIdle()
 
             val friendId = "friend_bob_456"
             val friendEntry =
@@ -909,21 +931,13 @@ class LocationViewModelTest {
                 )
 
             // Inject friend (not paused)
-            val friendsField = LocationViewModel::class.java.getDeclaredField("_friends")
-            friendsField.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val friendsFlow = friendsField.get(vm) as MutableStateFlow<List<FriendEntry>>
-            friendsFlow.value = listOf(friendEntry)
+            (vm.friends as MutableStateFlow).value = listOf(friendEntry)
 
             val location = UserLocation(friendId, 40.7128, -74.0060, 2000L)
-            vm.friendLocations.value = mapOf(friendId to location)
+            source.onFriendUpdate(location, 2000L)
 
             // pausedFriendIds is empty
-            val pausedField = LocationViewModel::class.java.getDeclaredField("_pausedFriendIds")
-            pausedField.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val pausedFlow = pausedField.get(vm) as MutableStateFlow<Set<String>>
-            pausedFlow.value = emptySet()
+            source.setPausedFriends(emptySet())
 
             io.mockk.coEvery { store.listFriends() } returns emptyList()
 
@@ -943,6 +957,7 @@ class LocationViewModelTest {
             // Test removeFriend when multiple friends exist - verify only target is removed
             var currentTime = 1_000_000_000L
             val store = mockk<E2eeStore>(relaxed = true)
+            val source = FakeLocationSource()
 
             // Mock listFriends() to return empty list during init()
             io.mockk.coEvery { store.listFriends() } returns emptyList()
@@ -954,7 +969,7 @@ class LocationViewModelTest {
                     locationClient = TestLocationClient(mockk(relaxed = true)),
                     startPolling = false,
                     clock = { currentTime },
-                    locationSource = FakeLocationSource(),
+                    locationSource = source,
                 )
             val vm = viewModel!!
             advanceUntilIdle() // Let init() block complete
@@ -991,25 +1006,15 @@ class LocationViewModelTest {
             val charlieId = charlie.id
 
             // Inject multiple friends
-            val friendsField = LocationViewModel::class.java.getDeclaredField("_friends")
-            friendsField.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val friendsFlow = friendsField.get(vm) as MutableStateFlow<List<FriendEntry>>
-            friendsFlow.value = listOf(alice, bob, charlie)
+            (vm.friends as MutableStateFlow).value = listOf(alice, bob, charlie)
 
-            vm.friendLocations.value =
-                mapOf(
-                    alice.id to UserLocation(alice.id, 1.0, 2.0, 1000L),
-                    bob.id to UserLocation(bob.id, 3.0, 4.0, 2000L),
-                    charlie.id to UserLocation(charlie.id, 5.0, 6.0, 3000L),
-                )
+            source.onFriendUpdate(UserLocation(alice.id, 1.0, 2.0, 1000L), 1000L)
+            source.onFriendUpdate(UserLocation(bob.id, 3.0, 4.0, 2000L), 2000L)
+            source.onFriendUpdate(UserLocation(charlie.id, 5.0, 6.0, 3000L), 3000L)
+
             println("Initial friendLocations: ${vm.friendLocations.value}") // Added logging
 
-            val pausedField = LocationViewModel::class.java.getDeclaredField("_pausedFriendIds")
-            pausedField.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val pausedFlow = pausedField.get(vm) as MutableStateFlow<Set<String>>
-            pausedFlow.value = setOf(aliceId, bobId)
+            source.setPausedFriends(setOf(aliceId, bobId))
 
             // Update mock to return two friends after removing bob
             io.mockk.coEvery { store.listFriends() } returns listOf(alice, charlie)

--- a/ios/Tests/WhereTests/LocationSyncServiceTests.swift
+++ b/ios/Tests/WhereTests/LocationSyncServiceTests.swift
@@ -8,23 +8,11 @@ import UIKit
 class LocationSyncServiceTests: XCTestCase {
     var service: LocationSyncService!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
-        // Since XCTestCase.setUp is nonisolated, but class is @MainActor,
-        // and we are on the Main thread, we use MainActor.run { ... }
-        // BUT we must avoid capturing 'self' in a way that risks races.
-        // XCTest guarantees setUp runs on the main thread, so assumeIsolated is the right tool.
-        // The error before was "sending self risks causing data races" because it was captured 
-        // in a closure passed to an actor-isolated context.
-        
-        MainActor.assumeIsolated {
-            // We use a local helper to avoid direct self capture in the closure if possible,
-            // but we need to set self.service.
-            // Let's try the most direct way again but be careful.
-            let s = LocationSyncService(e2eeStore: store, locationClient: nil)
-            self.service = s
-        }
+        // Using async setUp allows us to safely initialize @MainActor properties
+        self.service = LocationSyncService(e2eeStore: store, locationClient: nil)
     }
 
     func testThrottleLogic() async throws {

--- a/ios/Tests/WhereTests/LocationSyncServiceTests.swift
+++ b/ios/Tests/WhereTests/LocationSyncServiceTests.swift
@@ -9,9 +9,10 @@ class LocationSyncServiceTests: XCTestCase {
     var service: LocationSyncService!
 
     override func setUp() async throws {
-        try await super.setUp()
+        // We skip super.setUp() because it is non-isolated in the base XCTestCase,
+        // and calling it from this @MainActor-isolated class with 'self' (which is non-Sendable)
+        // triggers Swift 6 data race warnings. XCTestCase.setUp() is empty, so this is safe.
         let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
-        // Using async setUp allows us to safely initialize @MainActor properties
         self.service = LocationSyncService(e2eeStore: store, locationClient: nil)
     }
 


### PR DESCRIPTION
Fix compilation errors and unit test failures in the Android module by refactoring `LocationViewModel` to use `LocationSource` as a single source of truth for shared state. This eliminates brittle reflection in tests and improves overall architectural consistency.

---
*PR created automatically by Jules for task [6939584003312312811](https://jules.google.com/task/6939584003312312811) started by @danmarg*