### PR TITLE
Fix race condition in isSharingLocation initialization

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/BootReceiver.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/BootReceiver.kt
@@ -17,8 +17,12 @@ class BootReceiver : BroadcastReceiver() {
             action == "android.intent.action.QUICKBOOT_POWERON" ||
             action == "com.htc.intent.action.QUICKBOOT_POWERON"
         ) {
-            Log.d(TAG, "Starting LocationService after boot: $action")
-            context.startForegroundService(Intent(context, LocationService::class.java))
+            if (UserPrefs.isSharing(context)) {
+                Log.d(TAG, "Starting LocationService after boot: $action")
+                context.startForegroundService(Intent(context, LocationService::class.java))
+            } else {
+                Log.d(TAG, "Skipping LocationService after boot because sharing is disabled.")
+            }
         }
     }
 }

--- a/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
@@ -100,7 +100,7 @@ object LocationRepository : LocationSource {
     internal val _pendingInitPayload = MutableStateFlow<KeyExchangeInitPayload?>(null)
     override val pendingInitPayload: StateFlow<KeyExchangeInitPayload?> = _pendingInitPayload.asStateFlow()
 
-    private val _isSharingLocation = MutableStateFlow(true)
+    private val _isSharingLocation = MutableStateFlow(false)
     override val isSharingLocation: StateFlow<Boolean> = _isSharingLocation.asStateFlow()
 
     private val _pausedFriendIds = MutableStateFlow<Set<String>>(emptySet())
@@ -230,7 +230,7 @@ object LocationRepository : LocationSource {
         _connectionStatus.value = ConnectionStatus.Ok
         _isAppInForeground.value = false
         _pendingInitPayload.value = null
-        _isSharingLocation.value = true
+        _isSharingLocation.value = false
         _pausedFriendIds.value = emptySet()
         _friends.value = emptyList()
         _lastRapidPollTrigger.value = 0L

--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -62,6 +62,9 @@ class LocationService : Service() {
         createNotificationChannel()
         startForeground(NOTIFICATION_ID, buildNotification())
 
+        // Initialise repository sharing state from prefs before starting any collection.
+        locationSource.setSharingLocation(UserPrefs.isSharing(this))
+
         val app = application as WhereApplication
         e2eeStore = e2eeStoreOverride ?: app.e2eeStore
         locationClient = locationClientOverride ?: app.locationClient

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -99,6 +99,10 @@ class LocationViewModel(
 
     init {
         Log.d(TAG, "LocationViewModel init: server=${BuildConfig.SERVER_HTTP_URL}")
+        // Restore initial sharing state synchronously so observers (like LocationService)
+        // see the correct value immediately.
+        locationSource.setSharingLocation(UserPrefs.isSharing(app))
+
         viewModelScope.launch {
             val savedFriends = this@LocationViewModel.e2eeStore.listFriends()
             locationSource.onFriendsUpdated(savedFriends)
@@ -114,7 +118,6 @@ class LocationViewModel(
                 }
             }
             locationSource.setInitialFriendLocations(initialLocations, initialLastPing)
-            locationSource.setSharingLocation(UserPrefs.isSharing(app))
             locationSource.setPausedFriends(UserPrefs.getPausedFriends(app))
         }
 

--- a/android/src/androidUnitTest/kotlin/net/af0/where/BootReceiverTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/BootReceiverTest.kt
@@ -28,6 +28,21 @@ class BootReceiverTest {
     }
 
     @Test
+    fun testOnReceiveRespectsSharingPreference() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val prefs = context.getSharedPreferences("where_prefs", Context.MODE_PRIVATE)
+        prefs.edit().putBoolean("is_sharing", false).commit()
+
+        val receiver = BootReceiver()
+        val intent = Intent(Intent.ACTION_BOOT_COMPLETED)
+
+        receiver.onReceive(context, intent)
+
+        val nextIntent = shadowOf(context as android.app.Application).nextStartedService
+        assertEquals(null, nextIntent, "Should not start service when sharing is disabled")
+    }
+
+    @Test
     fun testOnReceiveIgnoresOtherActions() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val receiver = BootReceiver()

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationRepositoryTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationRepositoryTest.kt
@@ -17,7 +17,14 @@ class LocationRepositoryTest {
     @Before
     fun resetRepository() {
         // Reset the repository to a known state before each test
+        LocationRepository.reset()
         LocationRepository.onLocation(0.0, 0.0)
+    }
+
+    @Test
+    fun testDefaultSharingStateIsFalse() {
+        LocationRepository.reset()
+        assertTrue(!LocationRepository.isSharingLocation.value, "Default sharing state should be false")
     }
 
     /**

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
@@ -92,7 +92,7 @@ private class FakeLocationSource : LocationSource {
     private val _pendingInitPayload = MutableStateFlow<KeyExchangeInitPayload?>(null)
     override val pendingInitPayload: StateFlow<KeyExchangeInitPayload?> = _pendingInitPayload
 
-    private val _isSharingLocation = MutableStateFlow(true)
+    private val _isSharingLocation = MutableStateFlow(false)
     override val isSharingLocation: StateFlow<Boolean> = _isSharingLocation
 
     private val _pausedFriendIds = MutableStateFlow<Set<String>>(emptySet())


### PR DESCRIPTION
This change fixes a race condition where the location sharing state could incorrectly default to true during application startup or device boot.

Key changes:
- Changed `LocationRepository`'s default `isSharingLocation` state to `false`.
- Updated `LocationViewModel` to restore the sharing preference synchronously in its `init` block.
- Updated `LocationService` to restore the sharing preference synchronously in `onCreate`.
- Modified `BootReceiver` to check `UserPrefs.isSharing` before starting the `LocationService`.
- Added regression tests in `LocationRepositoryTest` and `BootReceiverTest`.

---
*PR created automatically by Jules for task [12019309800420133767](https://jules.google.com/task/12019309800420133767) started by @danmarg*