### PR TITLE
Fix iOS crashes in key exchange code paths

### DIFF
--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -16,7 +16,7 @@ private func debugLog(_ msg: () -> String) {
 
 // MARK: - QR payload URL helpers
 
-func qrPayloadToUrl(_ qr: Shared.QrPayload) -> String {
+func qrPayloadToUrl(_ qr: Shared.QrPayload) -> String? {
     var ekPubData = toSwiftData(qr.ekPub)
     defer { ekPubData.zeroize() }
 
@@ -25,12 +25,17 @@ func qrPayloadToUrl(_ qr: Shared.QrPayload) -> String {
         "suggested_name": qr.suggestedName,
         "fingerprint": qr.fingerprint,
     ]
-    let jsonData = try! JSONSerialization.data(withJSONObject: dict)
-    let b64 = jsonData.base64EncodedString()
-        .replacingOccurrences(of: "+", with: "-")
-        .replacingOccurrences(of: "/", with: "_")
-        .replacingOccurrences(of: "=", with: "")
-    return "https://where.af0.net/invite#\(b64)"
+    do {
+        let jsonData = try JSONSerialization.data(withJSONObject: dict)
+        let b64 = jsonData.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "https://where.af0.net/invite#\(b64)"
+    } catch {
+        logger.error("Failed to serialize QR payload: \(error.localizedDescription)")
+        return nil
+    }
 }
 
 private func urlToQrPayload(_ url: String) -> Shared.QrPayload? {
@@ -462,8 +467,11 @@ final class LocationSyncService: ObservableObject {
         defer { isExchanging = false }
         do {
             let result = try await e2eeStore.processScannedQr(qr: qrWithName, bobSuggestedName: displayName)
-            let initPayload = result.first!
-            let bobEntry = result.second!
+            guard let initPayload = result.first, let bobEntry = result.second else {
+                logger.error("processScannedQr returned nil components")
+                updateStatus(NSError(domain: "Where", code: -1, userInfo: [NSLocalizedDescriptionKey: "Pairing failed: invalid response"]))
+                return
+            }
 
             await clearInvite()
             // Insert AFTER clearInvite: clearInvite calls resetRapidPoll which clears

--- a/ios/Sources/Where/QrCodeView.swift
+++ b/ios/Sources/Where/QrCodeView.swift
@@ -78,15 +78,16 @@ struct InviteSheet: View {
                         .buttonStyle(.bordered)
                     Button("Share Link") { showShareSheet = true }
                         .buttonStyle(.borderedProminent)
+                        .disabled(cachedQrUrl.isEmpty)
                 }
             }
             .padding(32)
         }
         .onAppear {
-            cachedQrUrl = qrPayloadToUrl(qrPayload)
+            cachedQrUrl = qrPayloadToUrl(qrPayload) ?? ""
         }
         .onChange(of: qrPayload) { oldValue, newValue in
-            cachedQrUrl = qrPayloadToUrl(newValue)
+            cachedQrUrl = qrPayloadToUrl(newValue) ?? ""
         }
         .sheet(isPresented: $showShareSheet) {
             ShareSheet(items: [cachedQrUrl])


### PR DESCRIPTION
This change addresses issue #108 where the iOS app could crash on malformed server data or serialization errors in the key exchange flow.

Key changes:
1.  **LocationSyncService.swift**:
    -   `qrPayloadToUrl`: Now returns `String?` and uses a `do-catch` block for JSON serialization instead of `try!`.
    -   `confirmQrScan`: Replaced `result.first!` and `result.second!` with `guard let` bindings. It now logs an error and updates the `connectionStatus` instead of crashing if the server returns malformed data.
2.  **QrCodeView.swift**:
    -   `InviteSheet`: Updated to handle the optional return from `qrPayloadToUrl`. The "Share Link" button is now disabled if the URL cannot be generated.

These changes improve the robustness of the pairing process against malicious or malformed server responses.

---
*PR created automatically by Jules for task [2311986840959481281](https://jules.google.com/task/2311986840959481281) started by @danmarg*