### PR TITLE
Fix #104: Zero key material buffers after use

### DIFF
--- a/ios/Sources/Where/KotlinByteArrayUtils.swift
+++ b/ios/Sources/Where/KotlinByteArrayUtils.swift
@@ -18,9 +18,26 @@ func toHex(_ kba: Shared.KotlinByteArray) -> String {
     (0..<Int(kba.size)).map { String(format: "%02x", UInt8(bitPattern: kba.get(index: Int32($0)))) }.joined()
 }
 
+extension Data {
+    /// Securely zeros out the buffer using memset_s to prevent compiler elision.
+    /// This is critical for sensitive data like cryptographic keys.
+    mutating func zeroize() {
+        withUnsafeMutableBytes { ptr in
+            guard let base = ptr.baseAddress else { return }
+            memset_s(base, ptr.count, 0, ptr.count)
+        }
+    }
+}
+
 func identityFingerprint(ikPub: Shared.KotlinByteArray, sigIkPub: Shared.KotlinByteArray) -> Shared.KotlinByteArray {
     var hasher = SHA256()
-    hasher.update(data: toSwiftData(ikPub))
-    hasher.update(data: toSwiftData(sigIkPub))
+    var ikPubData = toSwiftData(ikPub)
+    var sigIkPubData = toSwiftData(sigIkPub)
+    defer {
+        ikPubData.zeroize()
+        sigIkPubData.zeroize()
+    }
+    hasher.update(data: ikPubData)
+    hasher.update(data: sigIkPubData)
     return kotlinByteArray(from: Data(hasher.finalize()))
 }

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -17,8 +17,11 @@ private func debugLog(_ msg: () -> String) {
 // MARK: - QR payload URL helpers
 
 func qrPayloadToUrl(_ qr: Shared.QrPayload) -> String {
+    var ekPubData = toSwiftData(qr.ekPub)
+    defer { ekPubData.zeroize() }
+
     let dict: [String: Any] = [
-        "ek_pub": toSwiftData(qr.ekPub).base64EncodedString(),
+        "ek_pub": ekPubData.base64EncodedString(),
         "suggested_name": qr.suggestedName,
         "fingerprint": qr.fingerprint,
     ]
@@ -468,12 +471,19 @@ final class LocationSyncService: ObservableObject {
             updateVisibleUsers()
 
             let discoveryHex = toHex(qrWithName.discoveryToken())
+            var ekPubData = toSwiftData(initPayload.ekPub)
+            var keyConfData = toSwiftData(initPayload.keyConfirmation)
+            defer {
+                ekPubData.zeroize()
+                keyConfData.zeroize()
+            }
+
             let payload: [String: Any] = [
                 "v": 1,
                 "type": "KeyExchangeInit",
                 "token": initPayload.token,
-                "ek_pub": toSwiftData(initPayload.ekPub).base64EncodedString(),
-                "key_confirmation": toSwiftData(initPayload.keyConfirmation).base64EncodedString(),
+                "ek_pub": ekPubData.base64EncodedString(),
+                "key_confirmation": keyConfData.base64EncodedString(),
                 "suggested_name": initPayload.suggestedName,
             ]
 


### PR DESCRIPTION
## Summary
Fixes #104 — key material buffers created in `KotlinByteArrayUtils.swift` were never zeroed before deallocation, violating spec §5.5 requirements.

## Changes
- Added `Data.zeroize()` extension using `memset_s` to prevent compiler elision
- Applied `defer { buffer.zeroize() }` pattern to all sensitive key buffers:
  - `ekPub` in `qrPayloadToUrl` 
  - `ekPub` and `keyConfirmation` in `confirmQrScan`
  - `ikPub` and `sigIkPub` in `identityFingerprint`

## Test plan
- ✅ JVM tests pass (shared module)
- ✅ iOS framework builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)