### PR TITLE
Fix premature rapid poll termination after pairing #56

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
@@ -13,6 +13,7 @@ import net.af0.where.model.UserLocation
 
 sealed class ConnectionStatus {
     object Ok : ConnectionStatus()
+
     data class Error(val message: String) : ConnectionStatus()
 }
 
@@ -44,16 +45,30 @@ interface LocationSource {
     )
 
     fun onFriendRemoved(id: String)
+
     fun onConnectionStatus(status: ConnectionStatus)
+
     fun onConnectionError(e: Throwable)
+
     fun setAppForeground(foreground: Boolean)
+
     fun onPendingInit(payload: KeyExchangeInitPayload?)
+
     fun setSharingLocation(sharing: Boolean)
+
     fun setPausedFriends(friendIds: Set<String>)
-    fun setInitialFriendLocations(locations: Map<String, UserLocation>, pings: Map<String, Long>)
+
+    fun setInitialFriendLocations(
+        locations: Map<String, UserLocation>,
+        pings: Map<String, Long>,
+    )
+
     fun onFriendsUpdated(friends: List<FriendEntry>)
+
     fun triggerRapidPoll()
+
     fun resetRapidPoll()
+
     fun wakePoll()
 }
 
@@ -124,13 +139,14 @@ object LocationRepository : LocationSource {
     }
 
     override fun onConnectionError(e: Throwable) {
-        val msg = when {
-            e.message?.contains("Unable to resolve host", ignoreCase = true) == true -> "not resolved"
-            e.message?.contains("timeout", ignoreCase = true) == true -> "timeout"
-            e.message?.contains("ConnectException", ignoreCase = true) == true -> "no connection"
-            e.message?.contains("Failed to post to mailbox: 500", ignoreCase = true) == true -> "server error 500"
-            else -> e.message?.take(32) ?: "unknown error"
-        }
+        val msg =
+            when {
+                e.message?.contains("Unable to resolve host", ignoreCase = true) == true -> "not resolved"
+                e.message?.contains("timeout", ignoreCase = true) == true -> "timeout"
+                e.message?.contains("ConnectException", ignoreCase = true) == true -> "no connection"
+                e.message?.contains("Failed to post to mailbox: 500", ignoreCase = true) == true -> "server error 500"
+                else -> e.message?.take(32) ?: "unknown error"
+            }
         _connectionStatus.value = ConnectionStatus.Error(msg)
     }
 
@@ -155,7 +171,10 @@ object LocationRepository : LocationSource {
         _pausedFriendIds.value = friendIds
     }
 
