### PR TITLE
Fix #105: Move sensitive data from UserDefaults to Keychain

### DIFF
--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -115,18 +115,28 @@ final class LocationSyncService: ObservableObject {
     @Published var friends: [Shared.FriendEntry] = []
     @Published var inviteState: InviteState = .none
     @Published var isSharingLocation: Bool {
-        didSet { UserDefaults.standard.set(isSharingLocation, forKey: "where_is_sharing") }
+        didSet {
+            let keychain = KeychainE2eeStorage()
+            keychain.putString(key: "where_is_sharing", value: isSharingLocation ? "true" : "false")
+        }
     }
     @Published var displayName: String {
         didSet {
-            UserDefaults.standard.set(displayName, forKey: "display_name")
+            let keychain = KeychainE2eeStorage()
+            keychain.putString(key: "display_name", value: displayName)
             if isInviteActive {
                 Task { await createInvite() }
             }
         }
     }
     @Published var pausedFriendIds: Set<String> {
-        didSet { UserDefaults.standard.set(Array(pausedFriendIds), forKey: "paused_friends") }
+        didSet {
+            let keychain = KeychainE2eeStorage()
+            let json = try? JSONSerialization.data(withJSONObject: Array(pausedFriendIds))
+            if let json = json, let jsonStr = String(data: json, encoding: .utf8) {
+                keychain.putString(key: "paused_friends", value: jsonStr)
+            }
+        }
     }
 
     @Published var pendingQrForNaming: Shared.QrPayload? = nil
@@ -178,13 +188,23 @@ final class LocationSyncService: ObservableObject {
         self.e2eeStore = store
         self.locationClient = locationClient ?? Shared.LocationClient(baseUrl: ServerConfig.httpBaseUrl, store: store)
 
-        let savedSharing = UserDefaults.standard.object(forKey: "where_is_sharing")
-        isSharingLocation = savedSharing != nil ? UserDefaults.standard.bool(forKey: "where_is_sharing") : true
+        let keychain = KeychainE2eeStorage()
 
-        displayName = UserDefaults.standard.string(forKey: "display_name") ?? ""
+        if let sharingStr = keychain.getString(key: "where_is_sharing") {
+            isSharingLocation = sharingStr == "true"
+        } else {
+            isSharingLocation = true
+        }
 
-        let savedPaused = UserDefaults.standard.stringArray(forKey: "paused_friends") ?? []
-        pausedFriendIds = Set(savedPaused)
+        displayName = keychain.getString(key: "display_name") ?? ""
+
+        if let pausedJsonStr = keychain.getString(key: "paused_friends"),
+           let pausedData = pausedJsonStr.data(using: .utf8),
+           let pausedArray = try? JSONSerialization.jsonObject(with: pausedData) as? [String] {
+            pausedFriendIds = Set(pausedArray)
+        } else {
+            pausedFriendIds = []
+        }
 
         Task { @MainActor in
             do {

--- a/ios/Tests/WhereTests/LocationSyncServiceTests.swift
+++ b/ios/Tests/WhereTests/LocationSyncServiceTests.swift
@@ -256,6 +256,78 @@ class LocationSyncServiceTests: XCTestCase {
         XCTAssertTrue(endCalledBox.getCalled())
     }
 
+    // MARK: - Keychain storage tests
+
+    func testIsSharingLocationStoredInKeychain() throws {
+        let keychain = KeychainE2eeStorage()
+
+        // Test setting to false and verifying Keychain storage
+        keychain.putString(key: "where_is_sharing", value: "false")
+        XCTAssertEqual(keychain.getString(key: "where_is_sharing"), "false")
+
+        // Test persistence with a fresh service
+        let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
+        service = LocationSyncService(e2eeStore: store, locationClient: nil)
+        XCTAssertFalse(service.isSharingLocation)
+
+        // Test setting to true
+        service.isSharingLocation = true
+        let keychain2 = KeychainE2eeStorage()
+        XCTAssertEqual(keychain2.getString(key: "where_is_sharing"), "true")
+    }
+
+    func testDisplayNameStoredInKeychain() throws {
+        let keychain = KeychainE2eeStorage()
+
+        // Test setting and reading from Keychain
+        keychain.putString(key: "display_name", value: "Alice")
+        XCTAssertEqual(keychain.getString(key: "display_name"), "Alice")
+
+        // Test persistence with a fresh service
+        let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
+        service = LocationSyncService(e2eeStore: store, locationClient: nil)
+        XCTAssertEqual(service.displayName, "Alice")
+    }
+
+    func testPausedFriendIdsStoredInKeychain() throws {
+        let keychain = KeychainE2eeStorage()
+
+        // Test setting paused friend IDs through the service
+        let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
+        service = LocationSyncService(e2eeStore: store, locationClient: nil)
+        service.pausedFriendIds = ["friend1", "friend2"]
+
+        // Verify they're in Keychain
+        let pausedJson = keychain.getString(key: "paused_friends")
+        XCTAssertNotNil(pausedJson)
+        if let pausedData = pausedJson?.data(using: .utf8),
+           let pausedArray = try? JSONSerialization.jsonObject(with: pausedData) as? [String] {
+            XCTAssertEqual(Set(pausedArray), ["friend1", "friend2"])
+        } else {
+            XCTFail("Failed to parse paused friends from Keychain")
+        }
+
+        // Test persistence with a fresh service
+        let store2 = Shared.E2eeStore(storage: KeychainE2eeStorage())
+        let service2 = LocationSyncService(e2eeStore: store2, locationClient: nil)
+        XCTAssertEqual(service2.pausedFriendIds, ["friend1", "friend2"])
+    }
+
+    func testKeychainNotUserDefaults() throws {
+        // Verify that UserDefaults no longer contains these keys
+        let store = Shared.E2eeStore(storage: KeychainE2eeStorage())
+        service = LocationSyncService(e2eeStore: store, locationClient: nil)
+
+        service.isSharingLocation = false
+        service.displayName = "TestUser"
+        service.pausedFriendIds = ["friend1"]
+
+        // Verify that UserDefaults does not have these keys
+        XCTAssertNil(UserDefaults.standard.object(forKey: "where_is_sharing"))
+        XCTAssertNil(UserDefaults.standard.object(forKey: "display_name"))
+        XCTAssertNil(UserDefaults.standard.object(forKey: "paused_friends"))
+    }
+
     private final class ExpiryHandlerBox: @unchecked Sendable {
         private let lock = NSLock()
         private var handler: (@Sendable () -> Void)?


### PR DESCRIPTION
## Summary
Fixes #105 by migrating sensitive user data (`isSharingLocation`, `displayName`, `pausedFriendIds`) from UserDefaults to Keychain. This prevents these values from being included in iCloud and iTunes encrypted backups, complying with the specification's §5.5 requirement for session-adjacent data.

## Changes
- **LocationSyncService.swift**: Updated didSet handlers and init to use Keychain instead of UserDefaults
- **LocationSyncServiceTests.swift**: Added 4 new tests verifying Keychain storage and persistence

## Details
- `isSharingLocation` stored as "true"/"false" string
- `displayName` stored directly as string  
- `pausedFriendIds` serialized as JSON array for storage
- All values use Keychain's existing `getString`/`putString` methods with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`

## Test coverage
- `testIsSharingLocationStoredInKeychain`: Verifies persistence across service instances
- `testDisplayNameStoredInKeychain`: Verifies persistence across service instances
- `testPausedFriendIdsStoredInKeychain`: Verifies JSON serialization and persistence
- `testKeychainNotUserDefaults`: Confirms UserDefaults is no longer used for these keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)