### PR TITLE
Zero ekB.priv in bobProcessQr after use

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
@@ -41,6 +41,7 @@ object KeyExchange {
     ): Pair<KeyExchangeInitMessage, SessionState> {
         val ekB = generateX25519KeyPair()
         val sk = x25519(ekB.priv, qr.ekPub)
+        ekB.priv.fill(0)
 
         val aliceFp = fingerprint(qr.ekPub)
         val bobFp = fingerprint(ekB.pub)


### PR DESCRIPTION
This change ensures that Bob's ephemeral private key is explicitly zeroed immediately after its use in the key exchange process, as required by the security specification (§4.2). This prevents sensitive key material from lingering in the heap.

---
*PR created automatically by Jules for task [9908596372263235174](https://jules.google.com/task/9908596372263235174) started by @danmarg*