### PR TITLE
Remove unused Ed25519 implementation

### DIFF
--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
@@ -2,12 +2,9 @@ package net.af0.where
 
 import android.app.Application
 import android.content.Intent
-import com.google.android.gms.location.LocationCallback
-import com.google.android.gms.location.LocationRequest
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
@@ -328,10 +325,10 @@ class LocationServiceTest {
 
             val mockClient = io.mockk.mockk<LocationClient>(relaxed = true)
             service.locationClientOverride = mockClient
-            
+
             val mockFused = io.mockk.mockk<com.google.android.gms.location.FusedLocationProviderClient>(relaxed = true)
             service.fusedClientOverride = mockFused
-            
+
             val mockStore = io.mockk.mockk<net.af0.where.e2ee.E2eeStore>(relaxed = true)
             service.e2eeStoreOverride = mockStore
 

--- a/docs/IMPLEMENTATION-CHECKLIST.md
+++ b/docs/IMPLEMENTATION-CHECKLIST.md
@@ -57,7 +57,7 @@ Split into client-crypto, client-app, and server.
 - **Bob: Periodically generate and post `PreKeyBundle`**:
   - Generate a batch of X25519 keypairs (OPKs).
   - Post public keys with unique IDs to the shared mailbox.
-  - **Authenticate bundle with HMAC**: `HMAC-SHA-256(K_bundle, v || token || keys_json_canonical)`. (No Ed25519; `K_bundle` is session-derived.)
+  - **Authenticate bundle with HMAC**: `HMAC-SHA-256(K_bundle, v || token || keys_json_canonical)`. (`K_bundle` is session-derived.)
 - **Alice: Consume OPK for Epoch Rotation**:
   - Cache Bob's OPKs from mailbox. Verify HMAC before use.
   - On epoch boundary (every `T` minutes), pop one OPK.

--- a/docs/e2ee-location-sync.md
+++ b/docs/e2ee-location-sync.md
@@ -891,7 +891,7 @@ With this design:
 | Random number generation | OS CSPRNG | Ephemeral key generation | `SecureRandom` (Android) / `SecRandomCopyBytes` (iOS) |
 
 **Library recommendations:**
-- **Kotlin Multiplatform:** Use [ionspin/kotlin-multiplatform-libsodium](https://github.com/ionspin/kotlin-multiplatform-libsodium) for all cryptographic primitives (X25519, ChaCha20-Poly1305, SHA-256, HMAC-SHA-256, Ed25519). Libsodium provides a unified API across JVM, Android, and iOS, eliminating platform-specific implementation variance. All crypto operations are common-code `expect/actual` implementations.
+- **Kotlin Multiplatform:** Use [ionspin/kotlin-multiplatform-libsodium](https://github.com/ionspin/kotlin-multiplatform-libsodium) for all cryptographic primitives (X25519, ChaCha20-Poly1305, SHA-256, HMAC-SHA-256). Libsodium provides a unified API across JVM, Android, and iOS, eliminating platform-specific implementation variance. All crypto operations are common-code `expect/actual` implementations.
 - **Android / Kotlin:** Libsodium bindings use `libsodium.so` (statically linked). Store root keys in Android Keystore where supported; a Keystore-backed wrapper key can protect the master key material.
 - **iOS / Swift:** Libsodium bindings use the native `libsodium` framework (iOS includes sodium.dylib). Key material persists in the Secure Enclave-backed Keychain. SwiftUI calls the KMP shared module for crypto operations.
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/CryptoPrimitives.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/CryptoPrimitives.kt
@@ -32,33 +32,6 @@ internal expect fun x25519(
     theirPub: ByteArray,
 ): ByteArray
 
-/** Generate a fresh Ed25519 keypair from the platform CSPRNG. */
-expect fun generateEd25519KeyPair(): RawKeyPair
-
-/**
- * Ed25519 sign.
- * @param priv 32-byte Ed25519 private key seed
- * @param message arbitrary message bytes
- * @return 64-byte signature
- */
-internal expect fun ed25519Sign(
-    priv: ByteArray,
-    message: ByteArray,
-): ByteArray
-
-/**
- * Ed25519 verify.
- * @param pub 32-byte Ed25519 public key
- * @param message message that was signed
- * @param sig 64-byte signature
- * @return true iff signature is valid
- */
-internal expect fun ed25519Verify(
-    pub: ByteArray,
-    message: ByteArray,
-    sig: ByteArray,
-): Boolean
-
 /**
  * AEAD encrypt (ChaCha20-Poly1305 IETF).
  * @param key   32-byte key

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Raw X25519 or Ed25519 keypair. Both fields are 32-byte little-endian representations
- * as defined by RFC 7748 / RFC 8032.
+ * Raw X25519 keypair. Both fields are 32-byte little-endian representations
+ * as defined by RFC 7748.
  */
 data class RawKeyPair(val priv: ByteArray, val pub: ByteArray) {
     override fun equals(other: Any?): Boolean = other is RawKeyPair && priv.contentEquals(other.priv) && pub.contentEquals(other.pub)

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/CryptoPrimitivesVectorTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/CryptoPrimitivesVectorTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
  * cinterop; on JVM/Android they use libsodium bindings.
  *
  * Catching a failure here on one platform means that platform's implementation
- * diverges from the spec — most likely an Ed25519 seed-format mismatch.
+ * diverges from the spec.
  */
 class CryptoPrimitivesVectorTest {
     companion object {
@@ -99,76 +99,6 @@ class CryptoPrimitivesVectorTest {
             aliceShared,
             bobShared,
             "Shared secrets must match",
-        )
-    }
-
-    // -----------------------------------------------------------------------
-    // Ed25519 (RFC 8032 §5.1 Test Vector 1)
-    //
-    // CRITICAL: this vector catches private-key seed-format mismatches between
-    // Apple Security framework and BouncyCastle.  Both must treat the 32-byte
-    // private key as the seed (random nonce), not the expanded scalar.
-    // -----------------------------------------------------------------------
-
-    @Test
-    fun `ed25519 RFC 8032 test vector 1 round-trip`() {
-        // RFC 8032 §5.1.7: Ed25519 Test Vectors, Vector 1
-        // This tests that a signature produced by our implementation
-        // can be verified by our implementation.
-        val kp = generateEd25519KeyPair()
-        val msg = ByteArray(0) // empty message (like RFC vector 1)
-
-        val sig = ed25519Sign(kp.priv, msg)
-        assertTrue(
-            ed25519Verify(kp.pub, msg, sig),
-            "Signature must verify with the same implementation",
-        )
-    }
-
-    @Test
-    fun `ed25519 verify RFC 8032 vector 1 signature`() {
-        val pub =
-            hex(
-                "d75a980182b10ab7d54bfed3c964073a" +
-                    "0ee172f3daa62325af021a68f707511a",
-            )
-        // RFC 8032 §5.1 Test Vector 1: empty message
-        val sig =
-            hex(
-                "e5564300c360ac729086e2cc806e828a" +
-                    "84877f1eb8e5d974d873e06522490155" +
-                    "5fb8821590a33bacc61e39701cf9b46b" +
-                    "d25bf5f0595bbe24655141438e7a100b",
-            )
-        assertTrue(
-            ed25519Verify(pub, ByteArray(0), sig),
-            "RFC 8032 test vector 1 signature must verify",
-        )
-    }
-
-    @Test
-    fun `ed25519 rejects invalid signature`() {
-        val pub =
-            hex(
-                "d75a980182b10ab7d54bfed3c964073a" +
-                    "0ee172f3daa62325af021a68f707511a",
-            )
-        val badSig = ByteArray(64) // all-zero signature is always invalid
-        assertTrue(
-            !ed25519Verify(pub, ByteArray(0), badSig),
-            "All-zero signature must not verify",
-        )
-    }
-
-    @Test
-    fun `ed25519 round-trip sign and verify`() {
-        val kp = generateEd25519KeyPair()
-        val msg = "hello world".encodeToByteArray()
-        val sig = ed25519Sign(kp.priv, msg)
-        assertTrue(ed25519Verify(kp.pub, msg, sig))
-        assertTrue(
-            !ed25519Verify(kp.pub, msg + byteArrayOf(0), sig),
-            "Signature must not verify for different message",
         )
     }
 

--- a/shared/src/iosMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
+++ b/shared/src/iosMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
@@ -5,7 +5,6 @@ package net.af0.where.e2ee
 import com.ionspin.kotlin.crypto.aead.AuthenticatedEncryptionWithAssociatedData
 import com.ionspin.kotlin.crypto.box.Box
 import com.ionspin.kotlin.crypto.hash.Hash
-import com.ionspin.kotlin.crypto.signature.Signature
 import com.ionspin.kotlin.crypto.util.LibsodiumRandom
 
 // ---------------------------------------------------------------------------
@@ -75,38 +74,6 @@ internal actual fun x25519(
     theirPub: ByteArray,
 ): ByteArray {
     return Box.beforeNM(theirPub.toUByteArray(), myPriv.toUByteArray()).toByteArray()
-}
-
-// ---------------------------------------------------------------------------
-// Ed25519
-// ---------------------------------------------------------------------------
-
-actual fun generateEd25519KeyPair(): RawKeyPair {
-    val keyPair = Signature.keypair()
-    return RawKeyPair(
-        keyPair.secretKey.toByteArray(),
-        keyPair.publicKey.toByteArray(),
-    )
-}
-
-internal actual fun ed25519Sign(
-    priv: ByteArray,
-    message: ByteArray,
-): ByteArray {
-    return Signature.detached(message.toUByteArray(), priv.toUByteArray()).toByteArray()
-}
-
-internal actual fun ed25519Verify(
-    pub: ByteArray,
-    message: ByteArray,
-    sig: ByteArray,
-): Boolean {
-    return try {
-        Signature.verifyDetached(sig.toUByteArray(), message.toUByteArray(), pub.toUByteArray())
-        true
-    } catch (_: Exception) {
-        false
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
+++ b/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
@@ -5,7 +5,6 @@ package net.af0.where.e2ee
 import com.ionspin.kotlin.crypto.aead.AuthenticatedEncryptionWithAssociatedData
 import com.ionspin.kotlin.crypto.box.Box
 import com.ionspin.kotlin.crypto.hash.Hash
-import com.ionspin.kotlin.crypto.signature.Signature
 import com.ionspin.kotlin.crypto.util.LibsodiumRandom
 
 // ---------------------------------------------------------------------------
@@ -75,38 +74,6 @@ internal actual fun x25519(
     theirPub: ByteArray,
 ): ByteArray {
     return Box.beforeNM(theirPub.toUByteArray(), myPriv.toUByteArray()).toByteArray()
-}
-
-// ---------------------------------------------------------------------------
-// Ed25519
-// ---------------------------------------------------------------------------
-
-actual fun generateEd25519KeyPair(): RawKeyPair {
-    val keyPair = Signature.keypair()
-    return RawKeyPair(
-        keyPair.secretKey.toByteArray(),
-        keyPair.publicKey.toByteArray(),
-    )
-}
-
-internal actual fun ed25519Sign(
-    priv: ByteArray,
-    message: ByteArray,
-): ByteArray {
-    return Signature.detached(message.toUByteArray(), priv.toUByteArray()).toByteArray()
-}
-
-internal actual fun ed25519Verify(
-    pub: ByteArray,
-    message: ByteArray,
-    sig: ByteArray,
-): Boolean {
-    return try {
-        Signature.verifyDetached(sig.toUByteArray(), message.toUByteArray(), pub.toUByteArray())
-        true
-    } catch (_: Exception) {
-        false
-    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Removed Ed25519 from the repository's cryptographic implementation (CryptoPrimitives) and documentation, as it was not used by the application logic. Verified that all tests pass and that the remaining cryptographic primitives (X25519, ChaCha20-Poly1305, etc.) continue to function correctly.

---
*PR created automatically by Jules for task [9404245284810815622](https://jules.google.com/task/9404245284810815622) started by @danmarg*