### PR TITLE
Refactor iOS polling and fix pairing flow bugs

### DIFF
--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -140,7 +140,7 @@ final class LocationSyncService: ObservableObject {
     private var isPollInFlight = false
     /// Overridable in tests to simulate foreground/background without UIKit.
     var isInForeground: () -> Bool = { UIApplication.shared.applicationState == .active }
-    private static let rapidPollInterval: TimeInterval = 2.0
+    private static let rapidPollInterval: TimeInterval = 1.0
     private static let normalPollInterval: TimeInterval = 60.0
     private var visibleUsersCancellables = Set<AnyCancellable>()
 

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -137,12 +137,13 @@ final class LocationSyncService: ObservableObject {
     var isInviteActive: Bool { if case .pending = inviteState { return true } else { return false } }
 
     var lastRapidPollTrigger: Date = Date(timeIntervalSince1970: 0)  // internal for testing
-    var pollTimer: Timer?  // internal for testing
-    private var isPollInFlight = false
+    var pollTask: Task<Void, Never>? = nil
+    var debounceTask: Task<Void, Never>? = nil
+
     /// Overridable in tests to simulate foreground/background without UIKit.
     var isInForeground: () -> Bool = { UIApplication.shared.applicationState == .active }
-    private static let rapidPollInterval: TimeInterval = 1.0
-    private static let normalPollInterval: TimeInterval = 10.0
+    private static let rapidPollInterval: TimeInterval = 2.0
+    private static let normalPollInterval: TimeInterval = 60.0
     private var visibleUsersCancellables = Set<AnyCancellable>()
 
     private var lastSentLocation: (lat: Double, lng: Double)? = nil
@@ -216,7 +217,13 @@ final class LocationSyncService: ObservableObject {
             }
             .store(in: &visibleUsersCancellables)
 
-        startPolling()
+        Task {
+            // Clear any stale invite from a previous session before first poll.
+            if (try? await e2eeStore.pendingQrPayload()) ?? nil != nil {
+                try? await e2eeStore.clearInvite()
+            }
+            startPolling()
+        }
     }
 
     func isRapidPolling() async -> Bool {
@@ -245,75 +252,59 @@ final class LocationSyncService: ObservableObject {
         visibleUsers = result
     }
 
-    // Poll timer: handles inbound friend-location polling and the outbound heartbeat.
+    // Poll loop: handles inbound friend-location polling and the outbound heartbeat.
     // Movement-driven sends are handled by LocationManager's CoreLocation delegate.
     // Since UIBackgroundModes contains "location", CoreLocation wakes the app in the
     // background and delivers didUpdateLocations callbacks — no BGAppRefreshTask required.
     // However, when the device is stationary CoreLocation may not fire for extended periods,
-    // so the poll timer also triggers a heartbeat send (throttled to 5 minutes by sendLocation).
+    // so the poll loop also triggers a heartbeat send (throttled to 5 minutes by sendLocation).
     func startPolling() {
         logger.debug("startPolling called")
-        guard pollTimer?.isValid != true else { return }
-        schedulePollTimer(interval: Self.normalPollInterval)
-        Task {
-            // Clear any stale invite from a previous session before first poll.
-            if (try? await e2eeStore.pendingQrPayload()) ?? nil != nil {
-                try? await e2eeStore.clearInvite()
+        pollTask?.cancel()
+        pollTask = Task { @MainActor [weak self] in
+            guard let self = self else { return }
+            while !Task.isCancelled {
+                let inForeground = isInForeground()
+                let isRapid = await isRapidPolling()
+
+                // Only fetch friends' locations when there's a user to see the result.
+                if inForeground || isRapid {
+                    await pollAll(updateUi: true)
+                }
+                // Heartbeat always runs: covers the stationary background case where
+                // didUpdateLocations never fires (distanceFilter suppresses updates).
+                if let loc = LocationManager.shared.lastLocation {
+                    sendLocation(lat: loc.coordinate.latitude, lng: loc.coordinate.longitude, isHeartbeat: true)
+                }
+
+                // Slow the timer down in the background — it only needs to fire for heartbeats.
+                let targetInterval: TimeInterval
+                if isRapid {
+                    targetInterval = Self.rapidPollInterval
+                } else if inForeground {
+                    targetInterval = Self.normalPollInterval       // 60s
+                } else {
+                    targetInterval = 5 * 60                       // 5 min: matches heartbeat throttle
+                }
+
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(targetInterval * 1_000_000_000))
+                } catch {
+                    // Task was cancelled, exit the loop.
+                    break
+                }
             }
-            await firePoll()
         }
     }
 
     func stopPolling() {
-        pollTimer?.invalidate()
-        pollTimer = nil
-    }
-
-    private func schedulePollTimer(interval: TimeInterval) {
-        pollTimer?.invalidate()
-        pollTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                await self?.firePoll()
-            }
-        }
-    }
-
-    func firePoll() async {  // internal for testing
-        guard !isPollInFlight else { return }
-        isPollInFlight = true
-        defer { isPollInFlight = false }
-
-        let inForeground = isInForeground()
-        let isRapid = await isRapidPolling()
-
-        // Only fetch friends' locations when there's a user to see the result.
-        if inForeground || isRapid {
-            await pollAll(updateUi: true)
-        }
-        // Heartbeat always runs: covers the stationary background case where
-        // didUpdateLocations never fires (distanceFilter suppresses updates).
-        if let loc = LocationManager.shared.lastLocation {
-            sendLocation(lat: loc.coordinate.latitude, lng: loc.coordinate.longitude, isHeartbeat: true)
-        }
-
-        // Slow the timer down in the background — it only needs to fire for heartbeats.
-        let targetInterval: TimeInterval
-        if isRapid {
-            targetInterval = Self.rapidPollInterval
-        } else if inForeground {
-            targetInterval = Self.normalPollInterval       // 10s
-        } else {
-            targetInterval = 5 * 60                       // 5 min: matches heartbeat throttle
-        }
-        if let t = pollTimer, abs(t.timeInterval - targetInterval) > 0.1 {
-            schedulePollTimer(interval: targetInterval)
-        }
+        pollTask?.cancel()
+        pollTask = nil
     }
 
     private func triggerRapidPoll() {
         lastRapidPollTrigger = Date()
-        schedulePollTimer(interval: Self.rapidPollInterval)
-        Task { await firePoll() }
+        wakePoll()
     }
 
     @MainActor
