### PR TITLE
Add Redis-backed mailbox store for restart resilience

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ play-services-location = "21.3.0"
 accompanist-permissions = "0.37.3"
 zxing-core = "3.5.3"
 zxing-android = "4.3.0"
+jedis = "5.2.0"
 libsodium = "0.9.5"
 security-crypto = "1.1.0-alpha06"
 
@@ -62,6 +63,9 @@ bouncycastle = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "boun
 libsodium-kmp = { module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings", version.ref = "libsodium" }
 libsodium-kmp-jvm = { module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings-jvm", version.ref = "libsodium" }
 security-crypto = { module = "androidx.security:security-crypto", version.ref = "security-crypto" }
+
+# Redis
+jedis = { module = "redis.clients:jedis", version.ref = "jedis" }
 
 # Logging
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.server.call.logging)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.jedis)
     implementation(libs.logback.classic)
     testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/server/src/main/kotlin/net/af0/where/Server.kt
+++ b/server/src/main/kotlin/net/af0/where/Server.kt
@@ -19,6 +19,8 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
+import redis.clients.jedis.JedisPooled
+import java.net.URI
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -40,18 +42,50 @@ internal const val RATE_LIMIT_MAX_POSTS = 60
 /** Rate-limit window duration in milliseconds (1 minute). */
 private const val RATE_LIMIT_WINDOW_MS = 60_000L
 
-/** How often the background eviction job sweeps stale map entries. */
+/** How often the background eviction job sweeps stale map entries (in-memory only). */
 private const val EVICTION_INTERVAL_MS = 5 * 60_000L
