### PR TITLE
Fix Location double registration in LocationService

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -35,6 +35,15 @@ private const val TAG = "LocationService"
  * and the E2EE protocol work (polling, sending location).
  */
 class LocationService : Service() {
+    @VisibleForTesting
+    internal var fusedClientOverride: com.google.android.gms.location.FusedLocationProviderClient? = null
+
+    @VisibleForTesting
+    internal var e2eeStoreOverride: E2eeStore? = null
+
+    @VisibleForTesting
+    internal var locationClientOverride: LocationClient? = null
+
     private lateinit var fusedClient: com.google.android.gms.location.FusedLocationProviderClient
     private lateinit var locationCallback: LocationCallback
     private var isRegistered = false
@@ -53,10 +62,10 @@ class LocationService : Service() {
         startForeground(NOTIFICATION_ID, buildNotification())
 
         val app = application as WhereApplication
-        e2eeStore = app.e2eeStore
-        locationClient = app.locationClient
+        e2eeStore = e2eeStoreOverride ?: app.e2eeStore
+        locationClient = locationClientOverride ?: app.locationClient
+        fusedClient = fusedClientOverride ?: LocationServices.getFusedLocationProviderClient(this)
 
-        fusedClient = LocationServices.getFusedLocationProviderClient(this)
         locationCallback =
             object : LocationCallback() {
                 override fun onLocationResult(result: LocationResult) {
@@ -72,18 +81,7 @@ class LocationService : Service() {
         } catch (_: SecurityException) {
         }
 
-        val request =
-            LocationRequest.Builder(Priority.PRIORITY_BALANCED_POWER_ACCURACY, 30_000L)
-                .setMinUpdateIntervalMillis(15_000L)
-                .setMinUpdateDistanceMeters(10f)
-                .build()
-
-        try {
-            fusedClient.requestLocationUpdates(request, locationCallback, mainLooper)
-            isRegistered = true
-        } catch (_: SecurityException) {
-            stopSelf()
-        }
+        ensureLocationRegistration()
 
         serviceScope.launch { pollLoop() }
         serviceScope.launch {
@@ -139,25 +137,31 @@ class LocationService : Service() {
             }
         }
 
-        if (!isRegistered) {
-            val request =
-                LocationRequest.Builder(Priority.PRIORITY_BALANCED_POWER_ACCURACY, 30_000L)
-                    .setMinUpdateIntervalMillis(15_000L)
-                    .setMinUpdateDistanceMeters(10f)
-                    .build()
-            try {
-                fusedClient.requestLocationUpdates(request, locationCallback, mainLooper)
-                isRegistered = true
-            } catch (_: SecurityException) {
-                stopSelf()
-            }
-        }
+        ensureLocationRegistration()
         return START_STICKY
+    }
+
+    private fun ensureLocationRegistration() {
+        if (isRegistered) return
+
+        val request =
+            LocationRequest.Builder(Priority.PRIORITY_BALANCED_POWER_ACCURACY, 30_000L)
+                .setMinUpdateIntervalMillis(15_000L)
+                .setMinUpdateDistanceMeters(10f)
+                .build()
+
+        try {
+            fusedClient.requestLocationUpdates(request, locationCallback, mainLooper)
+            isRegistered = true
+        } catch (_: SecurityException) {
+            stopSelf()
+        }
     }
 
     override fun onDestroy() {
         Log.d(TAG, "onDestroy")
         fusedClient.removeLocationUpdates(locationCallback)
+        isRegistered = false
         serviceScope.cancel()
         super.onDestroy()
     }

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
@@ -1,6 +1,8 @@
 package net.af0.where
 
 import android.app.Application
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.test.runTest
 import net.af0.where.e2ee.KeyExchangeInitPayload
@@ -39,15 +41,21 @@ class LocationServiceTest {
     fun testDeduplication_BugC() {
         val controller = Robolectric.buildService(LocationService::class.java)
         val service = controller.get()
+
+        val mockFusedClient = io.mockk.mockk<com.google.android.gms.location.FusedLocationProviderClient>(relaxed = true)
+        service.fusedClientOverride = mockFusedClient
+
         controller.create()
 
         assertTrue(getServiceIsRegistered(service))
+        io.mockk.verify(exactly = 1) { mockFusedClient.requestLocationUpdates(any<LocationRequest>(), any<LocationCallback>(), any<android.os.Looper>()) }
 
         // Multiple startCommand calls must not attempt to re-register location updates.
         controller.startCommand(0, 1)
         controller.startCommand(0, 2)
 
         assertTrue(getServiceIsRegistered(service))
+        io.mockk.verify(exactly = 1) { mockFusedClient.requestLocationUpdates(any<LocationRequest>(), any<LocationCallback>(), any<android.os.Looper>()) }
     }
 
     @Test
@@ -56,14 +64,11 @@ class LocationServiceTest {
             var currentTime = 100_000L
             LocationService.clock = { currentTime }
 
+            val mockClient = io.mockk.mockk<LocationClient>(relaxed = true)
             val controller = Robolectric.buildService(LocationService::class.java)
             val service = controller.get()
+            service.locationClientOverride = mockClient
             controller.create()
-
-            val mockClient = io.mockk.mockk<LocationClient>(relaxed = true)
-            val locationClientField = LocationService::class.java.getDeclaredField("locationClient")
-            locationClientField.isAccessible = true
-            locationClientField.set(service, mockClient)
 
             // 1. Initial send
             service.sendLocationIfNeeded(37.7, -122.4, false, false)
@@ -86,14 +91,11 @@ class LocationServiceTest {
             var currentTime = 1_000_000L
             LocationService.clock = { currentTime }
 
+            val mockClient = io.mockk.mockk<LocationClient>(relaxed = true)
             val controller = Robolectric.buildService(LocationService::class.java)
             val service = controller.get()
+            service.locationClientOverride = mockClient
             controller.create()
-
-            val mockClient = io.mockk.mockk<LocationClient>(relaxed = true)
-            val locationClientField = LocationService::class.java.getDeclaredField("locationClient")
-            locationClientField.isAccessible = true
-            locationClientField.set(service, mockClient)
 
             // 1. Initial send
             service.sendLocationIfNeeded(37.7, -122.4, false, false)


### PR DESCRIPTION
Fixed Issue #79 where `LocationService` could perform redundant location callback registrations. Introduced `ensureLocationRegistration()` with an `isRegistered` guard and improved service testability via dependency injection overrides.

---
*PR created automatically by Jules for task [11729879009420890459](https://jules.google.com/task/11729879009420890459) started by @danmarg*