@@ -481,7 +472,7 @@ final class LocationSyncService: ObservableObject {
                     await pollAll(updateUi: true)
                     friends = try await e2eeStore.listFriends()
                     updateVisibleUsers()
-                    wakePoll()
+                    triggerRapidPoll()
 
                     updateStatus(nil)
                 } catch {
@@ -533,12 +524,20 @@ final class LocationSyncService: ObservableObject {
     }
 
     func wakePoll() {
-        Task { await firePoll() }
+        debounceTask?.cancel()
+        debounceTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: 10_000_000) // 10ms debounce
+            } catch {
+                return
+            }
+            self?.startPolling()
+        }
     }
 
     func resetRapidPoll() {
         lastRapidPollTrigger = Date(timeIntervalSince1970: 0)
-        schedulePollTimer(interval: Self.normalPollInterval)
+        startPolling()
     }
 
     func renameFriend(id: String, newName: String) async {
@@ -646,8 +645,8 @@ final class LocationSyncService: ObservableObject {
                 suggestedName: suggestedName
             )
 
-            pendingInitPayload = initPayload
             inviteState = .none   // dismiss the QR sheet so the naming alert can appear
+            pendingInitPayload = initPayload
             triggerRapidPoll()
             break
         }

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -4,7 +4,6 @@ import os
 import UIKit
 import CoreLocation
 import Combine
-
 private let logger = Logger(subsystem: "net.af0.where", category: "LocationSync")
 
 @inline(__always)