+
+// ---------------------------------------------------------------------------
+// MailboxStore interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Backing store for the anonymous mailbox routing table.
+ *
+ * Two implementations:
+ *   - [InMemoryMailboxState] — used in tests and when REDIS_URL is absent.
+ *   - [RedisMailboxState]    — used in production; state survives restarts.
+ */
+interface MailboxStore {
+    /**
+     * Store [payload] under [token]. Returns false if the token is rate-limited
+     * or has reached [MAX_QUEUE_DEPTH].
+     */
+    fun post(token: String, payload: JsonElement): Boolean
+
+    /** Destructively drain all non-expired messages for [token]. */
+    fun drain(token: String): List<JsonElement>
+
+    /** Reclaim stale entries. No-op for implementations where the store handles expiry. */
+    fun evict() {}
+
+    /** Release any external resources (connections, pools). */
+    fun close() {}
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementation (tests / no Redis)
+// ---------------------------------------------------------------------------
 
 private data class MailboxEntry(val payload: JsonElement, val expiresAt: Long)
 
 /**
- * Anonymous mailbox routing table (§7.1, §10).
+ * Anonymous mailbox routing table backed by in-process maps (§7.1, §10).
  *
  * Keys are opaque routing tokens (hex strings from the URL). Values are queues of
  * timestamped JSON payloads. The server never parses payload content.
  */
-class MailboxState {
+class InMemoryMailboxState : MailboxStore {
     private val mailboxes = ConcurrentHashMap<String, ConcurrentLinkedQueue<MailboxEntry>>()
 
     /** Per-token post timestamps used for rate limiting (sliding window). */
@@ -67,7 +101,7 @@ class MailboxState {
      * payload) if the token has exceeded [MAX_QUEUE_DEPTH] live messages or the
      * [RATE_LIMIT_MAX_POSTS] per-minute rate limit.
      */
-    fun post(
+    override fun post(
         token: String,
         payload: JsonElement,
     ): Boolean {
@@ -102,7 +136,7 @@ class MailboxState {
      * at which point it will create a fresh entry via [computeIfAbsent].  Either way no
      * data is lost.
      */
-    fun evict() = evictWithParams(rateLimitWindowMs = RATE_LIMIT_WINDOW_MS)
+    override fun evict() = evictWithParams(rateLimitWindowMs = RATE_LIMIT_WINDOW_MS)
 
     /** Exposed for tests to control the rate-limit window (e.g. 0 to treat all entries as stale). */
     internal fun evictForTest(rateLimitWindowMs: Long) = evictWithParams(rateLimitWindowMs)
@@ -127,7 +161,7 @@ class MailboxState {
      * Drain all non-expired messages for [token] and return them.
      * Returns an empty list for unknown or empty tokens (§7.2: indistinguishable responses).
      */
-    fun drain(token: String): List<JsonElement> {
+    override fun drain(token: String): List<JsonElement> {
         val now = System.currentTimeMillis()
 
         // Constant-Time Invariant (§7.2, §10.2):
@@ -144,29 +178,120 @@ class MailboxState {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Redis implementation (production)
+// ---------------------------------------------------------------------------
+
+/**
+ * Anonymous mailbox routing table backed by Redis (§7.1, §10).
+ *
+ * All operations are atomic via Lua scripts. Redis key TTLs replace the background
+ * eviction job — no [evict] implementation is needed.
+ *
+ * Key layout:
+ *   inbox:{token}     — Redis List of JSON payload strings
+ *   ratelimit:{token} — Redis counter (INCR) for fixed-window rate limiting
+ */
+class RedisMailboxState(redisUrl: String) : MailboxStore {
+    private val jedis = JedisPooled(URI(redisUrl))
+
+    /**
+     * Atomically: check fixed-window rate limit, check queue depth, append payload.
+     *
+     * Rate limiting uses a fixed 1-minute window (INCR + EXPIRE on first increment).
+     * At window boundaries a client could burst up to 2× the per-minute limit, which
+     * is acceptable for location sharing at this scale.
+     *
+     * Returns 1 on success, 0 if rate-limited or queue full.
+     */
+    private val postScript = """
+        local maxPosts = tonumber(ARGV[1])
+        local maxDepth = tonumber(ARGV[2])
+        local payload  = ARGV[3]
+        local ttlSec   = tonumber(ARGV[4])
+        local rlTtlSec = tonumber(ARGV[5])
+        local count = redis.call('INCR', KEYS[1])
+        if count == 1 then redis.call('EXPIRE', KEYS[1], rlTtlSec) end
+        if count > maxPosts then return 0 end
+        if redis.call('LLEN', KEYS[2]) >= maxDepth then return 0 end
+        redis.call('RPUSH', KEYS[2], payload)
+        redis.call('EXPIRE', KEYS[2], ttlSec)
+        return 1
+    """.trimIndent()
+
+    /** Atomically drain all messages for the token. */
+    private val drainScript = """
+        local msgs = redis.call('LRANGE', KEYS[1], 0, -1)
+        if #msgs > 0 then redis.call('DEL', KEYS[1]) end
+        return msgs
+    """.trimIndent()
+
+    override fun post(token: String, payload: JsonElement): Boolean {
+        val result = jedis.eval(
+            postScript,
+            listOf("ratelimit:$token", "inbox:$token"),
+            listOf(
+                RATE_LIMIT_MAX_POSTS.toString(),
+                MAX_QUEUE_DEPTH.toString(),
+                payload.toString(),
+                (MAILBOX_TTL_MS / 1000).toString(),
+                (RATE_LIMIT_WINDOW_MS / 1000).toString(),
+            ),
+        )
+        return result == 1L
+    }
+
+    override fun drain(token: String): List<JsonElement> {
+        @Suppress("UNCHECKED_CAST")
+        val msgs = jedis.eval(drainScript, listOf("inbox:$token"), emptyList()) as List<*>
+        return msgs.map { item ->
+            val str = when (item) {
+                is String -> item
+                is ByteArray -> item.decodeToString()
+                else -> item.toString()
+            }
+            json.parseToJsonElement(str)
+        }
+    }
+
+    // evict() is intentionally left as the interface no-op: Redis TTL handles expiry.
+
+    override fun close() = jedis.close()
+}
+
+// ---------------------------------------------------------------------------
+// ServerState
+// ---------------------------------------------------------------------------
+
 /**
  * Encapsulates all mutable server state so each module() invocation (including in tests)
  * gets its own isolated state rather than sharing package-level globals.
  */
-class ServerState(val debug: Boolean = false) {
-    val mailbox = MailboxState()
-}
+class ServerState(
+    val debug: Boolean = false,
+    val mailbox: MailboxStore = InMemoryMailboxState(),
+)
 
 fun main(args: Array<String>) {
     val port = System.getenv("PORT")?.toInt() ?: 8080
     val debug = args.contains("--debug") || System.getenv("WHERE_DEBUG") == "true"
+    val redisUrl = System.getenv("REDIS_URL")
+    val mailbox: MailboxStore =
+        if (redisUrl != null) RedisMailboxState(redisUrl) else InMemoryMailboxState()
     embeddedServer(Netty, port = port, host = "0.0.0.0") {
-        module(ServerState(debug))
+        module(ServerState(debug, mailbox))
     }.start(wait = true)
+    mailbox.close()
 }
 
 fun Application.module(state: ServerState = ServerState()) {
     install(ContentNegotiation) { json(json) }
     install(CallLogging)
 
-    // Background eviction: remove zombie token entries from the mailbox and rate-limit
-    // maps.  Entries are created on first POST but never deleted by post/drain; without
-    // eviction a token-flooding attack causes unbounded memory growth.
+    environment.monitor.subscribe(ApplicationStopped) { state.mailbox.close() }
+
+    // Background eviction: remove zombie token entries from the in-memory mailbox and
+    // rate-limit maps. This is a no-op when using RedisMailboxState (TTL handles it).
     launch(Dispatchers.Default) {
         while (isActive) {
             delay(EVICTION_INTERVAL_MS)

--- a/server/src/test/kotlin/net/af0/where/MailboxTest.kt
+++ b/server/src/test/kotlin/net/af0/where/MailboxTest.kt
@@ -155,7 +155,7 @@ class MailboxTest {
 
     @Test
     fun `evict resets stale postTimes so rate limit no longer applies`() {
-        val state = MailboxState()
+        val state = InMemoryMailboxState()
         val token = "evicttoken0000001"
         // Exhaust the rate limit for this token.
         repeat(RATE_LIMIT_MAX_POSTS) { i ->
@@ -172,7 +172,7 @@ class MailboxTest {
 
     @Test
     fun `evict removes empty mailbox entries`() {
-        val state = MailboxState()
+        val state = InMemoryMailboxState()
         val token = "evicttoken0000002"
         state.post(token, JsonPrimitive("msg"))
         state.drain(token) // empties the mailbox queue
@@ -186,7 +186,7 @@ class MailboxTest {
 
     @Test
     fun `evict does not remove mailbox entries with live messages`() {
-        val state = MailboxState()
+        val state = InMemoryMailboxState()
         state.post("live", JsonPrimitive("msg"))
 
         // Evict — the message has not expired so the entry should be retained.


### PR DESCRIPTION
## Summary

- Introduces a `MailboxStore` interface with two implementations: `InMemoryMailboxState` (existing in-process maps, used in tests and local dev without Redis) and `RedisMailboxState` (production, selected when `REDIS_URL` env var is set)
- Redis operations use Lua scripts for atomic `post` (fixed-window rate-limit + depth cap + RPUSH) and `drain` (LRANGE + DEL); Redis key TTLs replace the background eviction job
- `ServerState` defaults to in-memory, so all existing tests pass without a Redis instance

## Motivation

The in-memory store loses all mailbox contents on server restart. Using Redis means restarts are transparent to clients (they just resume polling), and the door is open to multi-machine deployments in future without re-architecting.

## Deployment notes

Provision Upstash Redis on Fly and inject the URL before deploying:
```bash
fly redis create
fly secrets set REDIS_URL=rediss://default:...@...upstash.io:6379
```

## Test plan

- [ ] `./gradlew :server:test` passes (in-memory path, no Redis required)
- [ ] Deploy to staging with `REDIS_URL` set and verify messages survive a server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)