### PR TITLE
Add authoritative test vectors for crypto primitives

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Fingerprint.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Fingerprint.kt
@@ -35,14 +35,16 @@ fun safetyNumber(
  */
 fun formatSafetyNumber(sn: ByteArray): String {
     require(sn.size == 32) { "safety number must be 32 bytes" }
-    val groups = (0 until 8).map { i ->
-        val offset = i * 4
-        val v = ((sn[offset].toLong() and 0xFF) shl 24) or
-            ((sn[offset + 1].toLong() and 0xFF) shl 16) or
-            ((sn[offset + 2].toLong() and 0xFF) shl 8) or
-            (sn[offset + 3].toLong() and 0xFF)
-        (v % 100000L).toString().padStart(5, '0')
-    }
+    val groups =
+        (0 until 8).map { i ->
+            val offset = i * 4
+            val v =
+                ((sn[offset].toLong() and 0xFF) shl 24) or
+                    ((sn[offset + 1].toLong() and 0xFF) shl 16) or
+                    ((sn[offset + 2].toLong() and 0xFF) shl 8) or
+                    (sn[offset + 3].toLong() and 0xFF)
+            (v % 100000L).toString().padStart(5, '0')
+        }
     return groups.take(4).joinToString(" ") + "\n" + groups.drop(4).joinToString(" ")
 }
 

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/CryptoPrimitivesVectorTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/CryptoPrimitivesVectorTest.kt
@@ -81,8 +81,29 @@ class CryptoPrimitivesVectorTest {
     }
 
     // -----------------------------------------------------------------------
-    // X25519 (RFC 7748 §6.1 test vector)
+    // X25519 (RFC 7748 test vectors)
     // -----------------------------------------------------------------------
+
+    @Test
+    fun `x25519 RFC 7748 section 6 1 vector`() {
+        // Alice's private key, a
+        val aPriv = hex("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a")
+        // Bob's public key, X25519(b, 9)
+        val bPub = hex("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f")
+        // Their shared secret, K
+        val expectedK = hex("4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742")
+
+        assertContentEquals(expectedK, x25519(aPriv, bPub))
+    }
+
+    @Test
+    fun `x25519 RFC 7748 section 5 2 vector`() {
+        val scalar = hex("a546e36bf0527c9d3b16154b82465edd62144c0ac1fc5a18506a2244ba449ac4")
+        val uCoordinate = hex("e6db6867583030db3594c1a424b15f7c726624ec26b3353b10a903a6d0ab1c4c")
+        val expected = hex("c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552")
+
+        assertContentEquals(expected, x25519(scalar, uCoordinate))
+    }
 
     @Test
     fun x25519_DH_is_symmetric() {
@@ -103,8 +124,57 @@ class CryptoPrimitivesVectorTest {
     }
 
     // -----------------------------------------------------------------------
-    // ChaCha20-Poly1305 IETF (libsodium's authenticated encryption)
+    // ChaCha20-Poly1305 IETF (RFC 8439 test vectors)
     // -----------------------------------------------------------------------
+
+    @Test
+    fun `chachapoly RFC 8439 appendix A 5 vector`() {
+        val key = hex("1c9240a5eb55d38af333888604f6b5f0473917c1402b80099dca5cbc207075c0")
+        val nonce = hex("000000000102030405060708")
+        val aad = hex("f33388860000000000004e91")
+        // RFC 8439 Appendix A.5 Plaintext
+        val ptBytes =
+            hex(
+                "496e7465726e65742d4472616674732061726520647261667420646f63756d65" +
+                    "6e74732076616c696420666f722061206d6178696d756d206f6620736978206d" +
+                    "6f6e74687320616e64206d617920626520757064617465642c207265706c6163" +
+                    "65642c206f72206f62736f6c65746564206279206f7468657220646f63756d65" +
+                    "6e747320617420616e792074696d652e20497420697320696e617070726f7072" +
+                    "6961746520746f2075736520496e7465726e65742d4472616674732061732072" +
+                    "65666572656e6365206d6174657269616c206f7220746f206369746520746865" +
+                    "6d206f74686572207468616e206173202fe2809c776f726b20696e2070726f67" +
+                    "726573732e2fe2809d",
+            )
+
+        val ciphertext =
+            hex(
+                "64a0861575861af460f062c79be643bd" +
+                    "5e805cfd345cf389f108670ac76c8cb2" +
+                    "4c6cfc18755d43eea09ee94e382d26b0" +
+                    "bdb7b73c321b0100d4f03b7f355894cf" +
+                    "332f830e710b97ce98c8a84abd0b9481" +
+                    "14ad176e008d33bd60f982b1ff37c855" +
+                    "9797a06ef4f0ef61c186324e2b350638" +
+                    "3606907b6a7c02b0f9f6157b53c867e4" +
+                    "b9166c767b804d46a59b5216cde7a4e9" +
+                    "9040c5a40433225ee282a1b0a06c523e" +
+                    "af4534d7f83fa1155b0047718cbc546a" +
+                    "0d072b04b3564eea1b422273f548271a" +
+                    "0bb2316053fa76991955ebd63159434e" +
+                    "cebb4e466dae5a1073a6727627097a10" +
+                    "49e617d91d361094fa68f0ff77987130" +
+                    "305beaba2eda04df997b714d6c6f2c29" +
+                    "a6ad5cb4022b02709b",
+            )
+        val tag = hex("eead9d67890cbb22392336fea1851f38")
+        val expectedCtTag = ciphertext + tag
+
+        val actualCtTag = aeadEncrypt(key, nonce, ptBytes, aad)
+        assertContentEquals(expectedCtTag, actualCtTag, "Encryption output must match RFC vector")
+
+        val decryptedPT = aeadDecrypt(key, nonce, actualCtTag, aad)
+        assertContentEquals(ptBytes, decryptedPT, "Decryption must return original plaintext")
+    }
 
     @Test
     fun `chachapoly round-trip with plaintext and aad`() {
@@ -151,5 +221,25 @@ class CryptoPrimitivesVectorTest {
                 true
             }
         assertTrue(threw, "Corrupted tag must cause decryption to fail")
+    }
+
+    // -----------------------------------------------------------------------
+    // HKDF-SHA-256 (RFC 5869 Test Case 1)
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `hkdf RFC 5869 test case 1`() {
+        val ikm = hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")
+        val salt = hex("000102030405060708090a0b0c")
+        val info = hex("f0f1f2f3f4f5f6f7f8f9")
+        val l = 42
+        val expectedOkm =
+            hex(
+                "3cb25f25faacd57a90434f64d0362f2a" +
+                    "2d2d0a90cf1a5a4c5db02d56ecc4c5bf" +
+                    "34007208d5b887185865",
+            )
+
+        assertContentEquals(expectedOkm, hkdfSha256(ikm, salt, info, l))
     }
 }

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
@@ -225,10 +225,15 @@ class KeyExchangeTest {
         // Simulate an epoch rotation (alice generates new EK, bob processes it)
         val bobOpk = generateX25519KeyPair()
         val aliceNewEk = generateX25519KeyPair()
-        val aliceRotated = Session.aliceEpochRotation(
-            aliceSession, aliceNewEk.priv, aliceNewEk.pub, bobOpk.pub,
-            aliceSession.aliceFp, aliceSession.bobFp,
-        )
+        val aliceRotated =
+            Session.aliceEpochRotation(
+                aliceSession,
+                aliceNewEk.priv,
+                aliceNewEk.pub,
+                bobOpk.pub,
+                aliceSession.aliceFp,
+                aliceSession.bobFp,
+            )
 
         // aliceEkPub and bobEkPub must be unchanged after rotation
         assertContentEquals(aliceSession.aliceEkPub, aliceRotated.aliceEkPub)

--- a/shared/src/iosMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
+++ b/shared/src/iosMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
@@ -5,6 +5,7 @@ package net.af0.where.e2ee
 import com.ionspin.kotlin.crypto.aead.AuthenticatedEncryptionWithAssociatedData
 import com.ionspin.kotlin.crypto.box.Box
 import com.ionspin.kotlin.crypto.hash.Hash
+import com.ionspin.kotlin.crypto.scalarmult.ScalarMultiplication
 import com.ionspin.kotlin.crypto.util.LibsodiumRandom
 
 // ---------------------------------------------------------------------------
@@ -73,7 +74,8 @@ internal actual fun x25519(
     myPriv: ByteArray,
     theirPub: ByteArray,
 ): ByteArray {
-    return Box.beforeNM(theirPub.toUByteArray(), myPriv.toUByteArray()).toByteArray()
+    return ScalarMultiplication.scalarMultiplication(myPriv.toUByteArray(), theirPub.toUByteArray())
+        .toByteArray()
 }
 
 // ---------------------------------------------------------------------------

--- a/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
+++ b/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/CryptoPrimitivesImpl.kt
@@ -5,6 +5,7 @@ package net.af0.where.e2ee
 import com.ionspin.kotlin.crypto.aead.AuthenticatedEncryptionWithAssociatedData
 import com.ionspin.kotlin.crypto.box.Box
 import com.ionspin.kotlin.crypto.hash.Hash
+import com.ionspin.kotlin.crypto.scalarmult.ScalarMultiplication
 import com.ionspin.kotlin.crypto.util.LibsodiumRandom
 
 // ---------------------------------------------------------------------------
@@ -73,7 +74,8 @@ internal actual fun x25519(
     myPriv: ByteArray,
     theirPub: ByteArray,
 ): ByteArray {
-    return Box.beforeNM(theirPub.toUByteArray(), myPriv.toUByteArray()).toByteArray()
+    return ScalarMultiplication.scalarMultiplication(myPriv.toUByteArray(), theirPub.toUByteArray())
+        .toByteArray()
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Added authoritative test vectors for X25519 (RFC 7748), ChaCha20-Poly1305-IETF (RFC 8439), and HKDF-SHA256 (RFC 5869) to ensure platform interoperability and compliance with standards. Fixed a bug in the X25519 implementation that was discovered by the new test vectors. All changes have been verified with unit tests and linting.

---
*PR created automatically by Jules for task [186951864869462331](https://jules.google.com/task/186951864869462331) started by @danmarg*