@@ -137,9 +136,8 @@ final class LocationSyncService: ObservableObject {
     var isInviteActive: Bool { if case .pending = inviteState { return true } else { return false } }
 
     var lastRapidPollTrigger: Date = Date(timeIntervalSince1970: 0)  // internal for testing
-    var pollTask: Task<Void, Never>? = nil
-    var debounceTask: Task<Void, Never>? = nil
-
+    var pollTimer: Timer?  // internal for testing
+    private var isPollInFlight = false
     /// Overridable in tests to simulate foreground/background without UIKit.
     var isInForeground: () -> Bool = { UIApplication.shared.applicationState == .active }
     private static let rapidPollInterval: TimeInterval = 2.0
@@ -252,59 +250,71 @@ final class LocationSyncService: ObservableObject {
         visibleUsers = result
     }
 
-    // Poll loop: handles inbound friend-location polling and the outbound heartbeat.
+    // Poll timer: handles inbound friend-location polling and the outbound heartbeat.
     // Movement-driven sends are handled by LocationManager's CoreLocation delegate.
     // Since UIBackgroundModes contains "location", CoreLocation wakes the app in the
     // background and delivers didUpdateLocations callbacks — no BGAppRefreshTask required.
     // However, when the device is stationary CoreLocation may not fire for extended periods,
-    // so the poll loop also triggers a heartbeat send (throttled to 5 minutes by sendLocation).
+    // so the poll timer also triggers a heartbeat send (throttled to 5 minutes by sendLocation).
     func startPolling() {
         logger.debug("startPolling called")
-        pollTask?.cancel()
-        pollTask = Task { @MainActor [weak self] in
-            guard let self = self else { return }
-            while !Task.isCancelled {
-                let inForeground = isInForeground()
-                let isRapid = await isRapidPolling()
-
-                // Only fetch friends' locations when there's a user to see the result.
-                if inForeground || isRapid {
-                    await pollAll(updateUi: true)
-                }
-                // Heartbeat always runs: covers the stationary background case where
-                // didUpdateLocations never fires (distanceFilter suppresses updates).
-                if let loc = LocationManager.shared.lastLocation {
-                    sendLocation(lat: loc.coordinate.latitude, lng: loc.coordinate.longitude, isHeartbeat: true)
-                }
-
-                // Slow the timer down in the background — it only needs to fire for heartbeats.
-                let targetInterval: TimeInterval
-                if isRapid {
-                    targetInterval = Self.rapidPollInterval
-                } else if inForeground {
-                    targetInterval = Self.normalPollInterval       // 60s
-                } else {
-                    targetInterval = 5 * 60                       // 5 min: matches heartbeat throttle
-                }
-
-                do {
-                    try await Task.sleep(nanoseconds: UInt64(targetInterval * 1_000_000_000))
-                } catch {
-                    // Task was cancelled, exit the loop.
-                    break
-                }
-            }
+        guard pollTimer?.isValid != true else { return }
+        schedulePollTimer(interval: Self.normalPollInterval)
+        Task {
+            await firePoll()
         }
     }
 
     func stopPolling() {
-        pollTask?.cancel()
-        pollTask = nil
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+
+    private func schedulePollTimer(interval: TimeInterval) {
+        pollTimer?.invalidate()
+        pollTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.firePoll()
+            }
+        }
+    }
+
+    func firePoll() async {  // internal for testing
+        guard !isPollInFlight else { return }
+        isPollInFlight = true
+        defer { isPollInFlight = false }
+
+        let inForeground = isInForeground()
+        let isRapid = await isRapidPolling()
+
+        // Only fetch friends' locations when there's a user to see the result.
+        if inForeground || isRapid {
+            await pollAll(updateUi: true)
+        }
+        // Heartbeat always runs: covers the stationary background case where
+        // didUpdateLocations never fires (distanceFilter suppresses updates).
+        if let loc = LocationManager.shared.lastLocation {
+            sendLocation(lat: loc.coordinate.latitude, lng: loc.coordinate.longitude, isHeartbeat: true)
+        }
+
+        // Slow the timer down in the background — it only needs to fire for heartbeats.
+        let targetInterval: TimeInterval
+        if isRapid {
+            targetInterval = Self.rapidPollInterval
+        } else if inForeground {
+            targetInterval = Self.normalPollInterval       // 60s
+        } else {
+            targetInterval = 5 * 60                       // 5 min: matches heartbeat throttle
+        }
+        if let t = pollTimer, abs(t.timeInterval - targetInterval) > 0.1 {
+            schedulePollTimer(interval: targetInterval)
+        }
     }
 
     private func triggerRapidPoll() {
         lastRapidPollTrigger = Date()
-        wakePoll()
+        schedulePollTimer(interval: Self.rapidPollInterval)
+        Task { await firePoll() }
     }
 
     @MainActor
@@ -524,20 +534,18 @@ final class LocationSyncService: ObservableObject {
     }
 
     func wakePoll() {
-        debounceTask?.cancel()
-        debounceTask = Task { @MainActor [weak self] in
-            do {
-                try await Task.sleep(nanoseconds: 10_000_000) // 10ms debounce
-            } catch {
-                return
-            }
-            self?.startPolling()
-        }
+        Task { await firePoll() }
+    }
+
+    private func triggerRapidPoll() {
+        lastRapidPollTrigger = Date()
+        schedulePollTimer(interval: Self.rapidPollInterval)
+        Task { await firePoll() }
     }
 
     func resetRapidPoll() {
         lastRapidPollTrigger = Date(timeIntervalSince1970: 0)
-        startPolling()
+        schedulePollTimer(interval: Self.normalPollInterval)
     }
 
     func renameFriend(id: String, newName: String) async {

--- a/ios/Tests/WhereTests/LocationSyncServiceTests.swift
+++ b/ios/Tests/WhereTests/LocationSyncServiceTests.swift
@@ -74,70 +74,75 @@ class LocationSyncServiceTests: XCTestCase {
 
     // MARK: - firePoll foreground/background gating
 
-    func testFirePoll_ForegroundDoesPollFriends() async throws {
+    func testStartPolling_ForegroundDoesPollFriends() async throws {
         let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
         let mockClient = MockLocationClient(baseUrl: "", store: store)
         service = LocationSyncService(e2eeStore: store, locationClient: mockClient)
         service.isInForeground = { true }
         service.startPolling()
 
-        await service.firePoll()
+        // Wait for pollAll to be called
+        for _ in 0..<100 {
+            if mockClient.pollCallCount > 0 { break }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
 
         XCTAssertGreaterThan(mockClient.pollCallCount, 0, "Should poll friends when in foreground")
     }
 
-    func testFirePoll_BackgroundSkipsPollFriends() async throws {
+    func testStartPolling_BackgroundSkipsPollFriends() async throws {
         let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
         let mockClient = MockLocationClient(baseUrl: "", store: store)
         service = LocationSyncService(e2eeStore: store, locationClient: mockClient)
         service.isInForeground = { false }
         service.startPolling()
 
-        await service.firePoll()
+        // Wait a bit
+        try? await Task.sleep(nanoseconds: 100_000_000)
 
         XCTAssertEqual(mockClient.pollCallCount, 0, "Should not poll friends when in background")
     }
 
-    func testFirePoll_RapidPollsEvenInBackground() async throws {
+    func testStartPolling_RapidPollsEvenInBackground() async throws {
         let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
         let mockClient = MockLocationClient(baseUrl: "", store: store)
         service = LocationSyncService(e2eeStore: store, locationClient: mockClient)
         service.isInForeground = { false }
-        service.startPolling()
         // Put service into rapid mode by setting a recent trigger timestamp.
         service.lastRapidPollTrigger = Date()
+        service.startPolling()
 
-        await service.firePoll()
+        // Wait for pollAll to be called
+        for _ in 0..<100 {
+            if mockClient.pollCallCount > 0 { break }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
 
         XCTAssertGreaterThan(mockClient.pollCallCount, 0, "Should poll friends during rapid mode even in background")
     }
 
-    // MARK: - Timer interval selection
-
-    func testTimerInterval_Foreground_Is10s() async throws {
+    func testWakePoll() async throws {
         let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
         let mockClient = MockLocationClient(baseUrl: "", store: store)
         service = LocationSyncService(e2eeStore: store, locationClient: mockClient)
         service.isInForeground = { true }
         service.startPolling()
 
-        await service.firePoll()
+        // Wait for first poll
+        for _ in 0..<100 {
+            if mockClient.pollCallCount == 1 { break }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(mockClient.pollCallCount, 1)
 
-        XCTAssertEqual(service.pollTimer?.timeInterval ?? 0, 10.0, accuracy: 0.1,
-                       "Foreground normal poll should be 10s")
-    }
+        service.wakePoll()
 
-    func testTimerInterval_Background_Is5min() async throws {
-        let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
-        let mockClient = MockLocationClient(baseUrl: "", store: store)
-        service = LocationSyncService(e2eeStore: store, locationClient: mockClient)
-        service.isInForeground = { false }
-        service.startPolling()
-
-        await service.firePoll()
-
-        XCTAssertEqual(service.pollTimer?.timeInterval ?? 0, 300.0, accuracy: 0.1,
-                       "Background poll should slow to 5min for heartbeat-only firing")
+        // Wait for second poll (including 10ms debounce)
+        for _ in 0..<100 {
+            if mockClient.pollCallCount == 2 { break }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(mockClient.pollCallCount, 2)
     }
 
     func testIsRapidPolling() async throws {

--- a/ios/Tests/WhereTests/LocationSyncServiceTests.swift
+++ b/ios/Tests/WhereTests/LocationSyncServiceTests.swift
@@ -74,75 +74,70 @@ class LocationSyncServiceTests: XCTestCase {
 
     // MARK: - firePoll foreground/background gating
 
-    func testStartPolling_ForegroundDoesPollFriends() async throws {
+    func testFirePoll_ForegroundDoesPollFriends() async throws {
         let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
         let mockClient = MockLocationClient(baseUrl: "", store: store)
         service = LocationSyncService(e2eeStore: store, locationClient: mockClient)
         service.isInForeground = { true }
         service.startPolling()
 
-        // Wait for pollAll to be called
-        for _ in 0..<100 {
-            if mockClient.pollCallCount > 0 { break }
-            try? await Task.sleep(nanoseconds: 10_000_000)
-        }
+        await service.firePoll()
 
         XCTAssertGreaterThan(mockClient.pollCallCount, 0, "Should poll friends when in foreground")
     }
 
-    func testStartPolling_BackgroundSkipsPollFriends() async throws {
+    func testFirePoll_BackgroundSkipsPollFriends() async throws {
         let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
         let mockClient = MockLocationClient(baseUrl: "", store: store)
         service = LocationSyncService(e2eeStore: store, locationClient: mockClient)
         service.isInForeground = { false }
         service.startPolling()
 
-        // Wait a bit
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        await service.firePoll()
 
         XCTAssertEqual(mockClient.pollCallCount, 0, "Should not poll friends when in background")
     }
 
-    func testStartPolling_RapidPollsEvenInBackground() async throws {
+    func testFirePoll_RapidPollsEvenInBackground() async throws {
         let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
         let mockClient = MockLocationClient(baseUrl: "", store: store)
         service = LocationSyncService(e2eeStore: store, locationClient: mockClient)
         service.isInForeground = { false }
+        service.startPolling()
         // Put service into rapid mode by setting a recent trigger timestamp.
         service.lastRapidPollTrigger = Date()
-        service.startPolling()
 
-        // Wait for pollAll to be called
-        for _ in 0..<100 {
-            if mockClient.pollCallCount > 0 { break }
-            try? await Task.sleep(nanoseconds: 10_000_000)
-        }
+        await service.firePoll()
 
         XCTAssertGreaterThan(mockClient.pollCallCount, 0, "Should poll friends during rapid mode even in background")
     }
 
-    func testWakePoll() async throws {
+    // MARK: - Timer interval selection
+
+    func testTimerInterval_Foreground_Is60s() async throws {
         let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
         let mockClient = MockLocationClient(baseUrl: "", store: store)
         service = LocationSyncService(e2eeStore: store, locationClient: mockClient)
         service.isInForeground = { true }
         service.startPolling()
 
-        // Wait for first poll
-        for _ in 0..<100 {
-            if mockClient.pollCallCount == 1 { break }
-            try? await Task.sleep(nanoseconds: 10_000_000)
-        }
-        XCTAssertEqual(mockClient.pollCallCount, 1)
+        await service.firePoll()
 
-        service.wakePoll()
+        XCTAssertEqual(service.pollTimer?.timeInterval ?? 0, 60.0, accuracy: 0.1,
+                       "Foreground normal poll should be 60s")
+    }
 
-        // Wait for second poll (including 10ms debounce)
-        for _ in 0..<100 {
-            if mockClient.pollCallCount == 2 { break }
-            try? await Task.sleep(nanoseconds: 10_000_000)
-        }
-        XCTAssertEqual(mockClient.pollCallCount, 2)
+    func testTimerInterval_Background_Is5min() async throws {
+        let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
+        let mockClient = MockLocationClient(baseUrl: "", store: store)
+        service = LocationSyncService(e2eeStore: store, locationClient: mockClient)
+        service.isInForeground = { false }
+        service.startPolling()
+
+        await service.firePoll()
+
+        XCTAssertEqual(service.pollTimer?.timeInterval ?? 0, 300.0, accuracy: 0.1,
+                       "Background poll should slow to 5min for heartbeat-only firing")
     }
 
     func testIsRapidPolling() async throws {


### PR DESCRIPTION
This change addresses several iOS-specific issues in the LocationSyncService. It improves battery life by increasing polling intervals (60s normal, 2s rapid) and ensures a reliable state machine during the E2EE pairing flow. Specifically, it fixes a UI race condition where the naming alert was suppressed by the QR sheet dismissal, and it correctly manages the lifecycle of ephemeral pairing keys and rapid polling windows. The implementation strictly adheres to the Timer-based polling architecture to avoid race conditions seen with task-based approaches.

---
*PR created automatically by Jules for task [10511242309391034943](https://jules.google.com/task/10511242309391034943) started by @danmarg*