### PR TITLE
Zero out ephemeral private keys after use in Session operations

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -195,6 +195,7 @@ object Session {
 
         // Security (§5.5, §11): zero out ephemeral keys after use
         dhOut.fill(0)
+        aliceNewEkPriv.fill(0)
 
         return newState
     }
@@ -237,6 +238,7 @@ object Session {
 
         // Security (§5.5, §11): zero out ephemeral keys after use
         dhOut.fill(0)
+        bobOpkPriv.fill(0)
 
         return newState
     }
@@ -290,6 +292,7 @@ object Session {
                 myEkPriv = ByteArray(32),
             )
         dhOut.fill(0)
+        state.myEkPriv.fill(0)
         return newState
     }
 

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/SessionTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/SessionTest.kt
@@ -425,4 +425,57 @@ class SessionTest {
             }
         assertTrue(threw, "Expected AEAD to fail with wrong routing token")
     }
+
+    @Test
+    fun `test private keys are zeroed after use`() {
+        val (aliceSession, bobSession) = exchangeKeys()
+
+        val aliceNewEk = generateX25519KeyPair()
+        val bobOpk = generateX25519KeyPair()
+
+        val aliceEkPrivCopy = aliceNewEk.priv.copyOf()
+        val bobOpkPrivCopy = bobOpk.priv.copyOf()
+
+        // aliceEpochRotation
+        Session.aliceEpochRotation(
+            state = aliceSession,
+            aliceNewEkPriv = aliceNewEk.priv,
+            aliceNewEkPub = aliceNewEk.pub,
+            bobOpkPub = bobOpk.pub,
+            senderFp = aliceSession.aliceFp,
+            recipientFp = aliceSession.bobFp,
+        )
+        assertTrue(aliceNewEk.priv.all { it == 0.toByte() }, "aliceNewEkPriv should be zeroed")
+
+        // bobProcessAliceRotation
+        Session.bobProcessAliceRotation(
+            state = bobSession,
+            aliceNewEkPub = aliceNewEk.pub,
+            bobOpkPriv = bobOpk.priv,
+            newEpoch = 1,
+            senderFp = bobSession.aliceFp,
+            recipientFp = bobSession.bobFp,
+        )
+        assertTrue(bobOpk.priv.all { it == 0.toByte() }, "bobOpkPriv should be zeroed")
+
+        // aliceProcessRatchetAck
+        // First we need to get a session where myEkPriv is not zero.
+        // This happens after Alice rotates her epoch.
+        val bobOpk2 = generateX25519KeyPair()
+        val aliceNewEk2 = generateX25519KeyPair()
+        val aliceRotated = Session.aliceEpochRotation(
+            state = aliceSession,
+            aliceNewEkPriv = aliceNewEk2.priv,
+            aliceNewEkPub = aliceNewEk2.pub,
+            bobOpkPub = bobOpk2.pub,
+            senderFp = aliceSession.aliceFp,
+            recipientFp = aliceSession.bobFp,
+        )
+
+        val bobNewEk = generateX25519KeyPair()
+        assertTrue(aliceRotated.myEkPriv.any { it != 0.toByte() }, "Pre-condition: aliceRotated.myEkPriv should not be all zeros")
+
+        Session.aliceProcessRatchetAck(aliceRotated, bobNewEk.pub)
+        assertTrue(aliceRotated.myEkPriv.all { it == 0.toByte() }, "aliceRotated.myEkPriv should be zeroed")
+    }
 }

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/SessionTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/SessionTest.kt
@@ -463,14 +463,15 @@ class SessionTest {
         // This happens after Alice rotates her epoch.
         val bobOpk2 = generateX25519KeyPair()
         val aliceNewEk2 = generateX25519KeyPair()
-        val aliceRotated = Session.aliceEpochRotation(
-            state = aliceSession,
-            aliceNewEkPriv = aliceNewEk2.priv,
-            aliceNewEkPub = aliceNewEk2.pub,
-            bobOpkPub = bobOpk2.pub,
-            senderFp = aliceSession.aliceFp,
-            recipientFp = aliceSession.bobFp,
-        )
+        val aliceRotated =
+            Session.aliceEpochRotation(
+                state = aliceSession,
+                aliceNewEkPriv = aliceNewEk2.priv,
+                aliceNewEkPub = aliceNewEk2.pub,
+                bobOpkPub = bobOpk2.pub,
+                senderFp = aliceSession.aliceFp,
+                recipientFp = aliceSession.bobFp,
+            )
 
         val bobNewEk = generateX25519KeyPair()
         assertTrue(aliceRotated.myEkPriv.any { it != 0.toByte() }, "Pre-condition: aliceRotated.myEkPriv should not be all zeros")


### PR DESCRIPTION
Summary:
Session.bobProcessAliceRotation (in Session.kt) computed dhOut = x25519(bobOpkPriv, aliceNewEkPub) but never zeroed bobOpkPriv before the function returned. This violated the spec which states: "Bob MUST delete the OPK private key immediately after use."

This change adds `bobOpkPriv.fill(0)` immediately after use. It also proactively zeroes other ephemeral private keys in `aliceEpochRotation` and `aliceProcessRatchetAck`.

Changes:
- In `Session.aliceEpochRotation`, added `aliceNewEkPriv.fill(0)` after use.
- In `Session.bobProcessAliceRotation`, added `bobOpkPriv.fill(0)` after use.
- In `Session.aliceProcessRatchetAck`, added `state.myEkPriv.fill(0)` after use.
- Added a new unit test `test private keys are zeroed after use` in `SessionTest.kt` to verify that these keys are actually zeroed.

Verified by running `./gradlew jvmTest`.

---
*PR created automatically by Jules for task [15059694682416416902](https://jules.google.com/task/15059694682416416902) started by @danmarg*