### PR TITLE
Fix #115: derive discovery token from random secret, not EK_A.pub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 |---|---|
 | `shared/` | KMP library — data models, E2EE crypto implementations (Double Ratchet), `LocationClient` |
 | `android/` | Android app — Compose UI, FusedLocation foreground service, Google Maps |
-| `server/` | Ktor server — Anonymous Mailbox API, in-memory location store |
+| `server/` | Ktor server — Anonymous Mailbox API, Redis-backed persistent mailbox store |
 | `ios/` | iOS app — SwiftUI + MapKit + CoreLocation, native HTTP polling |
 
 ### Data flow
@@ -53,7 +53,8 @@
 - **iOS**: `distanceFilter = 50m` + `desiredAccuracy = kCLLocationAccuracyHundredMeters`; `startMonitoringSignificantLocationChanges()` when backgrounded.
 
 ### Server state
-- In-memory `ConcurrentHashMap`s for mailboxes. State is lost on restart.
+- Mailboxes are persisted in Redis. State survives restarts.
+- Messages are retained for 7 days, aligning with the client re-pair timeout.
 
 ---
 
@@ -122,6 +123,5 @@ and run on the JVM target via `:shared:jvmTest`.
 ---
 
 ## Planned future work
-- Persistent server storage
 - User-controlled sharing (groups, time-limited sharing)
 - Push notifications when a friend's location changes significantly

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
@@ -301,7 +301,7 @@ class LocationViewModelTest {
             viewModel = LocationViewModel(app, E2eeStore(FakeE2eeStorage()), startPolling = false)
             val vm = viewModel!!
 
-            val qr = QrPayload(byteArrayOf(1, 2, 3), "Alice", "fp")
+            val qr = QrPayload(byteArrayOf(1, 2, 3), "Alice", "fp", ByteArray(32))
 
             // Bob scans
             (vm.pendingQrForNaming as MutableStateFlow).value = qr
@@ -431,6 +431,7 @@ class LocationViewModelTest {
                     ekPub = byteArrayOf(1, 2, 3),
                     suggestedName = "Alice",
                     fingerprint = "alice_fp",
+                    discoverySecret = ByteArray(32),
                 )
 
             // 3. Call confirmQrScan (synchronous sets isExchanging = true before async work)
@@ -751,6 +752,7 @@ class LocationViewModelTest {
                     ekPub = byteArrayOf(1, 2, 3),
                     suggestedName = "Alice",
                     fingerprint = "fp",
+                    discoverySecret = ByteArray(32),
                 )
 
             // Mock store to return a friend

--- a/cli/src/main/kotlin/net/af0/where/cli/Main.kt
+++ b/cli/src/main/kotlin/net/af0/where/cli/Main.kt
@@ -55,11 +55,13 @@ fun qrPayloadToUrl(qr: QrPayload): String {
     // Mimic the iOS/Android URL format
     // {"ekPub": "...", "suggestedName": "...", "fingerprint": "..."}
     val ekPubB64 = Base64.getEncoder().encodeToString(qr.ekPub)
+    val secretB64 = Base64.getEncoder().encodeToString(qr.discoverySecret)
     val map =
         mapOf(
             "ekPub" to ekPubB64,
             "suggestedName" to qr.suggestedName,
             "fingerprint" to qr.fingerprint,
+            "discoverySecret" to secretB64,
         )
     val b64 = Base64.getUrlEncoder().withoutPadding().encodeToString(json.encodeToString(map).toByteArray())
     return "where://invite?q=$b64"
@@ -95,10 +97,13 @@ fun urlToQrPayload(url: String): QrPayload? {
     val decoded = String(Base64.getUrlDecoder().decode(q))
     val map: Map<String, String> = json.decodeFromString(decoded)
     val ekPub = Base64.getDecoder().decode(map["ekPub"] ?: return null)
+    val discoverySecret = map["discoverySecret"]?.let { Base64.getDecoder().decode(it) } ?: return null
+    if (ekPub.size != 32 || discoverySecret.size != 32) return null
     return QrPayload(
         ekPub = ekPub,
         suggestedName = map["suggestedName"] ?: "Friend",
         fingerprint = map["fingerprint"] ?: "",
+        discoverySecret = discoverySecret,
     )
 }
 

--- a/docs/e2ee-location-sync.md
+++ b/docs/e2ee-location-sync.md
@@ -854,7 +854,7 @@ Recipients MUST reject any `EpochRotation` or `RatchetAck` whose decrypted `ts` 
 
 ### 10.2 Routing Table
 
-The server maintains a Redis-backed map of **mailboxes** indexed by 16-byte routing tokens. Mailboxes are durable across server restarts.
+The server maintains a persistent map of **mailboxes** indexed by 16-byte routing tokens. Mailboxes are durable across server restarts.
 
 1. **POST /inbox/{token}:**
    - Push the payload into the corresponding queue.

--- a/docs/e2ee-location-sync.md
+++ b/docs/e2ee-location-sync.md
@@ -161,12 +161,13 @@ Both private keys are deleted immediately after `SK` is computed and verified.
 
 **Setup:**
 
-Alice opens "Add Friend" and generates a fresh ephemeral key pair `EK_A`. She displays a QR code encoding:
+Alice opens "Add Friend" and generates a fresh ephemeral key pair `EK_A` and a fresh random 32-byte `discovery_secret`. She displays a QR code encoding:
 ```
 {
-  "ek_pub":        base64(Alice.EK_A.pub),  // X25519 ephemeral public key (32 bytes)
-  "suggested_name": "Alice",
-  "fingerprint":   hex(SHA-256(EK_A.pub)[0:10])
+  "ek_pub":            base64(Alice.EK_A.pub),  // X25519 ephemeral public key (32 bytes)
+  "suggested_name":    "Alice",
+  "fingerprint":       hex(SHA-256(EK_A.pub)[0:10]),
+  "discovery_secret":  base64(random_32_bytes)   // fresh per QR; HKDF IKM for discovery token
 }
 ```
 
@@ -174,16 +175,18 @@ No long-term keys, no signatures. The QR is intentionally minimal.
 
 **Discovery Token (Pre-Session Rendezvous):**
 
-After Alice generates her QR, she derives the discovery token from `EK_A.pub`:
+After Alice generates her QR, she derives the discovery token from `discovery_secret`:
 
 ```
-discovery_token_A = HKDF-SHA-256(IKM  = Alice.EK_A.pub,
-                                  salt = 0x00...00,   // 32 zero bytes
+discovery_token_A = HKDF-SHA-256(IKM  = Alice.discovery_secret,   // 32-byte random secret
+                                  salt = 0x00...00,                // 32 zero bytes
                                   info = "Where-v1-Discovery")[0:16]
 ```
 
+Using a random secret (rather than `EK_A.pub`) as HKDF IKM ensures that only someone who received the QR out-of-band can compute `discovery_token_A`. A network observer who later sees `EK_A.pub` in Bob's `KeyExchangeInit` message cannot retroactively map it to the discovery-phase mailbox.
+
 - Alice begins polling `GET /inbox/{hex(discovery_token_A)}` immediately.
-- Bob derives the same `discovery_token_A` from the scanned `ek_pub` and POSTs his `KeyExchangeInit` there.
+- Bob derives the same `discovery_token_A` from the scanned `discovery_secret` and POSTs his `KeyExchangeInit` there.
 - Once Alice retrieves and processes the `KeyExchangeInit`, she switches to polling `recv_token` for all subsequent messages.
 - The discovery token is single-use and ephemeral: implementations MUST discard it after `aliceProcessInit` completes.
 
@@ -260,7 +263,7 @@ The key agreement proceeds identically to Option A, using the same discovery tok
 
 ### 4.4 What the Server Learns from Key Exchange
 
-- **Discovery phase:** A 16-byte token was used briefly for rendezvous. This token is derived from `EK_A.pub` (ephemeral, per-invite), so the server cannot link it to any stable user identity. The server observes that some IP polled it and another IP posted to it, but learns nothing about who those IPs represent.
+- **Discovery phase:** A 16-byte token was used briefly for rendezvous. This token is derived from a random 32-byte `discovery_secret` embedded in the QR (not from `EK_A.pub`), so neither the server nor any observer who later sees `EK_A.pub` in a `KeyExchangeInit` message can compute or correlate the discovery-phase mailbox. The server observes that some IP polled it and another IP posted to it, but learns nothing about who those IPs represent.
 - **`KeyExchangeInit` phase:** The server sees Bob's `EK_B.pub` (ephemeral, 32 bytes) and the HMAC confirmation tag. Both are ephemeral and single-use. No stable long-term key material is exposed to the server at any point.
 - **Nothing** about the resulting shared secret `SK`, the session fingerprints, or the identities of the participants.
 
@@ -383,7 +386,7 @@ This provides true asynchronous PCS: Alice can "heal" the session at any time us
 
 **OPK Depletion:** If Alice has no OPKs for Bob, she SHOULD continue broadcasting on the symmetric ratchet and SHOULD NOT rotate the DH epoch until a new bundle is received.
 
-**Retransmission:** Alice retransmits her `EpochRotation` every `T` minutes until she receives an `EncryptedLocation` acknowledgment or a `RatchetAck` (optional) from Bob.
+**EpochRotation delivery:** The server guarantees message durability for at least 7 days (see §10.2), so Alice does not need to retransmit `EpochRotation` messages. If Bob is offline, the `EpochRotation` will remain in the mailbox until he polls. If Alice has not received any valid `EncryptedLocation` or `RatchetAck` on the new token after 7 days, she SHOULD stop transmitting and prompt the user to re-pair.
 
 **Summary of PCS guarantees in OPK mode:**
 
@@ -533,7 +536,7 @@ Because of the indistinguishable response invariant (§7.2), clients can impleme
 | Message encryption | ChaCha20-Poly1305 | 256-bit | Per-message key; deleted after use |
 | Message authentication | ChaCha20-Poly1305 tag | 128-bit | Included in AEAD output; covers AAD |
 | Key exchange KDF | HKDF-SHA-256 | — | `info = "Where-v1-KeyExchange"` (initial SK) |
-| Discovery token | HKDF-SHA-256 | 16-byte output | `ikm = EK_A.pub`, `salt = 0x00*32`, `info = "Where-v1-Discovery"` (§4.2) |
+| Discovery token | HKDF-SHA-256 | 16-byte output | `ikm = discovery_secret` (32-byte random, from QR payload), `salt = 0x00*32`, `info = "Where-v1-Discovery"` (§4.2) |
 | Bundle auth key | HKDF-SHA-256 | 32-byte output | `K_bundle = HKDF(SK, salt=0, info="Where-v1-BundleAuth")`; for PreKeyBundle HMAC |
 | Rotation auth key | HKDF-SHA-256 | 32-byte output | `K_rot = HKDF(root_key, salt=epoch_be4, info="Where-v1-EpochRotation")`; for EpochRotation AEAD |
 | Ack auth key | HKDF-SHA-256 | 32-byte output | `K_ack = HKDF(new_root_key, salt=epoch_be4, info="Where-v1-RatchetAck")`; for RatchetAck AEAD |
@@ -846,19 +849,16 @@ Recipients MUST reject any `EpochRotation` or `RatchetAck` whose decrypted `ts` 
 |---|---|
 | Routing Model | **Anonymous Mailboxes.** Routes opaque `EncryptedLocation` payloads by pairwise routing tokens (T). No userid-based addressing. |
 | Client Interaction | **Registration-less.** Clients poll `GET /inbox/{token}` and post `POST /inbox/{token}`; the server has no knowledge of user identity. |
-| In-memory store | **Opaque Payload Buffer.** Brief TTL buffer of encrypted payloads indexed by routing token T. |
+| Persistent store | **Opaque Payload Buffer.** Redis-backed durable buffer of encrypted payloads indexed by routing token T, retained for 7 days. |
 | Metadata Exposure | **Obfuscated.** Routing tokens are pairwise and random-looking; social graph is hidden from the server. |
 
 ### 10.2 Routing Table
 
-The server maintains an in-memory or persisted map of **mailboxes** indexed by 16-byte routing tokens:
-```kotlin
-val mailboxes: ConcurrentHashMap<RoutingToken, Queue<EncryptedMessage>>
-```
+The server maintains a Redis-backed map of **mailboxes** indexed by 16-byte routing tokens. Mailboxes are durable across server restarts.
 
 1. **POST /inbox/{token}:**
    - Push the payload into the corresponding queue.
-   - Apply a TTL of at least 30–60 minutes to ensure messages are available when Bob reconnects after a typical offline period.
+   - Apply a TTL of 7 days. This aligns with the client re-pair timeout: if Bob has not polled within 7 days, the session will be abandoned on both sides regardless.
 
 2. **GET /inbox/{token}:**
    - Drain and return all messages in the queue.
@@ -909,6 +909,4 @@ With this design:
 
 3. **Multi-Device Support.** Full session synchronization across multiple devices (e.g., phone and tablet) is a complex challenge planned for future work.
 
-4. **Server-Side Message Buffering TTL Tuning.** The current default TTL is 30–60 minutes (§10.2). The optimal value balances offline tolerance against server memory footprint and should be informed by real-world usage data.
-
-5. **Session Expiry and Staleness Handling.** If Alice stops sharing (app uninstalled, account deleted, extended offline period), Bob's client continues polling indefinitely against a token that will never receive new messages. Bob's client SHOULD implement exponential back-off after a configurable number of consecutive empty responses (e.g., back off after 10 empty polls, doubling the interval up to a maximum of 30 min), and SHOULD surface a "no recent location" staleness indicator to the user after a threshold (e.g., 2 hours without a new frame).
+4. **Session Expiry and Staleness Handling.** If Alice stops sharing (app uninstalled, account deleted, extended offline period), Bob's client continues polling indefinitely against a token that will never receive new messages. Bob's client SHOULD implement exponential back-off after a configurable number of consecutive empty responses (e.g., back off after 10 empty polls, doubling the interval up to a maximum of 30 min), and SHOULD surface a "no recent location" staleness indicator to the user after a threshold (e.g., 2 hours without a new frame).

--- a/docs/e2ee-location-sync.md
+++ b/docs/e2ee-location-sync.md
@@ -849,7 +849,7 @@ Recipients MUST reject any `EpochRotation` or `RatchetAck` whose decrypted `ts` 
 |---|---|
 | Routing Model | **Anonymous Mailboxes.** Routes opaque `EncryptedLocation` payloads by pairwise routing tokens (T). No userid-based addressing. |
 | Client Interaction | **Registration-less.** Clients poll `GET /inbox/{token}` and post `POST /inbox/{token}`; the server has no knowledge of user identity. |
-| Persistent store | **Opaque Payload Buffer.** Redis-backed durable buffer of encrypted payloads indexed by routing token T, retained for 7 days. |
+| Persistent store | **Opaque Payload Buffer.** Durable buffer of encrypted payloads indexed by routing token T, retained for 7 days. |
 | Metadata Exposure | **Obfuscated.** Routing tokens are pairwise and random-looking; social graph is hidden from the server. |
 
 ### 10.2 Routing Table
@@ -870,7 +870,7 @@ The server exposes only the mailbox API (`POST /inbox/{token}` and `GET /inbox/{
 
 - TLS termination (HTTPS).
 - Best-effort delivery model.
-- Horizontal scalability via Redis if needed.
+- Horizontal scalability.
 
 ### 10.4 Server Cannot Decrypt or Link
 

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -19,11 +19,14 @@ private func debugLog(_ msg: () -> String) {
 func qrPayloadToUrl(_ qr: Shared.QrPayload) -> String? {
     var ekPubData = toSwiftData(qr.ekPub)
     defer { ekPubData.zeroize() }
+    var secretData = toSwiftData(qr.discoverySecret)
+    defer { secretData.zeroize() }
 
     let dict: [String: Any] = [
         "ek_pub": ekPubData.base64EncodedString(),
         "suggested_name": qr.suggestedName,
         "fingerprint": qr.fingerprint,
+        "discovery_secret": secretData.base64EncodedString(),
     ]
     do {
         let jsonData = try JSONSerialization.data(withJSONObject: dict)
@@ -48,12 +51,15 @@ private func urlToQrPayload(_ url: String) -> Shared.QrPayload? {
           ekPub.count == 32,
           let name = dict["suggested_name"] as? String,
           let fp = dict["fingerprint"] as? String,
-          fp.count == 16
+          fp.count == 16,
+          let discoverySecret = (dict["discovery_secret"] as? String).flatMap({ Data(base64Encoded: $0) }),
+          discoverySecret.count == 32
     else { return nil }
     return Shared.QrPayload(
         ekPub: kotlinByteArray(from: ekPub),
         suggestedName: name,
-        fingerprint: fp
+        fingerprint: fp,
+        discoverySecret: kotlinByteArray(from: discoverySecret)
     )
 }
 
@@ -458,7 +464,8 @@ final class LocationSyncService: ObservableObject {
         let qrWithName = Shared.QrPayload(
             ekPub: qr.ekPub,
             suggestedName: friendName,
-            fingerprint: qr.fingerprint
+            fingerprint: qr.fingerprint,
+            discoverySecret: qr.discoverySecret
         )
         debugLog { "Scanning QR: discovery=\(toHex(qrWithName.discoveryToken())), friendName=\(friendName)" }
         isExchanging = true

--- a/server/src/test/kotlin/net/af0/where/E2eeBidirectionalEndToEndTest.kt
+++ b/server/src/test/kotlin/net/af0/where/E2eeBidirectionalEndToEndTest.kt
@@ -229,7 +229,7 @@ class E2eeBidirectionalEndToEndTest {
         runBlocking {
             initializeLibsodium()
             val bobStore = E2eeStore(MemoryE2eeStorage())
-            val qr = QrPayload(byteArrayOf(1, 2, 3), "Alice", "fp")
+            val qr = QrPayload(byteArrayOf(1, 2, 3), "Alice", "fp", ByteArray(32))
             val (initPayload, _) = bobStore.processScannedQr(qr, "Bob")
 
             // Use a non-existent host to trigger a failure

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/DiscoveryToken.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/DiscoveryToken.kt
@@ -1,10 +1,12 @@
 package net.af0.where.e2ee
 
 /**
- * Discovery token for the initial key-exchange rendezvous (§4.0 / danmarg/where#5).
+ * Discovery token for the initial key-exchange rendezvous (§4.2 / danmarg/where#5).
  *
- * Both Alice and Bob derive this from EK_A.pub — which is already present in the
- * QrPayload — so neither party needs prior knowledge of the other.
+ * The token is derived from a fresh random 32-byte [secret] that is embedded in
+ * the QR payload alongside EK_A.pub. Only someone who received the QR out-of-band
+ * can derive this token — in particular the server and any observer who later sees
+ * EK_A.pub in a network message cannot compute it (fixes danmarg/where#115).
  *
  * Flow:
  *   1. Alice generates a QR; her app polls /inbox/{discoveryToken} during the pending
@@ -14,19 +16,19 @@ package net.af0.where.e2ee
  *      the pairwise T_AB_0 routing token for all subsequent messages.
  *
  * The token is single-use: once Alice has processed Bob's init it is discarded.
- * EK_A is ephemeral (freshly generated per QR), so each invite produces a unique,
- * unlinkable discovery token.
+ * The [secret] is ephemeral (freshly generated per QR), so each invite produces a
+ * unique, unlinkable discovery token.
  *
- * @param ekPub Alice's ephemeral X25519 public key (32 bytes), taken from QrPayload.ekPub.
+ * @param secret Fresh random 32-byte secret from QrPayload.discoverySecret.
  * @return 16-byte discovery token (opaque; hex-encode for use as a URL path segment).
  */
-fun deriveDiscoveryToken(ekPub: ByteArray): ByteArray =
+fun deriveDiscoveryToken(secret: ByteArray): ByteArray =
     hkdfSha256(
-        ikm = ekPub,
+        ikm = secret,
         salt = ByteArray(32),
         info = "Where-v1-Discovery".encodeToByteArray(),
         length = 16,
     )
 
 /** Convenience extension — compute the discovery token from an existing QrPayload. */
-fun QrPayload.discoveryToken(): ByteArray = deriveDiscoveryToken(ekPub)
+fun QrPayload.discoveryToken(): ByteArray = deriveDiscoveryToken(discoverySecret)

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
@@ -27,6 +27,7 @@ object KeyExchange {
                 ekPub = ek.pub.copyOf(),
                 suggestedName = suggestedName,
                 fingerprint = fp,
+                discoverySecret = randomBytes(32),
             )
         return payload to ek.priv
     }

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
@@ -115,7 +115,10 @@ data class LocationPlaintext(
 
 /**
  * Alice's QR / invite-link payload.
- * Contains only her ephemeral public key; no long-term identity keys.
+ * Contains Alice's ephemeral public key and a fresh random secret used to derive
+ * the discovery token. Only someone who received the QR (out-of-band) knows
+ * [discoverySecret], so the discovery mailbox address is not computable by the
+ * server or a network observer who later sees EK_A.pub in a KeyExchangeInit.
  */
 @Serializable
 data class QrPayload(
@@ -126,17 +129,21 @@ data class QrPayload(
     val suggestedName: String,
     // hex(SHA-256(ekPub)[0:8])
     val fingerprint: String,
+    // Fresh random 32-byte secret; HKDF IKM for the discovery token (§4.2).
+    @SerialName("discovery_secret")
+    @Serializable(with = ByteArrayBase64Serializer::class) val discoverySecret: ByteArray,
 ) {
     override fun equals(other: Any?): Boolean {
         if (other !is QrPayload) return false
         return ekPub.contentEquals(other.ekPub) && suggestedName == other.suggestedName &&
-            fingerprint == other.fingerprint
+            fingerprint == other.fingerprint && discoverySecret.contentEquals(other.discoverySecret)
     }
 
     override fun hashCode(): Int {
         var h = ekPub.contentHashCode()
         h = 31 * h + suggestedName.hashCode()
         h = 31 * h + fingerprint.hashCode()
+        h = 31 * h + discoverySecret.contentHashCode()
         return h
     }
 }

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
@@ -275,7 +275,7 @@ class KeyExchangeTest {
         // Attacker knows the discovery token.
         val tamperedMsg =
             KeyExchangeInitMessage(
-                token = deriveDiscoveryToken(qr.ekPub),
+                token = deriveDiscoveryToken(qr.discoverySecret),
                 ekPub = ekM.pub.copyOf(),
                 keyConfirmation = KeyExchange.buildKeyConfirmation(skAM, qr.ekPub, ekM.pub),
                 suggestedName = "Attacker",
@@ -299,27 +299,27 @@ class KeyExchangeTest {
 
     @Test
     fun `deriveDiscoveryToken produces 16 bytes`() {
-        val ekPub = ByteArray(32) { it.toByte() }
-        assertEquals(16, deriveDiscoveryToken(ekPub).size)
+        val secret = ByteArray(32) { it.toByte() }
+        assertEquals(16, deriveDiscoveryToken(secret).size)
     }
 
     @Test
     fun `deriveDiscoveryToken is deterministic`() {
-        val ekPub = ByteArray(32) { it.toByte() }
-        assertContentEquals(deriveDiscoveryToken(ekPub), deriveDiscoveryToken(ekPub))
+        val secret = ByteArray(32) { it.toByte() }
+        assertContentEquals(deriveDiscoveryToken(secret), deriveDiscoveryToken(secret))
     }
 
     @Test
-    fun `deriveDiscoveryToken differs for distinct ephemeral keys`() {
-        val ek1 = generateX25519KeyPair().pub
-        val ek2 = generateX25519KeyPair().pub
-        assertNotEquals(deriveDiscoveryToken(ek1).toList(), deriveDiscoveryToken(ek2).toList())
+    fun `deriveDiscoveryToken differs for distinct secrets`() {
+        val s1 = ByteArray(32) { it.toByte() }
+        val s2 = ByteArray(32) { (it + 1).toByte() }
+        assertNotEquals(deriveDiscoveryToken(s1).toList(), deriveDiscoveryToken(s2).toList())
     }
 
     @Test
-    fun `QrPayload discoveryToken matches deriveDiscoveryToken on ekPub`() {
+    fun `QrPayload discoveryToken matches deriveDiscoveryToken on discoverySecret`() {
         val (qr, _) = KeyExchange.aliceCreateQrPayload("Alice")
-        assertContentEquals(deriveDiscoveryToken(qr.ekPub), qr.discoveryToken())
+        assertContentEquals(deriveDiscoveryToken(qr.discoverySecret), qr.discoveryToken())
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `QrPayload` now includes a fresh random 32-byte `discovery_secret` field alongside `EK_A.pub`
- `deriveDiscoveryToken` uses `discovery_secret` as HKDF IKM instead of `EK_A.pub`
- Only someone who received the QR out-of-band can compute the discovery token; the server and any observer who later sees `EK_A.pub` in a `KeyExchangeInit` message cannot retroactively correlate it to the discovery-phase mailbox

## Root cause

`EK_A.pub` is intentionally public — it appears in Bob's `KeyExchangeInit` message on the wire. Using it as HKDF IKM for the discovery token meant the server could map `EK_A.pub → discovery_token` and link the ephemeral key to the discovery-phase activity, undermining session unlinkability.

## Changes

- `shared/…/e2ee/Types.kt` — `discoverySecret: ByteArray` field added to `QrPayload` (`@SerialName("discovery_secret")`)
- `shared/…/e2ee/KeyExchange.kt` — `aliceCreateQrPayload` generates `randomBytes(32)` per invite
- `shared/…/e2ee/DiscoveryToken.kt` — `deriveDiscoveryToken(secret)` replaces `deriveDiscoveryToken(ekPub)`; `QrPayload.discoveryToken()` uses `discoverySecret`
- `cli/…/Main.kt` — URL serialization encodes/decodes `discoverySecret`; input validation added (`size != 32 → null`)
- `ios/…/LocationSyncService.swift` — URL serialization and `confirmQrScan` updated
- Tests, spec doc (§4.2, §4.4, §8.1) updated

## Test plan

- [x] `./gradlew :shared:jvmTest` passes
- [ ] Android build (`./gradlew :android:assembleDebug`)
- [ ] iOS build (`xcodegen && xcodebuild`)
- [ ] Manual QR invite flow end-to-end (Alice generates QR, Bob scans, session established)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)