### PR TITLE
Move name settings to sharing dialog and fix 'You' button

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
@@ -82,6 +82,14 @@ fun FriendsSheet(
         ) {
             Text("Friends", style = MaterialTheme.typography.titleLarge)
 
+            OutlinedTextField(
+                value = displayName,
+                onValueChange = onDisplayNameChange,
+                label = { Text("Your Name") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/android/src/androidMain/kotlin/net/af0/where/InviteSheet.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/InviteSheet.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -27,6 +28,8 @@ import net.af0.where.e2ee.QrPayload
 @Composable
 fun InviteSheet(
     qrPayload: QrPayload,
+    displayName: String,
+    onDisplayNameChange: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -47,6 +50,13 @@ fun InviteSheet(
                 "Have them scan this QR code or send the link.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedTextField(
+                value = displayName,
+                onValueChange = onDisplayNameChange,
+                label = { Text("Your Name") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
             )
             qrBitmap?.let {
                 Image(

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -144,6 +144,10 @@ class LocationViewModel(
         check(Looper.myLooper() == Looper.getMainLooper()) { "setDisplayName must be called on the main thread" }
         _displayName.value = name
         UserPrefs.setDisplayName(getApplication(), name)
+        // If an invite is active, we should update it.
+        if (_inviteState.value is InviteState.Pending) {
+            createInvite()
+        }
     }
 
     fun toggleSharing() {

--- a/android/src/androidMain/kotlin/net/af0/where/MainActivity.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MainActivity.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
@@ -72,7 +71,6 @@ class MainActivity : ComponentActivity() {
                 val connectionStatus by viewModel.connectionStatus.collectAsState()
 
                 var showSimulatorScanner by remember { mutableStateOf(false) }
-                var showUserSettings by remember { mutableStateOf(false) }
 
                 MapScreen(
                     userId = viewModel.userId,
@@ -106,7 +104,6 @@ class MainActivity : ComponentActivity() {
                     friendLastPing = friendLastPing,
                     onRenameFriend = { id, name -> viewModel.renameFriend(id, name) },
                     onRemoveFriend = { viewModel.removeFriend(it) },
-                    onShowSettings = { showUserSettings = true },
                     onLocationPermissionGranted = ::startLocationService,
                 )
 
@@ -153,7 +150,12 @@ class MainActivity : ComponentActivity() {
                 }
 
                 (inviteState as? InviteState.Pending)?.let { state ->
-                    InviteSheet(qrPayload = state.qr, onDismiss = { viewModel.clearInvite() })
+                    InviteSheet(
+                        qrPayload = state.qr,
+                        displayName = displayName,
+                        onDisplayNameChange = { viewModel.setDisplayName(it) },
+                        onDismiss = { viewModel.clearInvite() },
+                    )
                 }
 
                 pendingQrForNaming?.let { qr ->
@@ -177,29 +179,6 @@ class MainActivity : ComponentActivity() {
                         dismissButton = {
                             TextButton(onClick = { viewModel.cancelQrScan() }) {
                                 Text("Cancel")
-                            }
-                        },
-                    )
-                }
-
-                if (showUserSettings) {
-                    AlertDialog(
-                        onDismissRequest = { showUserSettings = false },
-                        title = { Text("You") },
-                        text = {
-                            Column {
-                                OutlinedTextField(
-                                    value = displayName,
-                                    onValueChange = { viewModel.setDisplayName(it) },
-                                    label = { Text("Your Name") },
-                                    modifier = Modifier.fillMaxWidth(),
-                                    singleLine = true,
-                                )
-                            }
-                        },
-                        confirmButton = {
-                            TextButton(onClick = { showUserSettings = false }) {
-                                Text("Close")
                             }
                         },
                     )

--- a/android/src/androidMain/kotlin/net/af0/where/MainActivity.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MainActivity.kt
@@ -71,6 +71,24 @@ class MainActivity : ComponentActivity() {
                 val connectionStatus by viewModel.connectionStatus.collectAsState()
 
                 var showSimulatorScanner by remember { mutableStateOf(false) }
+                var showNamePromptBeforeScan by remember { mutableStateOf(false) }
+
+                fun triggerScan() {
+                    if (android.os.Build.PRODUCT.contains("sdk") ||
+                        android.os.Build.MODEL.contains("Emulator") ||
+                        android.os.Build.DEVICE.contains("generic")
+                    ) {
+                        showSimulatorScanner = true
+                    } else {
+                        scanLauncher.launch(
+                            ScanOptions().apply {
+                                setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+                                setBeepEnabled(false)
+                                setOrientationLocked(false)
+                            },
+                        )
+                    }
+                }
 
                 MapScreen(
                     userId = viewModel.userId,
@@ -85,19 +103,10 @@ class MainActivity : ComponentActivity() {
                     connectionStatus = connectionStatus,
                     onCreateInvite = { viewModel.createInvite() },
                     onScanQr = {
-                        if (android.os.Build.PRODUCT.contains("sdk") ||
-                            android.os.Build.MODEL.contains("Emulator") ||
-                            android.os.Build.DEVICE.contains("generic")
-                        ) {
-                            showSimulatorScanner = true
+                        if (displayName.isEmpty()) {
+                            showNamePromptBeforeScan = true
                         } else {
-                            scanLauncher.launch(
-                                ScanOptions().apply {
-                                    setDesiredBarcodeFormats(ScanOptions.QR_CODE)
-                                    setBeepEnabled(false)
-                                    setOrientationLocked(false)
-                                },
-                            )
+                            triggerScan()
                         }
                     },
                     onPasteUrl = { viewModel.processQrUrl(it) },
@@ -114,6 +123,45 @@ class MainActivity : ComponentActivity() {
                     ) {
                         CircularProgressIndicator()
                     }
+                }
+
+                if (showNamePromptBeforeScan) {
+                    var newName by remember { mutableStateOf("") }
+                    AlertDialog(
+                        onDismissRequest = { showNamePromptBeforeScan = false },
+                        title = { Text("Choose your name") },
+                        text = {
+                            Column {
+                                Text("Please choose a name so your friend knows who you are.")
+                                Spacer(Modifier.height(8.dp))
+                                OutlinedTextField(
+                                    value = newName,
+                                    onValueChange = { newName = it },
+                                    label = { Text("Your Name") },
+                                    singleLine = true,
+                                )
+                            }
+                        },
+                        confirmButton = {
+                            TextButton(
+                                onClick = {
+                                    if (newName.isNotEmpty()) {
+                                        viewModel.setDisplayName(newName)
+                                        showNamePromptBeforeScan = false
+                                        triggerScan()
+                                    }
+                                },
+                                enabled = newName.isNotEmpty(),
+                            ) {
+                                Text("Continue")
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showNamePromptBeforeScan = false }) {
+                                Text("Cancel")
+                            }
+                        },
+                    )
                 }
 
                 if (showSimulatorScanner) {

--- a/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
@@ -44,7 +44,6 @@ fun MapScreen(
     friendLastPing: Map<String, Long>,
     onRenameFriend: (String, String) -> Unit,
     onRemoveFriend: (String) -> Unit,
-    onShowSettings: () -> Unit,
     onLocationPermissionGranted: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
@@ -218,7 +217,7 @@ fun MapScreen(
                 modifier =
                     Modifier
                         .weight(1f)
-                        .clickable { onShowSettings() },
+                        .clickable { zoomToUserId = userId },
                 shape = MaterialTheme.shapes.medium,
                 color = Color.Black.copy(alpha = 0.7f),
             ) {
@@ -238,7 +237,7 @@ fun MapScreen(
                     )
                     Column {
                         Text(
-                            text = if (displayName.isNotEmpty()) displayName else "You",
+                            text = "You",
                             color = Color.White,
                             style = MaterialTheme.typography.labelSmall,
                         )

--- a/ios/Sources/Where/ContentView.swift
+++ b/ios/Sources/Where/ContentView.swift
@@ -11,6 +11,7 @@ struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var showFriends = false
     @State private var showScanner = false
+    @State private var showNamePromptBeforeScan = false
     @State private var scannedUrl: String? = nil
     @State private var zoomTarget: CLLocationCoordinate2D? = nil
 
@@ -118,7 +119,11 @@ struct ContentView: View {
                 },
                 onScanQr: {
                     showFriends = false
-                    showScanner = true
+                    if syncService.displayName.isEmpty {
+                        showNamePromptBeforeScan = true
+                    } else {
+                        showScanner = true
+                    }
                 },
                 onRename: { id, name in Task { await syncService.renameFriend(id: id, newName: name) } },
                 onPasteUrl: { url in
@@ -171,6 +176,21 @@ struct ContentView: View {
                     onDismiss: { Task { await syncService.clearInvite() } }
                 )
             }
+        }
+        .alert("Choose your name", isPresented: $showNamePromptBeforeScan) {
+            TextField("Your Name", text: $syncService.displayName)
+            Button("Continue") {
+                if !syncService.displayName.isEmpty {
+                    showNamePromptBeforeScan = false
+                    showScanner = true
+                }
+            }
+            .disabled(syncService.displayName.isEmpty)
+            Button("Cancel", role: .cancel) {
+                showNamePromptBeforeScan = false
+            }
+        } message: {
+            Text("Please choose a name so your friend knows who you are.")
         }
         .alert("Name this contact", isPresented: Binding(
             get: { (syncService.pendingQrForNaming != nil || syncService.pendingInitPayload != nil) && !syncService.isInviteActive },

--- a/ios/Sources/Where/ContentView.swift
+++ b/ios/Sources/Where/ContentView.swift
@@ -11,7 +11,6 @@ struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var showFriends = false
     @State private var showScanner = false
-    @State private var showUserSettings = false
     @State private var scannedUrl: String? = nil
     @State private var zoomTarget: CLLocationCoordinate2D? = nil
 
@@ -57,7 +56,7 @@ struct ContentView: View {
                             Circle()
                                 .fill(syncService.connectionStatus.isOk ? Color.green : Color.orange)
                                 .frame(width: 8, height: 8)
-                            Text(syncService.displayName.isEmpty ? "You" : syncService.displayName)
+                            Text("You")
                                 .font(.caption)
                                 .foregroundStyle(.white)
                         }
@@ -74,7 +73,9 @@ struct ContentView: View {
                     .clipShape(Capsule())
                     .contentShape(Capsule())
                     .onTapGesture {
-                        showUserSettings = true
+                        if let loc = locationManager.location {
+                            zoomTarget = CLLocationCoordinate2D(latitude: loc.coordinate.latitude, longitude: loc.coordinate.longitude)
+                        }
                     }
 
                     Spacer()
@@ -164,14 +165,12 @@ struct ContentView: View {
             } }
         )) {
             if case .pending(let qr) = syncService.inviteState {
-                InviteSheet(qrPayload: qr, onDismiss: { Task { await syncService.clearInvite() } })
+                InviteSheet(
+                    qrPayload: qr,
+                    displayName: $syncService.displayName,
+                    onDismiss: { Task { await syncService.clearInvite() } }
+                )
             }
-        }
-        .alert("You", isPresented: $showUserSettings) {
-            TextField("Your Name", text: $syncService.displayName)
-            Button("Close", role: .cancel) {}
-        } message: {
-            Text("Set your display name that friends will see.")
         }
         .alert("Name this contact", isPresented: Binding(
             get: { (syncService.pendingQrForNaming != nil || syncService.pendingInitPayload != nil) && !syncService.isInviteActive },

--- a/ios/Sources/Where/FriendsSheet.swift
+++ b/ios/Sources/Where/FriendsSheet.swift
@@ -34,6 +34,11 @@ struct FriendsSheet: View {
         NavigationStack {
             List {
                 Section {
+                    TextField("Your Name", text: $displayName)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                Section {
                     VStack(spacing: 12) {
                         HStack(spacing: 12) {
                             Button {

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -119,7 +119,12 @@ final class LocationSyncService: ObservableObject {
         didSet { UserDefaults.standard.set(isSharingLocation, forKey: "where_is_sharing") }
     }
     @Published var displayName: String {
-        didSet { UserDefaults.standard.set(displayName, forKey: "display_name") }
+        didSet {
+            UserDefaults.standard.set(displayName, forKey: "display_name")
+            if isInviteActive {
+                Task { await createInvite() }
+            }
+        }
     }
     @Published var pausedFriendIds: Set<String> {
         didSet { UserDefaults.standard.set(Array(pausedFriendIds), forKey: "paused_friends") }

--- a/ios/Sources/Where/QrCodeView.swift
+++ b/ios/Sources/Where/QrCodeView.swift
@@ -45,6 +45,7 @@ struct QrCodeView: View {
 
 struct InviteSheet: View {
     let qrPayload: Shared.QrPayload
+    @Binding var displayName: String
     let onDismiss: () -> Void
 
     @State private var showShareSheet = false
@@ -60,6 +61,10 @@ struct InviteSheet: View {
                 Text("Have them scan this QR code or share the link.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                TextField("Your Name", text: $displayName)
+                    .textFieldStyle(.roundedBorder)
                     .multilineTextAlignment(.center)
 
                 QrCodeView(content: cachedQrUrl)
@@ -78,9 +83,10 @@ struct InviteSheet: View {
             .padding(32)
         }
         .onAppear {
-            if cachedQrUrl.isEmpty {
-                cachedQrUrl = qrPayloadToUrl(qrPayload)
-            }
+            cachedQrUrl = qrPayloadToUrl(qrPayload)
+        }
+        .onChange(of: qrPayload) { oldValue, newValue in
+            cachedQrUrl = qrPayloadToUrl(newValue)
         }
         .sheet(isPresented: $showShareSheet) {
             ShareSheet(items: [cachedQrUrl])

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Ratchet.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Ratchet.kt
@@ -1,6 +1,6 @@
 package net.af0.where.e2ee
 
-/**
+/*
  * Ratchet KDF functions.
  *
  * KDF_RK – DH ratchet step. Inputs the current root key as HKDF salt and a fresh DH output


### PR DESCRIPTION
This PR addresses the issue where the "You" button was misleadingly showing the user's name and opening a settings dialog instead of zooming to the user's location.

Key changes:
- **Map UI**: The "You" chip at the bottom of the map on both platforms now always says "You" and zooms the map to the user's current location when clicked.
- **Settings Relocation**: The "Change my name" option has been moved to the sharing (invite) dialog, clarifying that this name is what contacts see when adding the user.
- **Dynamic Updates**: Changing the display name while the sharing dialog is open now immediately re-generates the QR code to include the updated name.
- **Cleanup**: Standalone user settings dialogs and associated states have been removed from both Android and iOS applications.

---
*PR created automatically by Jules for task [3136076969231017364](https://jules.google.com/task/3136076969231017364) started by @danmarg*