### PR TITLE
Restart LocationService after device reboot

### DIFF
--- a/android/src/androidMain/AndroidManifest.xml
+++ b/android/src/androidMain/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".WhereApplication"
@@ -37,6 +38,16 @@
             android:name=".LocationService"
             android:foregroundServiceType="location"
             android:exported="false" />
+
+        <receiver
+            android:name=".BootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
+            </intent-filter>
+        </receiver>
 
     </application>
 </manifest>

--- a/android/src/androidMain/kotlin/net/af0/where/BootReceiver.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/BootReceiver.kt
@@ -1,0 +1,21 @@
+package net.af0.where
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+private const val TAG = "BootReceiver"
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action
+        if (action == Intent.ACTION_BOOT_COMPLETED ||
+            action == "android.intent.action.QUICKBOOT_POWERON" ||
+            action == "com.htc.intent.action.QUICKBOOT_POWERON"
+        ) {
+            Log.d(TAG, "Starting LocationService after boot: $action")
+            context.startForegroundService(Intent(context, LocationService::class.java))
+        }
+    }
+}

--- a/android/src/androidUnitTest/kotlin/net/af0/where/BootReceiverTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/BootReceiverTest.kt
@@ -1,0 +1,41 @@
+package net.af0.where
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = WhereApplication::class)
+class BootReceiverTest {
+    @Test
+    fun testOnReceiveStartsService() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val receiver = BootReceiver()
+        val intent = Intent(Intent.ACTION_BOOT_COMPLETED)
+
+        receiver.onReceive(context, intent)
+
+        val nextIntent = shadowOf(context as android.app.Application).nextStartedService
+        assertNotNull(nextIntent)
+        assertEquals(LocationService::class.java.name, nextIntent.component?.className)
+    }
+
+    @Test
+    fun testOnReceiveIgnoresOtherActions() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val receiver = BootReceiver()
+        val intent = Intent(Intent.ACTION_ANSWER)
+
+        receiver.onReceive(context, intent)
+
+        val nextIntent = shadowOf(context as android.app.Application).nextStartedService
+        assertEquals(null, nextIntent)
+    }
+}


### PR DESCRIPTION
This change implements a mechanism to restart the `LocationService` foreground service after an Android device reboots.

Key changes:
- Created `BootReceiver` class to handle `ACTION_BOOT_COMPLETED` and start the service.
- Added `RECEIVE_BOOT_COMPLETED` permission and registered the receiver in `AndroidManifest.xml`.
- Included support for `QUICKBOOT_POWERON` (common in HTC and other devices) for better compatibility.
- Added Robolectric unit tests to verify the receiver's functionality.

---
*PR created automatically by Jules for task [6956513556370890645](https://jules.google.com/task/6956513556370890645) started by @danmarg*