-    override fun setInitialFriendLocations(locations: Map<String, UserLocation>, pings: Map<String, Long>) {
+    override fun setInitialFriendLocations(
+        locations: Map<String, UserLocation>,
+        pings: Map<String, Long>,
+    ) {
         // Merge with current state to avoid overwriting live updates that arrived before initial load
         _friendLocations.update { locations + it }
         _friendLastPing.update { pings + it }

--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -17,14 +17,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
 import net.af0.where.e2ee.E2eeMailboxClient
 import net.af0.where.e2ee.E2eeStore
 import net.af0.where.e2ee.KeyExchangeInitPayload
@@ -207,17 +203,19 @@ class LocationService : Service() {
     ) {
         if (!locationSource.isSharingLocation.value) return
         val now = clock()
-        val shouldSend = sendLock.withLock {
-            val canSend = force || lastSentTime == 0L ||
-                (!isHeartbeat && now - lastSentTime > 15_000L) ||
-                (isHeartbeat && now - lastSentTime > 300_000L)
-            if (canSend) {
-                lastSentTime = now
-                true
-            } else {
-                false
+        val shouldSend =
+            sendLock.withLock {
+                val canSend =
+                    force || lastSentTime == 0L ||
+                        (!isHeartbeat && now - lastSentTime > 15_000L) ||
+                        (isHeartbeat && now - lastSentTime > 300_000L)
+                if (canSend) {
+                    lastSentTime = now
+                    true
+                } else {
+                    false
+                }
             }
-        }
         if (!shouldSend) return
         try {
             locationClient.sendLocation(lat, lng, locationSource.pausedFriendIds.value)

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -11,15 +11,12 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -138,7 +135,6 @@ class LocationViewModel(
             }
         }
     }
-
 
     private fun triggerRapidPoll() {
         locationSource.triggerRapidPoll()
@@ -352,7 +348,10 @@ class LocationViewModel(
                             val loc = locationSource.lastLocation.value
                             if (loc != null) {
                                 try {
-                                    Log.d(TAG, "confirmPendingInit: force-sending location to ${entry.id}: lat=${loc.first}, lng=${loc.second}")
+                                    Log.d(
+                                        TAG,
+                                        "confirmPendingInit: force-sending location to ${entry.id}: lat=${loc.first}, lng=${loc.second}",
+                                    )
                                     locationClient.sendLocationToFriend(entry.id, loc.first, loc.second)
                                     Log.d(TAG, "confirmPendingInit: sendLocationToFriend succeeded")
                                 } catch (e: Exception) {
@@ -408,7 +407,6 @@ class LocationViewModel(
         locationSource.resetRapidPoll()
         _inviteState.value = InviteState.None
     }
-
 
     private fun updateStatus(e: Throwable?) {
         if (e == null) {

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -212,6 +212,7 @@ class LocationViewModel(
                 e2eeStore.clearInvite()
             }
         }
+        locationSource.resetRapidPoll()
         _inviteState.value = InviteState.None
     }
 
@@ -232,6 +233,7 @@ class LocationViewModel(
     fun cancelQrScan() {
         _pendingQrForNaming.value = null
         if (locationSource is LocationRepository) locationSource.onPendingQrForNaming(null)
+        locationSource.resetRapidPoll()
     }
 
     fun confirmQrScan(
@@ -311,7 +313,7 @@ class LocationViewModel(
                     withContext(Dispatchers.Main.immediate) {
                         locationSource.onFriendsUpdated(e2eeStore.listFriends())
                     }
-                    locationSource.resetRapidPoll()
+                    locationSource.triggerRapidPoll()
                     locationSource.wakePoll()
                 } catch (e: Exception) {
                     Log.e(TAG, "confirmQrScan inner failure: ${e.message}")
@@ -340,7 +342,7 @@ class LocationViewModel(
                     withContext(Dispatchers.Main.immediate) {
                         locationSource.onFriendsUpdated(e2eeStore.listFriends())
                     }
-                    locationSource.resetRapidPoll()
+                    locationSource.triggerRapidPoll()
                     locationSource.wakePoll()
                     try {
                         // Upload OPK bundle so Bob can decrypt our future location messages.
@@ -403,6 +405,7 @@ class LocationViewModel(
             e2eeStore.clearInvite()
         }
         locationSource.onPendingInit(null)
+        locationSource.resetRapidPoll()
         _inviteState.value = InviteState.None
     }
 

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
@@ -2,19 +2,16 @@ package net.af0.where
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.runTest
+import net.af0.where.e2ee.KeyExchangeInitPayload
+import net.af0.where.e2ee.LocationClient
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlinx.coroutines.test.runTest
-import net.af0.where.e2ee.E2eeStore
-import kotlinx.coroutines.flow.MutableStateFlow
-import net.af0.where.e2ee.KeyExchangeInitPayload
-import net.af0.where.e2ee.LocationClient
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLog
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -53,90 +50,93 @@ class LocationServiceTest {
     }
 
     @Test
-    fun testSendLocationThrottle_Movement() = runTest {
-        var currentTime = 100_000L
-        LocationService.clock = { currentTime }
+    fun testSendLocationThrottle_Movement() =
+        runTest {
+            var currentTime = 100_000L
+            LocationService.clock = { currentTime }
 
-        val controller = Robolectric.buildService(LocationService::class.java)
-        val service = controller.get()
-        controller.create()
+            val controller = Robolectric.buildService(LocationService::class.java)
+            val service = controller.get()
+            controller.create()
 
-        val mockClient = io.mockk.mockk<LocationClient>(relaxed = true)
-        val locationClientField = LocationService::class.java.getDeclaredField("locationClient")
-        locationClientField.isAccessible = true
-        locationClientField.set(service, mockClient)
+            val mockClient = io.mockk.mockk<LocationClient>(relaxed = true)
+            val locationClientField = LocationService::class.java.getDeclaredField("locationClient")
+            locationClientField.isAccessible = true
+            locationClientField.set(service, mockClient)
 
-        // 1. Initial send
-        service.sendLocationIfNeeded(37.7, -122.4, false, false)
-        io.mockk.coVerify(exactly = 1) { mockClient.sendLocation(any(), any(), any()) }
-        assertTrue(service.lastSentTime > 0)
+            // 1. Initial send
+            service.sendLocationIfNeeded(37.7, -122.4, false, false)
+            io.mockk.coVerify(exactly = 1) { mockClient.sendLocation(any(), any(), any()) }
+            assertTrue(service.lastSentTime > 0)
 
-        // 2. Immediate second send (throttled)
-        service.sendLocationIfNeeded(37.8, -122.5, false, false)
-        io.mockk.coVerify(exactly = 1) { mockClient.sendLocation(any(), any(), any()) }
+            // 2. Immediate second send (throttled)
+            service.sendLocationIfNeeded(37.8, -122.5, false, false)
+            io.mockk.coVerify(exactly = 1) { mockClient.sendLocation(any(), any(), any()) }
 
-        // 3. Send after 16s (not throttled - movement throttle is 15s)
-        currentTime += 16_000L
-        service.sendLocationIfNeeded(37.9, -122.6, false, false)
-        io.mockk.coVerify(exactly = 2) { mockClient.sendLocation(any(), any(), any()) }
-    }
-
-    @Test
-    fun testSendLocationThrottle_Heartbeat() = runTest {
-        var currentTime = 1_000_000L
-        LocationService.clock = { currentTime }
-
-        val controller = Robolectric.buildService(LocationService::class.java)
-        val service = controller.get()
-        controller.create()
-
-        val mockClient = io.mockk.mockk<LocationClient>(relaxed = true)
-        val locationClientField = LocationService::class.java.getDeclaredField("locationClient")
-        locationClientField.isAccessible = true
-        locationClientField.set(service, mockClient)
-
-        // 1. Initial send
-        service.sendLocationIfNeeded(37.7, -122.4, false, false)
-        io.mockk.coVerify(exactly = 1) { mockClient.sendLocation(any(), any(), any()) }
-
-        // 2. Heartbeat after 1 minute (throttled - heartbeat throttle is 300s)
-        currentTime += 60_000L
-        service.sendLocationIfNeeded(37.7, -122.4, true, false)
-        io.mockk.coVerify(exactly = 1) { mockClient.sendLocation(any(), any(), any()) }
-
-        // 3. Heartbeat after 6 minutes (not throttled)
-        currentTime += 300_000L
-        service.sendLocationIfNeeded(37.7, -122.4, true, false)
-        io.mockk.coVerify(exactly = 2) { mockClient.sendLocation(any(), any(), any()) }
-    }
+            // 3. Send after 16s (not throttled - movement throttle is 15s)
+            currentTime += 16_000L
+            service.sendLocationIfNeeded(37.9, -122.6, false, false)
+            io.mockk.coVerify(exactly = 2) { mockClient.sendLocation(any(), any(), any()) }
+        }
 
     @Test
-    fun testIsRapidPolling() = runTest {
-        // Use a large initial time so that trigger=0 is not "recent"
-        var currentTime = 1_000_000_000L
-        LocationService.clock = { currentTime }
+    fun testSendLocationThrottle_Heartbeat() =
+        runTest {
+            var currentTime = 1_000_000L
+            LocationService.clock = { currentTime }
 
-        val controller = Robolectric.buildService(LocationService::class.java)
-        val service = controller.get()
-        controller.create()
+            val controller = Robolectric.buildService(LocationService::class.java)
+            val service = controller.get()
+            controller.create()
 
-        // 1. Initial state: not rapid
-        assertFalse(service.isRapidPolling())
+            val mockClient = io.mockk.mockk<LocationClient>(relaxed = true)
+            val locationClientField = LocationService::class.java.getDeclaredField("locationClient")
+            locationClientField.isAccessible = true
+            locationClientField.set(service, mockClient)
 
-        // 2. Recent rapid poll trigger (within 5 minutes)
-        LocationRepository._lastRapidPollTrigger.value = currentTime - 60_000L // 1 minute ago
-        assertTrue(service.isRapidPolling())
+            // 1. Initial send
+            service.sendLocationIfNeeded(37.7, -122.4, false, false)
+            io.mockk.coVerify(exactly = 1) { mockClient.sendLocation(any(), any(), any()) }
 
-        // 3. Stale rapid poll trigger (more than 5 minutes ago)
-        LocationRepository._lastRapidPollTrigger.value = currentTime - 301_000L
-        assertFalse(service.isRapidPolling())
+            // 2. Heartbeat after 1 minute (throttled - heartbeat throttle is 300s)
+            currentTime += 60_000L
+            service.sendLocationIfNeeded(37.7, -122.4, true, false)
+            io.mockk.coVerify(exactly = 1) { mockClient.sendLocation(any(), any(), any()) }
 
-        // 4. Pending init payload
-        LocationRepository._pendingInitPayload.value = io.mockk.mockk<KeyExchangeInitPayload>()
-        assertTrue(service.isRapidPolling())
+            // 3. Heartbeat after 6 minutes (not throttled)
+            currentTime += 300_000L
+            service.sendLocationIfNeeded(37.7, -122.4, true, false)
+            io.mockk.coVerify(exactly = 2) { mockClient.sendLocation(any(), any(), any()) }
+        }
 
-        // 5. Reset pending init
-        LocationRepository._pendingInitPayload.value = null
-        assertFalse(service.isRapidPolling())
-    }
+    @Test
+    fun testIsRapidPolling() =
+        runTest {
+            // Use a large initial time so that trigger=0 is not "recent"
+            var currentTime = 1_000_000_000L
+            LocationService.clock = { currentTime }
+
+            val controller = Robolectric.buildService(LocationService::class.java)
+            val service = controller.get()
+            controller.create()
+
+            // 1. Initial state: not rapid
+            assertFalse(service.isRapidPolling())
+
+            // 2. Recent rapid poll trigger (within 5 minutes)
+            LocationRepository._lastRapidPollTrigger.value = currentTime - 60_000L // 1 minute ago
+            assertTrue(service.isRapidPolling())
+
+            // 3. Stale rapid poll trigger (more than 5 minutes ago)
+            LocationRepository._lastRapidPollTrigger.value = currentTime - 301_000L
+            assertFalse(service.isRapidPolling())
+
+            // 4. Pending init payload
+            LocationRepository._pendingInitPayload.value = io.mockk.mockk<KeyExchangeInitPayload>()
+            assertTrue(service.isRapidPolling())
+
+            // 5. Reset pending init
+            LocationRepository._pendingInitPayload.value = null
+            assertFalse(service.isRapidPolling())
+        }
 }

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
 import android.text.TextUtils
-import app.cash.turbine.turbineScope
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -106,7 +105,10 @@ private class FakeLocationSource : LocationSource {
         _lastLocation.value = lat to lng
     }
 
-    override fun onFriendUpdate(update: UserLocation, timestamp: Long) {
+    override fun onFriendUpdate(
+        update: UserLocation,
+        timestamp: Long,
+    ) {
         _friendLocations.value += (update.userId to update)
         _friendLastPing.value += (update.userId to timestamp)
     }
@@ -148,7 +150,10 @@ private class FakeLocationSource : LocationSource {
         _pausedFriendIds.value = friendIds
     }
 
-    override fun setInitialFriendLocations(locations: Map<String, UserLocation>, pings: Map<String, Long>) {
+    override fun setInitialFriendLocations(
+        locations: Map<String, UserLocation>,
+        pings: Map<String, Long>,
+    ) {
         _friendLocations.value += locations
         _friendLastPing.value += pings
     }

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
@@ -723,4 +723,123 @@ class LocationViewModelTest {
             assertTrue(charlieId in vm.friendLocations.value.keys, "Charlie should still be in locations")
         }
 
+    @Test
+    fun testRapidPollResetAfterConfirmQrScan() =
+        runTest {
+            val store = mockk<E2eeStore>(relaxed = true)
+            val source = FakeLocationSource()
+            viewModel =
+                LocationViewModel(
+                    app,
+                    e2eeStore = store,
+                    startPolling = false,
+                    locationSource = source,
+                )
+            val vm = viewModel!!
+
+            val qr =
+                QrPayload(
+                    ekPub = byteArrayOf(1, 2, 3),
+                    suggestedName = "Alice",
+                    fingerprint = "fp",
+                )
+
+            // Mock store to return a friend
+            val newFriend =
+                FriendEntry(
+                    name = "Alice",
+                    session = mockk(relaxed = true),
+                    isInitiator = true,
+                    lastLat = null,
+                    lastLng = null,
+                    lastTs = null,
+                )
+            io.mockk.coEvery { store.processScannedQr(any(), any()) } returns Pair(mockk(relaxed = true), newFriend)
+            io.mockk.coEvery { store.listFriends() } returns emptyList()
+
+            vm.confirmQrScan(qr, "Alice")
+            advanceUntilIdle()
+
+            assertTrue(source.lastRapidPollTrigger.value > 0L, "Rapid poll should be triggered (not reset to 0)")
+        }
+
+    @Test
+    fun testRapidPollResetAfterConfirmPendingInit() =
+        runTest {
+            val store = mockk<E2eeStore>(relaxed = true)
+            val source = FakeLocationSource()
+            viewModel =
+                LocationViewModel(
+                    app,
+                    e2eeStore = store,
+                    startPolling = false,
+                    locationSource = source,
+                )
+            val vm = viewModel!!
+
+            val initPayload =
+                KeyExchangeInitPayload(
+                    v = 1,
+                    token = "test",
+                    ekPub = byteArrayOf(1),
+                    keyConfirmation = byteArrayOf(2),
+                    suggestedName = "Bob",
+                )
+            (vm.pendingInitPayload as MutableStateFlow).value = initPayload
+
+            // Mock store to return a friend
+            val newFriend =
+                FriendEntry(
+                    name = "Bob",
+                    session = mockk(relaxed = true),
+                    isInitiator = false,
+                    lastLat = null,
+                    lastLng = null,
+                    lastTs = null,
+                )
+            io.mockk.coEvery { store.processKeyExchangeInit(any(), any()) } returns newFriend
+            io.mockk.coEvery { store.listFriends() } returns listOf(newFriend)
+
+            vm.confirmPendingInit("Bob")
+            advanceUntilIdle()
+
+            assertTrue(source.lastRapidPollTrigger.value > 0L, "Rapid poll should be triggered (not reset to 0)")
+        }
+
+    @Test
+    fun testRapidPollResetOnCancellation() =
+        runTest {
+            val store = mockk<E2eeStore>(relaxed = true)
+            val source = FakeLocationSource()
+            viewModel =
+                LocationViewModel(
+                    app,
+                    e2eeStore = store,
+                    startPolling = false,
+                    locationSource = source,
+                )
+            val vm = viewModel!!
+
+            // Test cancelPendingInit
+            (vm.pendingInitPayload as MutableStateFlow).value = mockk()
+            source.triggerRapidPoll()
+            assertTrue(source.lastRapidPollTrigger.value > 0L)
+            vm.cancelPendingInit()
+            assertEquals(0L, source.lastRapidPollTrigger.value)
+
+            // Test cancelQrScan
+            (vm.pendingQrForNaming as MutableStateFlow).value = mockk()
+            source.triggerRapidPoll()
+            assertTrue(source.lastRapidPollTrigger.value > 0L)
+            vm.cancelQrScan()
+            assertEquals(0L, source.lastRapidPollTrigger.value)
+
+            // Test clearInvite
+            vm.createInvite()
+            advanceUntilIdle()
+            source.triggerRapidPoll()
+            assertTrue(source.lastRapidPollTrigger.value > 0L)
+            vm.clearInvite()
+            assertEquals(0L, source.lastRapidPollTrigger.value)
+        }
 }

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -406,6 +406,7 @@ final class LocationSyncService: ObservableObject {
         } catch {
             logger.error("Failed to clear invite: \(error.localizedDescription)")
         }
+        resetRapidPoll()
         inviteState = .none
     }
 
@@ -502,7 +503,7 @@ final class LocationSyncService: ObservableObject {
                     LocationManager.shared.requestPermissionAndStart()
                 }
             }
-            resetRapidPoll()
+            triggerRapidPoll()
             friends = try await e2eeStore.listFriends()
             updateVisibleUsers()
         } catch {
@@ -516,6 +517,7 @@ final class LocationSyncService: ObservableObject {
         guard pendingInitPayload != nil || hasInviteState else { return }
         await clearInvite()
         pendingInitPayload = nil
+        resetRapidPoll()
         inviteState = .none
     }
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -253,8 +253,8 @@ class E2eeStore(
             } catch (e: IllegalArgumentException) {
                 throw e // key_confirmation failure — surface to caller
             } catch (e: Exception) {
-								throw e // XXX
-                //null // transient parse/format error — treat as "not ready yet"
+                throw e // XXX
+                // null // transient parse/format error — treat as "not ready yet"
             }
         }
 


### PR DESCRIPTION
This PR fixes an issue where Android (and iOS) would stop rapid polling immediately after a successful friend pairing, often before receiving the first location from the new friend. 

The fix ensures that both platforms enter a 5-minute rapid-polling window upon successful key exchange. Additionally, it improves battery efficiency by ensuring rapid polling is explicitly halted when a pairing process is cancelled or an invite is cleared.

Changes:
- Android: `LocationViewModel.kt` now calls `triggerRapidPoll()` instead of `resetRapidPoll()` on success, and correctly resets it on cancellations.
- iOS: `LocationSyncService.swift` mirrors this behavior.
- Tests: Added coverage for these transitions in `LocationViewModelTest.kt`.

---
*PR created automatically by Jules for task [4146588914731806498](https://jules.google.com/task/4146588914731806498) started by @danmarg*