### PR TITLE
Fix background location synchronization and throttling issues (#64)

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -90,6 +90,8 @@ class LocationService : Service() {
                     if (locationSource.isSharingLocation.value) {
                         sendLocationIfNeeded(loc.first, loc.second, isHeartbeat = false)
                     }
+                    // When our own location changes, trigger a poll for friend updates.
+                    // This ensures that whenever we share, we also receive.
                     locationSource.wakePoll()
                 }
             }
@@ -153,7 +155,15 @@ class LocationService : Service() {
     internal fun shouldPollFriends(
         rapid: Boolean,
         inForeground: Boolean,
-    ): Boolean = inForeground || rapid
+    ): Boolean {
+        // We always poll if we're in the foreground or in rapid-poll mode (pairing).
+        if (inForeground || rapid) return true
+
+        // If we're in the background, we only poll if our own location was recently
+        // updated. This allows us to sync friends whenever the OS wakes us for a fix.
+        val now = clock()
+        return now - lastSentTime < 30_000L
+    }
 
     @VisibleForTesting
     internal fun pollInterval(
@@ -231,7 +241,7 @@ class LocationService : Service() {
             sendLock.withLock {
                 val canSend =
                     force || lastSentTime == 0L ||
-                        (!isHeartbeat && now - lastSentTime > 15_000L) ||
+                        !isHeartbeat ||
                         (isHeartbeat && now - lastSentTime > 300_000L)
                 if (canSend) {
                     lastSentTime = now

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
@@ -70,14 +70,14 @@ class LocationServiceTest {
             io.mockk.coVerify(exactly = 1) { mockClient.sendLocation(any(), any(), any()) }
             assertTrue(service.lastSentTime > 0)
 
-            // 2. Immediate second send (throttled)
+            // 2. Immediate second send (no longer throttled for non-heartbeat)
             service.sendLocationIfNeeded(37.8, -122.5, false, false)
-            io.mockk.coVerify(exactly = 1) { mockClient.sendLocation(any(), any(), any()) }
-
-            // 3. Send after 16s (not throttled - movement throttle is 15s)
-            currentTime += 16_000L
-            service.sendLocationIfNeeded(37.9, -122.6, false, false)
             io.mockk.coVerify(exactly = 2) { mockClient.sendLocation(any(), any(), any()) }
+
+            // 3. Send after 1s
+            currentTime += 1_000L
+            service.sendLocationIfNeeded(37.9, -122.6, false, false)
+            io.mockk.coVerify(exactly = 3) { mockClient.sendLocation(any(), any(), any()) }
         }
 
     @Test
@@ -150,9 +150,19 @@ class LocationServiceTest {
     }
 
     @Test
-    fun testShouldPollFriends_BackgroundNotRapid_ShouldNotPoll() {
+    fun testShouldPollFriends_BackgroundNotRapid_NotRecentlySent_ShouldNotPoll() {
         val service = Robolectric.buildService(LocationService::class.java).get()
+        service.lastSentTime = 100_000L
+        LocationService.clock = { 200_000L } // 100s later
         assertFalse(service.shouldPollFriends(rapid = false, inForeground = false))
+    }
+
+    @Test
+    fun testShouldPollFriends_BackgroundNotRapid_RecentlySent_ShouldPoll() {
+        val service = Robolectric.buildService(LocationService::class.java).get()
+        service.lastSentTime = 100_000L
+        LocationService.clock = { 110_000L } // 10s later
+        assertTrue(service.shouldPollFriends(rapid = false, inForeground = false))
     }
 
     @Test

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -44,6 +44,8 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         Task { @MainActor in
             self.location = loc
             LocationSyncService.shared.sendLocation(lat: loc.coordinate.latitude, lng: loc.coordinate.longitude)
+            // Ensure we also poll for updates when the OS wakes us for a location fix.
+            await LocationSyncService.shared.pollAll(updateUi: false)
         }
     }
 


### PR DESCRIPTION
This change improves the reliability and frequency of location updates and friend synchronization when the app is in the background. On both platforms, it implements a bi-directional sync strategy where friend updates are fetched whenever the user's own location is shared, leveraging the OS's location-based wake-ups. It also removes an unnecessary 15-second cooldown on Android for non-heartbeat updates to improve responsiveness.

---
*PR created automatically by Jules for task [7477066688489227325](https://jules.google.com/task/7477066688489227325) started by @danmarg*