### PR TITLE
Fix #119: Add MITM key substitution test for pairing flow

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
@@ -190,9 +190,10 @@ fun FriendsSheet(
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
-                                val ackStale = friend.isInitiator &&
-                                    friend.lastAckTs != Long.MAX_VALUE &&
-                                    System.currentTimeMillis() / 1000 - friend.lastAckTs > E2eeStore.ACK_TIMEOUT_SECONDS
+                                val ackStale =
+                                    friend.isInitiator &&
+                                        friend.lastAckTs != Long.MAX_VALUE &&
+                                        System.currentTimeMillis() / 1000 - friend.lastAckTs > E2eeStore.ACK_TIMEOUT_SECONDS
                                 if (ackStale) {
                                     Text(
                                         "Not receiving this friend's acks — location sharing paused",

--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -200,8 +200,8 @@ class LocationService : Service() {
         when {
             rapid -> 2_000L
             inForeground -> 10_000L
-            isSharingLocation -> 5 * 60 * 1000L      // heartbeat + friend poll
-            else -> 30 * 60 * 1000L                  // maintenance-only (Ratchet Acks)
+            isSharingLocation -> 5 * 60 * 1000L // heartbeat + friend poll
+            else -> 30 * 60 * 1000L // maintenance-only (Ratchet Acks)
         }
 
     @VisibleForTesting

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -85,8 +85,11 @@ class LocationViewModel(
 
     val ownLocation: StateFlow<UserLocation?> =
         combine(locationSource.lastLocation, isSharingLocation) { myLoc, sharing ->
-            if (myLoc != null && sharing) UserLocation("", myLoc.first, myLoc.second, clock() / 1000)
-            else null
+            if (myLoc != null && sharing) {
+                UserLocation("", myLoc.first, myLoc.second, clock() / 1000)
+            } else {
+                null
+            }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     val visibleUsers: StateFlow<List<UserLocation>> =

--- a/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
@@ -131,11 +131,12 @@ fun MapScreen(
 
     LaunchedEffect(zoomToUserId) {
         val id = zoomToUserId ?: return@LaunchedEffect
-        val target = if (id == "__own__") {
-            ownLocation?.let { LatLng(it.lat, it.lng) }
-        } else {
-            users.find { it.userId == id }?.let { LatLng(it.lat, it.lng) }
-        }
+        val target =
+            if (id == "__own__") {
+                ownLocation?.let { LatLng(it.lat, it.lng) }
+            } else {
+                users.find { it.userId == id }?.let { LatLng(it.lat, it.lng) }
+            }
         if (target != null) {
             cameraPositionState.animate(CameraUpdateFactory.newLatLngZoom(target, 15f))
         }

--- a/android/src/androidMain/kotlin/net/af0/where/SharedPrefsE2eeStorage.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/SharedPrefsE2eeStorage.kt
@@ -9,13 +9,14 @@ import androidx.security.crypto.MasterKey
 import net.af0.where.e2ee.E2eeStorage
 
 class SharedPrefsE2eeStorage(context: Context) : E2eeStorage {
-    private val prefs = EncryptedSharedPreferences.create(
-        context,
-        "e2ee_prefs",
-        buildMasterKey(context),
-        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-    )
+    private val prefs =
+        EncryptedSharedPreferences.create(
+            context,
+            "e2ee_prefs",
+            buildMasterKey(context),
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
 
     override fun getString(key: String): String? = prefs.getString(key, null)
 

--- a/android/src/androidUnitTest/kotlin/net/af0/where/TestWhereApplication.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/TestWhereApplication.kt
@@ -9,7 +9,10 @@ private class InMemoryE2eeStorage : E2eeStorage {
 
     override fun getString(key: String): String? = data[key]
 
-    override fun putString(key: String, value: String) {
+    override fun putString(
+        key: String,
+        value: String,
+    ) {
         data[key] = value
     }
 }

--- a/server/src/main/kotlin/net/af0/where/Server.kt
+++ b/server/src/main/kotlin/net/af0/where/Server.kt
@@ -112,7 +112,7 @@ class MailboxState {
         postTimes.forEach { (token, _) ->
             postTimes.computeIfPresent(token) { _, q ->
                 q.removeIf { it < now - rateLimitWindowMs }
-                if (q.isEmpty()) null else q   // null return removes the entry
+                if (q.isEmpty()) null else q // null return removes the entry
             }
         }
         mailboxes.forEach { (token, _) ->

--- a/server/src/test/kotlin/net/af0/where/MailboxTest.kt
+++ b/server/src/test/kotlin/net/af0/where/MailboxTest.kt
@@ -175,7 +175,7 @@ class MailboxTest {
         val state = MailboxState()
         val token = "evicttoken0000002"
         state.post(token, JsonPrimitive("msg"))
-        state.drain(token)  // empties the mailbox queue
+        state.drain(token) // empties the mailbox queue
 
         // Evict — the mailbox queue is empty so the entry should be removed.
         state.evictForTest(rateLimitWindowMs = 0)

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Fingerprint.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Fingerprint.kt
@@ -35,14 +35,16 @@ fun safetyNumber(
  */
 fun formatSafetyNumber(sn: ByteArray): String {
     require(sn.size == 32) { "safety number must be 32 bytes" }
-    val groups = (0 until 8).map { i ->
-        val offset = i * 4
-        val v = ((sn[offset].toLong() and 0xFF) shl 24) or
-            ((sn[offset + 1].toLong() and 0xFF) shl 16) or
-            ((sn[offset + 2].toLong() and 0xFF) shl 8) or
-            (sn[offset + 3].toLong() and 0xFF)
-        (v % 100000L).toString().padStart(5, '0')
-    }
+    val groups =
+        (0 until 8).map { i ->
+            val offset = i * 4
+            val v =
+                ((sn[offset].toLong() and 0xFF) shl 24) or
+                    ((sn[offset + 1].toLong() and 0xFF) shl 16) or
+                    ((sn[offset + 2].toLong() and 0xFF) shl 8) or
+                    (sn[offset + 3].toLong() and 0xFF)
+            (v % 100000L).toString().padStart(5, '0')
+        }
     return groups.take(4).joinToString(" ") + "\n" + groups.drop(4).joinToString(" ")
 }
 

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
@@ -225,10 +225,15 @@ class KeyExchangeTest {
         // Simulate an epoch rotation (alice generates new EK, bob processes it)
         val bobOpk = generateX25519KeyPair()
         val aliceNewEk = generateX25519KeyPair()
-        val aliceRotated = Session.aliceEpochRotation(
-            aliceSession, aliceNewEk.priv, aliceNewEk.pub, bobOpk.pub,
-            aliceSession.aliceFp, aliceSession.bobFp,
-        )
+        val aliceRotated =
+            Session.aliceEpochRotation(
+                aliceSession,
+                aliceNewEk.priv,
+                aliceNewEk.pub,
+                bobOpk.pub,
+                aliceSession.aliceFp,
+                aliceSession.bobFp,
+            )
 
         // aliceEkPub and bobEkPub must be unchanged after rotation
         assertContentEquals(aliceSession.aliceEkPub, aliceRotated.aliceEkPub)
@@ -249,6 +254,43 @@ class KeyExchangeTest {
         assertContentEquals(msg.ekPub, aliceSession.bobEkPub)
         assertContentEquals(qr.ekPub, bobSession.aliceEkPub)
         assertContentEquals(msg.ekPub, bobSession.bobEkPub)
+    }
+
+    @Test
+    fun `aliceProcessInit detects key substitution via different session keys`() {
+        // Alice creates a QR payload (EK_A).
+        val (qr, aliceEkPriv) = KeyExchange.aliceCreateQrPayload("Alice")
+
+        // Bob (legitimately) processes the QR and creates a KeyExchangeInitMessage (EK_B) and a session.
+        val (_, bobSession) = KeyExchange.bobProcessQr(qr, "Bob")
+
+        // Attacker generates their own key pair (EK_M).
+        val ekM = generateX25519KeyPair()
+
+        // Attacker computes SK_AM = x25519(ekM.priv, qr.ekPub).
+        val skAM = x25519(ekM.priv, qr.ekPub)
+
+        // Attacker constructs a tampered KeyExchangeInitMessage with EK_M.pub and a keyConfirmation
+        // correctly computed over (SK_AM, EK_A.pub, EK_M.pub) using KeyExchange.buildKeyConfirmation.
+        // Attacker knows the discovery token.
+        val tamperedMsg =
+            KeyExchangeInitMessage(
+                token = deriveDiscoveryToken(qr.ekPub),
+                ekPub = ekM.pub.copyOf(),
+                keyConfirmation = KeyExchange.buildKeyConfirmation(skAM, qr.ekPub, ekM.pub),
+                suggestedName = "Attacker",
+            )
+
+        // Alice processes the tampered message using KeyExchange.aliceProcessInit and derives a session.
+        val aliceSession = KeyExchange.aliceProcessInit(tamperedMsg, aliceEkPriv, qr.ekPub)
+
+        // Verify that Alice's session keys (rootKey, sendChainKey, recvChainKey) are different from Bob's session keys.
+        assertFalse(aliceSession.rootKey.contentEquals(bobSession.rootKey))
+        assertFalse(aliceSession.sendChainKey.contentEquals(bobSession.recvChainKey))
+        assertFalse(aliceSession.recvChainKey.contentEquals(bobSession.sendChainKey))
+
+        // Verify that Alice's bobEkPub in her session state matches EK_M.pub, not EK_B.pub.
+        assertContentEquals(ekM.pub, aliceSession.bobEkPub)
     }
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a test case to `KeyExchangeTest.kt` that simulates a Man-In-The-Middle (MITM) scenario where an attacker substitutes Bob's ephemeral public key with their own and provides a valid key confirmation MAC computed over the attacker's key. 

The test verifies that:
1. Alice correctly processes the message (since the MAC is valid for the attacker's key).
2. Alice's resulting session state correctly reflects the attacker's public key as `bobEkPub`.
3. Alice's derived session keys (`rootKey`, `sendChainKey`, `recvChainKey`) differ from those a legitimate Bob would have derived, ensuring that a simple substitution cannot go undetected once communication begins.

The test ensures the `verifyKeyConfirmation` path is exercised against a realistic adversarial payload as requested in issue #119.

Additionally, standard formatting fixes were applied to `shared` module tests and source files to ensure `ktlintCheck` passes.

---
*PR created automatically by Jules for task [7689506374324260802](https://jules.google.com/task/7689506374324260802) started by @danmarg*