### PR TITLE
Fix #101: Replace mutableSetOf with Channel to eliminate pendingFriendSends data race

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -48,7 +49,7 @@ class LocationService : Service() {
     private lateinit var locationCallback: LocationCallback
     private var isRegistered = false
 
-    private val pendingFriendSends = mutableSetOf<String>()
+    private val pendingFriendSends = Channel<String>(Channel.UNLIMITED)
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
@@ -91,16 +92,13 @@ class LocationService : Service() {
                         sendLocationIfNeeded(loc.first, loc.second, isHeartbeat = false)
                     }
 
-                    if (pendingFriendSends.isNotEmpty()) {
-                        val toSend = pendingFriendSends.toSet()
-                        pendingFriendSends.clear()
-                        for (friendId in toSend) {
-                            launch {
-                                try {
-                                    locationClient.sendLocationToFriend(friendId, loc.first, loc.second)
-                                } catch (e: Exception) {
-                                    Log.e(TAG, "Failed to send deferred location to $friendId: ${e.message}")
-                                }
+                    while (true) {
+                        val friendId = pendingFriendSends.tryReceive().getOrNull() ?: break
+                        launch {
+                            try {
+                                locationClient.sendLocationToFriend(friendId, loc.first, loc.second)
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Failed to send deferred location to $friendId: ${e.message}")
                             }
                         }
                     }
@@ -132,7 +130,7 @@ class LocationService : Service() {
                         }
                     }
                 } else {
-                    pendingFriendSends.add(friendId)
+                    pendingFriendSends.trySend(friendId)
                 }
             }
         }
@@ -162,6 +160,7 @@ class LocationService : Service() {
         Log.d(TAG, "onDestroy")
         fusedClient.removeLocationUpdates(locationCallback)
         isRegistered = false
+        pendingFriendSends.close()
         serviceScope.cancel()
         super.onDestroy()
     }


### PR DESCRIPTION
## Summary
- Replaces `private val pendingFriendSends = mutableSetOf<String>()` with `Channel<String>(Channel.UNLIMITED)`, which is concurrency-safe by design.
- `onStartCommand` now calls `trySend(friendId)` (non-suspending, never blocks on UNLIMITED channel) instead of `add`.
- The location collector drains pending items with `tryReceive` in a loop instead of `toSet()`/`clear()`, eliminating the window where an item could be added between the snapshot and the clear.
- Channel is closed in `onDestroy` alongside `serviceScope.cancel()`.

Fixes #101.

## Test plan
- [x] `./gradlew :shared:jvmTest` passes
- [ ] Manual smoke test: trigger `ACTION_FORCE_PUBLISH` before first location fix; verify location is sent once GPS becomes available

🤖 Generated with [Claude Code](https://claude.com/claude-code)