### PR TITLE
Crypto: Exclude myEkPriv from SessionState serialization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 |---|---|
 | `shared/` | KMP library — data models, E2EE crypto implementations (Double Ratchet), `LocationClient` |
 | `android/` | Android app — Compose UI, FusedLocation foreground service, Google Maps |
-| `server/` | Ktor server — Anonymous Mailbox API, in-memory location store |
+| `server/` | Ktor server — Anonymous Mailbox API, Redis-backed persistent mailbox store |
 | `ios/` | iOS app — SwiftUI + MapKit + CoreLocation, native HTTP polling |
 
 ### Data flow
@@ -53,7 +53,8 @@
 - **iOS**: `distanceFilter = 50m` + `desiredAccuracy = kCLLocationAccuracyHundredMeters`; `startMonitoringSignificantLocationChanges()` when backgrounded.
 
 ### Server state
-- In-memory `ConcurrentHashMap`s for mailboxes. State is lost on restart.
+- Mailboxes are persisted in Redis. State survives restarts.
+- Messages are retained for 7 days, aligning with the client re-pair timeout.
 
 ---
 
@@ -122,6 +123,5 @@ and run on the JVM target via `:shared:jvmTest`.
 ---
 
 ## Planned future work
-- Persistent server storage
 - User-controlled sharing (groups, time-limited sharing)
 - Push notifications when a friend's location changes significantly

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
@@ -301,7 +301,7 @@ class LocationViewModelTest {
             viewModel = LocationViewModel(app, E2eeStore(FakeE2eeStorage()), startPolling = false)
             val vm = viewModel!!
 
-            val qr = QrPayload(byteArrayOf(1, 2, 3), "Alice", "fp")
+            val qr = QrPayload(byteArrayOf(1, 2, 3), "Alice", "fp", ByteArray(32))
 
             // Bob scans
             (vm.pendingQrForNaming as MutableStateFlow).value = qr
@@ -431,6 +431,7 @@ class LocationViewModelTest {
                     ekPub = byteArrayOf(1, 2, 3),
                     suggestedName = "Alice",
                     fingerprint = "alice_fp",
+                    discoverySecret = ByteArray(32),
                 )
 
             // 3. Call confirmQrScan (synchronous sets isExchanging = true before async work)
@@ -751,6 +752,7 @@ class LocationViewModelTest {
                     ekPub = byteArrayOf(1, 2, 3),
                     suggestedName = "Alice",
                     fingerprint = "fp",
+                    discoverySecret = ByteArray(32),
                 )
 
             // Mock store to return a friend

--- a/cli/src/main/kotlin/net/af0/where/cli/Main.kt
+++ b/cli/src/main/kotlin/net/af0/where/cli/Main.kt
@@ -55,11 +55,13 @@ fun qrPayloadToUrl(qr: QrPayload): String {
     // Mimic the iOS/Android URL format
     // {"ekPub": "...", "suggestedName": "...", "fingerprint": "..."}
     val ekPubB64 = Base64.getEncoder().encodeToString(qr.ekPub)
+    val secretB64 = Base64.getEncoder().encodeToString(qr.discoverySecret)
     val map =
         mapOf(
             "ekPub" to ekPubB64,
             "suggestedName" to qr.suggestedName,
             "fingerprint" to qr.fingerprint,
+            "discoverySecret" to secretB64,
         )
     val b64 = Base64.getUrlEncoder().withoutPadding().encodeToString(json.encodeToString(map).toByteArray())
     return "where://invite?q=$b64"
@@ -95,10 +97,13 @@ fun urlToQrPayload(url: String): QrPayload? {
     val decoded = String(Base64.getUrlDecoder().decode(q))
     val map: Map<String, String> = json.decodeFromString(decoded)
     val ekPub = Base64.getDecoder().decode(map["ekPub"] ?: return null)
+    val discoverySecret = map["discoverySecret"]?.let { Base64.getDecoder().decode(it) } ?: return null
+    if (ekPub.size != 32 || discoverySecret.size != 32) return null
     return QrPayload(
         ekPub = ekPub,
         suggestedName = map["suggestedName"] ?: "Friend",
         fingerprint = map["fingerprint"] ?: "",
+        discoverySecret = discoverySecret,
     )
 }
 

--- a/docs/e2ee-location-sync.md
+++ b/docs/e2ee-location-sync.md
@@ -854,7 +854,7 @@ Recipients MUST reject any `EpochRotation` or `RatchetAck` whose decrypted `ts` 
 
 ### 10.2 Routing Table
 
-The server maintains a Redis-backed map of **mailboxes** indexed by 16-byte routing tokens. Mailboxes are durable across server restarts.
+The server maintains a persistent map of **mailboxes** indexed by 16-byte routing tokens. Mailboxes are durable across server restarts.
 
 1. **POST /inbox/{token}:**
    - Push the payload into the corresponding queue.

--- a/docs/e2ee-location-sync.md
+++ b/docs/e2ee-location-sync.md
@@ -161,12 +161,13 @@ Both private keys are deleted immediately after `SK` is computed and verified.
 
 **Setup:**
 
-Alice opens "Add Friend" and generates a fresh ephemeral key pair `EK_A`. She displays a QR code encoding:
+Alice opens "Add Friend" and generates a fresh ephemeral key pair `EK_A` and a fresh random 32-byte `discovery_secret`. She displays a QR code encoding:
 ```
 {
-  "ek_pub":        base64(Alice.EK_A.pub),  // X25519 ephemeral public key (32 bytes)
-  "suggested_name": "Alice",
-  "fingerprint":   hex(SHA-256(EK_A.pub)[0:10])
+  "ek_pub":            base64(Alice.EK_A.pub),  // X25519 ephemeral public key (32 bytes)
+  "suggested_name":    "Alice",
+  "fingerprint":       hex(SHA-256(EK_A.pub)[0:10]),
+  "discovery_secret":  base64(random_32_bytes)   // fresh per QR; HKDF IKM for discovery token
 }
 ```
 
@@ -174,16 +175,18 @@ No long-term keys, no signatures. The QR is intentionally minimal.
 
 **Discovery Token (Pre-Session Rendezvous):**
 
-After Alice generates her QR, she derives the discovery token from `EK_A.pub`:
+After Alice generates her QR, she derives the discovery token from `discovery_secret`:
 
 ```
-discovery_token_A = HKDF-SHA-256(IKM  = Alice.EK_A.pub,
-                                  salt = 0x00...00,   // 32 zero bytes
+discovery_token_A = HKDF-SHA-256(IKM  = Alice.discovery_secret,   // 32-byte random secret
+                                  salt = 0x00...00,                // 32 zero bytes
                                   info = "Where-v1-Discovery")[0:16]
 ```
 
+Using a random secret (rather than `EK_A.pub`) as HKDF IKM ensures that only someone who received the QR out-of-band can compute `discovery_token_A`. A network observer who later sees `EK_A.pub` in Bob's `KeyExchangeInit` message cannot retroactively map it to the discovery-phase mailbox.
+
 - Alice begins polling `GET /inbox/{hex(discovery_token_A)}` immediately.
-- Bob derives the same `discovery_token_A` from the scanned `ek_pub` and POSTs his `KeyExchangeInit` there.
+- Bob derives the same `discovery_token_A` from the scanned `discovery_secret` and POSTs his `KeyExchangeInit` there.
 - Once Alice retrieves and processes the `KeyExchangeInit`, she switches to polling `recv_token` for all subsequent messages.
 - The discovery token is single-use and ephemeral: implementations MUST discard it after `aliceProcessInit` completes.
 
@@ -260,7 +263,7 @@ The key agreement proceeds identically to Option A, using the same discovery tok
 
 ### 4.4 What the Server Learns from Key Exchange
 
-- **Discovery phase:** A 16-byte token was used briefly for rendezvous. This token is derived from `EK_A.pub` (ephemeral, per-invite), so the server cannot link it to any stable user identity. The server observes that some IP polled it and another IP posted to it, but learns nothing about who those IPs represent.
+- **Discovery phase:** A 16-byte token was used briefly for rendezvous. This token is derived from a random 32-byte `discovery_secret` embedded in the QR (not from `EK_A.pub`), so neither the server nor any observer who later sees `EK_A.pub` in a `KeyExchangeInit` message can compute or correlate the discovery-phase mailbox. The server observes that some IP polled it and another IP posted to it, but learns nothing about who those IPs represent.
 - **`KeyExchangeInit` phase:** The server sees Bob's `EK_B.pub` (ephemeral, 32 bytes) and the HMAC confirmation tag. Both are ephemeral and single-use. No stable long-term key material is exposed to the server at any point.
 - **Nothing** about the resulting shared secret `SK`, the session fingerprints, or the identities of the participants.
 
@@ -383,7 +386,7 @@ This provides true asynchronous PCS: Alice can "heal" the session at any time us
 
 **OPK Depletion:** If Alice has no OPKs for Bob, she SHOULD continue broadcasting on the symmetric ratchet and SHOULD NOT rotate the DH epoch until a new bundle is received.
 
-**Retransmission:** Alice retransmits her `EpochRotation` every `T` minutes until she receives an `EncryptedLocation` acknowledgment or a `RatchetAck` (optional) from Bob.
+**EpochRotation delivery:** The server guarantees message durability for at least 7 days (see §10.2), so Alice does not need to retransmit `EpochRotation` messages. If Bob is offline, the `EpochRotation` will remain in the mailbox until he polls. If Alice has not received any valid `EncryptedLocation` or `RatchetAck` on the new token after 7 days, she SHOULD stop transmitting and prompt the user to re-pair.
 
 **Summary of PCS guarantees in OPK mode:**
 
@@ -533,7 +536,7 @@ Because of the indistinguishable response invariant (§7.2), clients can impleme
 | Message encryption | ChaCha20-Poly1305 | 256-bit | Per-message key; deleted after use |
 | Message authentication | ChaCha20-Poly1305 tag | 128-bit | Included in AEAD output; covers AAD |
 | Key exchange KDF | HKDF-SHA-256 | — | `info = "Where-v1-KeyExchange"` (initial SK) |
-| Discovery token | HKDF-SHA-256 | 16-byte output | `ikm = EK_A.pub`, `salt = 0x00*32`, `info = "Where-v1-Discovery"` (§4.2) |
+| Discovery token | HKDF-SHA-256 | 16-byte output | `ikm = discovery_secret` (32-byte random, from QR payload), `salt = 0x00*32`, `info = "Where-v1-Discovery"` (§4.2) |
 | Bundle auth key | HKDF-SHA-256 | 32-byte output | `K_bundle = HKDF(SK, salt=0, info="Where-v1-BundleAuth")`; for PreKeyBundle HMAC |
 | Rotation auth key | HKDF-SHA-256 | 32-byte output | `K_rot = HKDF(root_key, salt=epoch_be4, info="Where-v1-EpochRotation")`; for EpochRotation AEAD |
 | Ack auth key | HKDF-SHA-256 | 32-byte output | `K_ack = HKDF(new_root_key, salt=epoch_be4, info="Where-v1-RatchetAck")`; for RatchetAck AEAD |
@@ -846,19 +849,16 @@ Recipients MUST reject any `EpochRotation` or `RatchetAck` whose decrypted `ts` 
 |---|---|
 | Routing Model | **Anonymous Mailboxes.** Routes opaque `EncryptedLocation` payloads by pairwise routing tokens (T). No userid-based addressing. |
 | Client Interaction | **Registration-less.** Clients poll `GET /inbox/{token}` and post `POST /inbox/{token}`; the server has no knowledge of user identity. |
-| In-memory store | **Opaque Payload Buffer.** Brief TTL buffer of encrypted payloads indexed by routing token T. |
+| Persistent store | **Opaque Payload Buffer.** Redis-backed durable buffer of encrypted payloads indexed by routing token T, retained for 7 days. |
 | Metadata Exposure | **Obfuscated.** Routing tokens are pairwise and random-looking; social graph is hidden from the server. |
 
 ### 10.2 Routing Table
 
-The server maintains an in-memory or persisted map of **mailboxes** indexed by 16-byte routing tokens:
-```kotlin
-val mailboxes: ConcurrentHashMap<RoutingToken, Queue<EncryptedMessage>>
-```
+The server maintains a Redis-backed map of **mailboxes** indexed by 16-byte routing tokens. Mailboxes are durable across server restarts.
 
 1. **POST /inbox/{token}:**
    - Push the payload into the corresponding queue.
-   - Apply a TTL of at least 30–60 minutes to ensure messages are available when Bob reconnects after a typical offline period.
+   - Apply a TTL of 7 days. This aligns with the client re-pair timeout: if Bob has not polled within 7 days, the session will be abandoned on both sides regardless.
 
 2. **GET /inbox/{token}:**
    - Drain and return all messages in the queue.
@@ -909,6 +909,4 @@ With this design:
 
 3. **Multi-Device Support.** Full session synchronization across multiple devices (e.g., phone and tablet) is a complex challenge planned for future work.
 
-4. **Server-Side Message Buffering TTL Tuning.** The current default TTL is 30–60 minutes (§10.2). The optimal value balances offline tolerance against server memory footprint and should be informed by real-world usage data.
-
-5. **Session Expiry and Staleness Handling.** If Alice stops sharing (app uninstalled, account deleted, extended offline period), Bob's client continues polling indefinitely against a token that will never receive new messages. Bob's client SHOULD implement exponential back-off after a configurable number of consecutive empty responses (e.g., back off after 10 empty polls, doubling the interval up to a maximum of 30 min), and SHOULD surface a "no recent location" staleness indicator to the user after a threshold (e.g., 2 hours without a new frame).
+4. **Session Expiry and Staleness Handling.** If Alice stops sharing (app uninstalled, account deleted, extended offline period), Bob's client continues polling indefinitely against a token that will never receive new messages. Bob's client SHOULD implement exponential back-off after a configurable number of consecutive empty responses (e.g., back off after 10 empty polls, doubling the interval up to a maximum of 30 min), and SHOULD surface a "no recent location" staleness indicator to the user after a threshold (e.g., 2 hours without a new frame).

--- a/docs/e2ee-location-sync.md
+++ b/docs/e2ee-location-sync.md
@@ -849,7 +849,7 @@ Recipients MUST reject any `EpochRotation` or `RatchetAck` whose decrypted `ts` 
 |---|---|
 | Routing Model | **Anonymous Mailboxes.** Routes opaque `EncryptedLocation` payloads by pairwise routing tokens (T). No userid-based addressing. |
 | Client Interaction | **Registration-less.** Clients poll `GET /inbox/{token}` and post `POST /inbox/{token}`; the server has no knowledge of user identity. |
-| Persistent store | **Opaque Payload Buffer.** Redis-backed durable buffer of encrypted payloads indexed by routing token T, retained for 7 days. |
+| Persistent store | **Opaque Payload Buffer.** Durable buffer of encrypted payloads indexed by routing token T, retained for 7 days. |
 | Metadata Exposure | **Obfuscated.** Routing tokens are pairwise and random-looking; social graph is hidden from the server. |
 
 ### 10.2 Routing Table
@@ -870,7 +870,7 @@ The server exposes only the mailbox API (`POST /inbox/{token}` and `GET /inbox/{
 
 - TLS termination (HTTPS).
 - Best-effort delivery model.
-- Horizontal scalability via Redis if needed.
+- Horizontal scalability.
 
 ### 10.4 Server Cannot Decrypt or Link
 

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -19,11 +19,14 @@ private func debugLog(_ msg: () -> String) {
 func qrPayloadToUrl(_ qr: Shared.QrPayload) -> String? {
     var ekPubData = toSwiftData(qr.ekPub)
     defer { ekPubData.zeroize() }
+    var secretData = toSwiftData(qr.discoverySecret)
+    defer { secretData.zeroize() }
 
     let dict: [String: Any] = [
         "ek_pub": ekPubData.base64EncodedString(),
         "suggested_name": qr.suggestedName,
         "fingerprint": qr.fingerprint,
+        "discovery_secret": secretData.base64EncodedString(),
     ]
     do {
         let jsonData = try JSONSerialization.data(withJSONObject: dict)
@@ -48,12 +51,15 @@ private func urlToQrPayload(_ url: String) -> Shared.QrPayload? {
           ekPub.count == 32,
           let name = dict["suggested_name"] as? String,
           let fp = dict["fingerprint"] as? String,
-          fp.count == 16
+          fp.count == 16,
+          let discoverySecret = (dict["discovery_secret"] as? String).flatMap({ Data(base64Encoded: $0) }),
+          discoverySecret.count == 32
     else { return nil }
     return Shared.QrPayload(
         ekPub: kotlinByteArray(from: ekPub),
         suggestedName: name,
-        fingerprint: fp
+        fingerprint: fp,
+        discoverySecret: kotlinByteArray(from: discoverySecret)
     )
 }
 
@@ -458,7 +464,8 @@ final class LocationSyncService: ObservableObject {
         let qrWithName = Shared.QrPayload(
             ekPub: qr.ekPub,
             suggestedName: friendName,
-            fingerprint: qr.fingerprint
+            fingerprint: qr.fingerprint,
+            discoverySecret: qr.discoverySecret
         )
         debugLog { "Scanning QR: discovery=\(toHex(qrWithName.discoveryToken())), friendName=\(friendName)" }
         isExchanging = true

--- a/server/src/test/kotlin/net/af0/where/E2eeBidirectionalEndToEndTest.kt
+++ b/server/src/test/kotlin/net/af0/where/E2eeBidirectionalEndToEndTest.kt
@@ -229,7 +229,7 @@ class E2eeBidirectionalEndToEndTest {
         runBlocking {
             initializeLibsodium()
             val bobStore = E2eeStore(MemoryE2eeStorage())
-            val qr = QrPayload(byteArrayOf(1, 2, 3), "Alice", "fp")
+            val qr = QrPayload(byteArrayOf(1, 2, 3), "Alice", "fp", ByteArray(32))
             val (initPayload, _) = bobStore.processScannedQr(qr, "Bob")
 
             // Use a non-existent host to trigger a failure

--- a/server/src/test/kotlin/net/af0/where/E2eeIntegrationTest.kt
+++ b/server/src/test/kotlin/net/af0/where/E2eeIntegrationTest.kt
@@ -315,6 +315,8 @@ class E2eeIntegrationTest {
                     1,
                     bobState.aliceFp,
                     bobState.bobFp,
+                    0L,
+                    0L,
                 )
             assertEquals(1, bobState.epoch)
 
@@ -364,6 +366,8 @@ class E2eeIntegrationTest {
                 1,
                 bobState0.aliceFp,
                 bobState0.bobFp,
+                0L,
+                0L,
             )
 
         // Correct: decrypt epoch-0 message with the epoch-0 (pre-rotation) state

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/DiscoveryToken.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/DiscoveryToken.kt
@@ -1,10 +1,12 @@
 package net.af0.where.e2ee
 
 /**
- * Discovery token for the initial key-exchange rendezvous (§4.0 / danmarg/where#5).
+ * Discovery token for the initial key-exchange rendezvous (§4.2 / danmarg/where#5).
  *
- * Both Alice and Bob derive this from EK_A.pub — which is already present in the
- * QrPayload — so neither party needs prior knowledge of the other.
+ * The token is derived from a fresh random 32-byte [secret] that is embedded in
+ * the QR payload alongside EK_A.pub. Only someone who received the QR out-of-band
+ * can derive this token — in particular the server and any observer who later sees
+ * EK_A.pub in a network message cannot compute it (fixes danmarg/where#115).
  *
  * Flow:
  *   1. Alice generates a QR; her app polls /inbox/{discoveryToken} during the pending
@@ -14,19 +16,19 @@ package net.af0.where.e2ee
  *      the pairwise T_AB_0 routing token for all subsequent messages.
  *
  * The token is single-use: once Alice has processed Bob's init it is discarded.
- * EK_A is ephemeral (freshly generated per QR), so each invite produces a unique,
- * unlinkable discovery token.
+ * The [secret] is ephemeral (freshly generated per QR), so each invite produces a
+ * unique, unlinkable discovery token.
  *
- * @param ekPub Alice's ephemeral X25519 public key (32 bytes), taken from QrPayload.ekPub.
+ * @param secret Fresh random 32-byte secret from QrPayload.discoverySecret.
  * @return 16-byte discovery token (opaque; hex-encode for use as a URL path segment).
  */
-fun deriveDiscoveryToken(ekPub: ByteArray): ByteArray =
+fun deriveDiscoveryToken(secret: ByteArray): ByteArray =
     hkdfSha256(
-        ikm = ekPub,
+        ikm = secret,
         salt = ByteArray(32),
         info = "Where-v1-Discovery".encodeToByteArray(),
         length = 16,
     )
 
 /** Convenience extension — compute the discovery token from an existing QrPayload. */
-fun QrPayload.discoveryToken(): ByteArray = deriveDiscoveryToken(ekPub)
+fun QrPayload.discoveryToken(): ByteArray = deriveDiscoveryToken(discoverySecret)

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -147,7 +147,7 @@ class E2eeStore(
                         SerializedFriendEntry(
                             friendId = f.id,
                             name = f.name,
-                            session = f.session,
+                            session = f.session.copy(myEkPriv = ByteArray(32)),
                             isInitiator = f.isInitiator,
                             myOpkPrivs = f.myOpkPrivs.map { (id, key) -> SerializedOpkEntry(id, key) },
                             theirOpkPubs = f.theirOpkPubs.map { (id, key) -> SerializedOpkEntry(id, key) },

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -320,6 +320,29 @@ class E2eeStore(
         }
     }
 
+    /**
+     * Clear the previous receive token state (used during epoch rotation window).
+     * Zeroes out the old chain key before nulling it.
+     */
+    suspend fun clearPrevRecvState(id: String) {
+        stateLock.withLock {
+            val entry = friends[id] ?: return@withLock
+            val session = entry.session
+            if (session.prevRecvToken == null && session.prevRecvChainKey == null) return@withLock
+
+            session.prevRecvChainKey?.fill(0)
+            friends[id] = entry.copy(
+                session = session.copy(
+                    prevRecvToken = null,
+                    prevRecvTokenDeadline = 0L,
+                    prevRecvChainKey = null,
+                    prevRecvSeq = 0L
+                )
+            )
+            save()
+        }
+    }
+
     // -----------------------------------------------------------------------
     // OPK management
     // -----------------------------------------------------------------------

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -544,6 +544,8 @@ class E2eeStore(
                     newEpoch = payload.epoch,
                     senderFp = entry.session.aliceFp,
                     recipientFp = entry.session.bobFp,
+                    currentTime = currentTimeSeconds(),
+                    timeout = PREV_TOKEN_TIMEOUT_SECONDS,
                 )
 
             // Step 2: Refresh Bob's own send chain
@@ -668,11 +670,17 @@ class E2eeStore(
      * }
      * ```
      *
+     * @param friendId   ID of the friend whose messages are being processed.
+     * @param messages   Batch of payloads from the mailbox.
+     * @param tokenUsed  The hex-encoded token from which these messages were polled.
+     *                   If this matches the session's prevRecvToken, the old chain state
+     *                   is used for decryption.
      * @return [PollBatchResult], or null if [friendId] is not found.
      */
     suspend fun processBatch(
         friendId: String,
         messages: List<MailboxPayload>,
+        tokenUsed: String? = null,
     ): PollBatchResult? =
         stateLock.withLock {
             friends[friendId] ?: return@withLock null
@@ -700,29 +708,60 @@ class E2eeStore(
             }
 
             // Step 2: Decrypt location updates BEFORE processing epoch rotation.
-            // All EncryptedLocationPayloads on this token are from the current epoch.
-            val preRotationSession = friends[friendId]?.session ?: return@withLock PollBatchResult(emptyList(), null, emptyList())
-            var currentSession = preRotationSession
-            for (msg in messages.filterIsInstance<EncryptedLocationPayload>().sortedBy { it.seqAsLong() }) {
+            // All EncryptedLocationPayloads on this token are from the same epoch.
+            val sessionAtStart = friends[friendId]?.session ?: return@withLock PollBatchResult(emptyList(), null, emptyList())
+            val isPrevToken = tokenUsed != null && sessionAtStart.prevRecvToken?.toHex() == tokenUsed
+
+            // Construct a temporary SessionState for decryption if this is the old token.
+            var decryptionSession = if (isPrevToken && sessionAtStart.prevRecvChainKey != null) {
+                sessionAtStart.copy(
+                    epoch = sessionAtStart.epoch - 1,
+                    recvChainKey = sessionAtStart.prevRecvChainKey,
+                    recvSeq = sessionAtStart.prevRecvSeq,
+                )
+            } else {
+                sessionAtStart
+            }
+
+            val sortedLocations = messages.filterIsInstance<EncryptedLocationPayload>().sortedBy { it.seqAsLong() }
+            for (msg in sortedLocations) {
                 try {
                     val (newSession, loc) =
                         Session.decryptLocation(
-                            state = currentSession,
+                            state = decryptionSession,
                             ct = msg.ct,
                             seq = msg.seqAsLong(),
-                            senderFp = currentSession.aliceFp,
-                            recipientFp = currentSession.bobFp,
+                            senderFp = decryptionSession.aliceFp,
+                            recipientFp = decryptionSession.bobFp,
                         )
-                    currentSession = newSession
+                    decryptionSession = newSession
                     decryptedLocations.add(loc)
                 } catch (_: Exception) {
                     // drop individually bad messages rather than aborting the whole batch
                 }
             }
-            if (currentSession !== preRotationSession) {
-                val entry = friends[friendId] ?: return@withLock PollBatchResult(decryptedLocations, null, emptyList())
-                friends[friendId] = entry.copy(session = currentSession)
+
+            // Save the updated receive state back to the correct fields.
+            val entryAfterDecryption = friends[friendId] ?: return@withLock PollBatchResult(decryptedLocations, null, emptyList())
+            val updatedSession = if (isPrevToken) {
+                // If we decrypted messages on the old token, update the prevRecv fields.
+                entryAfterDecryption.session.copy(
+                    prevRecvChainKey = decryptionSession.recvChainKey,
+                    prevRecvSeq = decryptionSession.recvSeq,
+                )
+            } else {
+                // If we decrypted messages on the new token, update the main recv fields.
+                var s = entryAfterDecryption.session.copy(
+                    recvChainKey = decryptionSession.recvChainKey,
+                    recvSeq = decryptionSession.recvSeq,
+                )
+                // §8.3: Stop polling the old token once we have a valid message on the new one.
+                if (decryptedLocations.isNotEmpty() && s.prevRecvToken != null) {
+                    s = s.copy(prevRecvToken = null, prevRecvTokenDeadline = 0L, prevRecvChainKey = null, prevRecvSeq = 0L)
+                }
+                s
             }
+            friends[friendId] = entryAfterDecryption.copy(session = updatedSession)
 
             // Step 3: Process epoch rotation (after location decryption).
             for (msg in messages.filterIsInstance<EpochRotationPayload>()) {
@@ -757,6 +796,8 @@ class E2eeStore(
                         newEpoch = msg.epoch,
                         senderFp = entry.session.aliceFp,
                         recipientFp = entry.session.bobFp,
+                        currentTime = currentTimeSeconds(),
+                        timeout = PREV_TOKEN_TIMEOUT_SECONDS,
                     )
 
                 // Step 3b: Refresh Bob's own send chain
@@ -920,6 +961,12 @@ class E2eeStore(
          * open the app and trigger a maintenance poll.
          */
         const val ACK_TIMEOUT_SECONDS = 7L * 24 * 3600
+
+        /**
+         * How long Bob continues polling the old recvToken after Alice rotates epochs.
+         * Per §8.3, this should be 2*T. 1 hour (3600s) is a safe upper bound.
+         */
+        const val PREV_TOKEN_TIMEOUT_SECONDS = 3600L
     }
 }
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
@@ -27,6 +27,7 @@ object KeyExchange {
                 ekPub = ek.pub.copyOf(),
                 suggestedName = suggestedName,
                 fingerprint = fp,
+                discoverySecret = randomBytes(32),
             )
         return payload to ek.priv
     }

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -68,6 +68,9 @@ open class LocationClient(
         initialFriend.session.prevRecvToken?.let { prev ->
             if (currentTimeSeconds() < initialFriend.session.prevRecvTokenDeadline) {
                 tokensToPoll.add(prev.toHex())
+            } else {
+                // Deadline passed: eager cleanup of stale chain state.
+                store.clearPrevRecvState(friendId)
             }
         }
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -61,34 +61,44 @@ open class LocationClient(
      */
     private suspend fun pollFriend(friendId: String): List<UserLocation> {
         val updates = mutableListOf<UserLocation>()
-        var currentFriend = store.getFriend(friendId) ?: return emptyList()
-        var tokenToPoll = currentFriend.session.recvToken.toHex()
+        val initialFriend = store.getFriend(friendId) ?: return emptyList()
 
-        while (true) {
-            val messages = E2eeMailboxClient.poll(baseUrl, tokenToPoll)
-            println("[LocationClient] pollFriend($friendId): got ${messages.size} messages, token=$tokenToPoll")
-            if (messages.isEmpty()) break
-
-            val result = store.processBatch(friendId, messages)
-            if (result == null) {
-                println("[LocationClient] pollFriend($friendId): processBatch returned null")
-                break
+        // §8.3: Poll both old and new tokens if we are in the rotation window.
+        val tokensToPoll = mutableListOf(initialFriend.session.recvToken.toHex())
+        initialFriend.session.prevRecvToken?.let { prev ->
+            if (currentTimeSeconds() < initialFriend.session.prevRecvTokenDeadline) {
+                tokensToPoll.add(prev.toHex())
             }
-            println("[LocationClient] pollFriend($friendId): processBatch returned ${result.decryptedLocations.size} locations")
-            updates.addAll(
-                result.decryptedLocations.map { loc ->
-                    UserLocation(userId = friendId, lat = loc.lat, lng = loc.lng, timestamp = loc.ts)
-                },
-            )
+        }
 
-            // Post any required protocol responses (RatchetAcks, OPK bundles)
-            for (out in result.outgoing) {
-                E2eeMailboxClient.post(baseUrl, out.token, out.payload)
+        for (token in tokensToPoll) {
+            var currentToken = token
+            while (true) {
+                val messages = E2eeMailboxClient.poll(baseUrl, currentToken)
+                println("[LocationClient] pollFriend($friendId): got ${messages.size} messages, token=$currentToken")
+                if (messages.isEmpty()) break
+
+                val result = store.processBatch(friendId, messages, tokenUsed = currentToken)
+                if (result == null) {
+                    println("[LocationClient] pollFriend($friendId): processBatch returned null")
+                    break
+                }
+                println("[LocationClient] pollFriend($friendId): processBatch returned ${result.decryptedLocations.size} locations")
+                updates.addAll(
+                    result.decryptedLocations.map { loc ->
+                        UserLocation(userId = friendId, lat = loc.lat, lng = loc.lng, timestamp = loc.ts)
+                    },
+                )
+
+                // Post any required protocol responses (RatchetAcks, OPK bundles)
+                for (out in result.outgoing) {
+                    E2eeMailboxClient.post(baseUrl, out.token, out.payload)
+                }
+
+                // If an epoch rotation happened, we MUST poll the new token immediately
+                // to ensure messages Alice posted to the new epoch aren't delayed.
+                currentToken = result.newToken ?: break
             }
-
-            // If an epoch rotation happened, we MUST poll the new token immediately
-            // to ensure messages Alice posted to the new epoch aren't delayed.
-            tokenToPoll = result.newToken ?: break
         }
         return updates
     }

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -211,6 +211,8 @@ object Session {
      * @param bobOpkPriv  Bob's OPK private key for the consumed opk_id.
      * @param senderFp    Alice's fingerprint.
      * @param recipientFp Bob's fingerprint.
+     * @param currentTime Bob's current local time (Unix seconds).
+     * @param timeout     How long to continue polling the old token (seconds).
      */
     fun bobProcessAliceRotation(
         state: SessionState,
@@ -219,6 +221,8 @@ object Session {
         newEpoch: Int,
         senderFp: ByteArray,
         recipientFp: ByteArray,
+        currentTime: Long,
+        timeout: Long,
     ): SessionState {
         val dhOut = x25519(bobOpkPriv, aliceNewEkPub)
         val ratchetStep = kdfRk(state.rootKey, dhOut)
@@ -234,6 +238,11 @@ object Session {
                 epoch = newEpoch,
                 theirEkPub = aliceNewEkPub.copyOf(),
                 recvSeq = 0L,
+                // §8.3: Continue polling old token for a safety window.
+                prevRecvToken = state.recvToken.copyOf(),
+                prevRecvTokenDeadline = currentTime + timeout,
+                prevRecvChainKey = state.recvChainKey.copyOf(),
+                prevRecvSeq = state.recvSeq,
             )
 
         // Security (§5.5, §11): zero out ephemeral keys after use

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
@@ -129,7 +129,10 @@ data class LocationPlaintext(
 
 /**
  * Alice's QR / invite-link payload.
- * Contains only her ephemeral public key; no long-term identity keys.
+ * Contains Alice's ephemeral public key and a fresh random secret used to derive
+ * the discovery token. Only someone who received the QR (out-of-band) knows
+ * [discoverySecret], so the discovery mailbox address is not computable by the
+ * server or a network observer who later sees EK_A.pub in a KeyExchangeInit.
  */
 @Serializable
 data class QrPayload(
@@ -140,17 +143,21 @@ data class QrPayload(
     val suggestedName: String,
     // hex(SHA-256(ekPub)[0:8])
     val fingerprint: String,
+    // Fresh random 32-byte secret; HKDF IKM for the discovery token (§4.2).
+    @SerialName("discovery_secret")
+    @Serializable(with = ByteArrayBase64Serializer::class) val discoverySecret: ByteArray,
 ) {
     override fun equals(other: Any?): Boolean {
         if (other !is QrPayload) return false
         return ekPub.contentEquals(other.ekPub) && suggestedName == other.suggestedName &&
-            fingerprint == other.fingerprint
+            fingerprint == other.fingerprint && discoverySecret.contentEquals(other.discoverySecret)
     }
 
     override fun hashCode(): Int {
         var h = ekPub.contentHashCode()
         h = 31 * h + suggestedName.hashCode()
         h = 31 * h + fingerprint.hashCode()
+        h = 31 * h + discoverySecret.contentHashCode()
         return h
     }
 }

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
@@ -48,7 +48,7 @@ data class SessionState(
     val sendSeq: Long,
     val recvSeq: Long,
     val epoch: Int,
-    @Serializable(with = ByteArrayBase64Serializer::class) val myEkPriv: ByteArray,
+    @kotlinx.serialization.Transient val myEkPriv: ByteArray = ByteArray(32),
     @Serializable(with = ByteArrayBase64Serializer::class) val myEkPub: ByteArray,
     @Serializable(with = ByteArrayBase64Serializer::class) val theirEkPub: ByteArray,
     @Serializable(with = ByteArrayBase64Serializer::class) val aliceFp: ByteArray,

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
@@ -56,6 +56,10 @@ data class SessionState(
     @Serializable(with = ByteArrayBase64Serializer::class) val aliceEkPub: ByteArray,
     @Serializable(with = ByteArrayBase64Serializer::class) val bobEkPub: ByteArray,
     @Serializable(with = ByteArrayBase64Serializer::class) val kBundle: ByteArray,
+    @Serializable(with = ByteArrayBase64Serializer::class) val prevRecvToken: ByteArray? = null,
+    val prevRecvTokenDeadline: Long = 0L,
+    @Serializable(with = ByteArrayBase64Serializer::class) val prevRecvChainKey: ByteArray? = null,
+    val prevRecvSeq: Long = 0L,
 ) {
     override fun equals(other: Any?): Boolean {
         if (other !is SessionState) return false
@@ -74,7 +78,13 @@ data class SessionState(
             bobFp.contentEquals(other.bobFp) &&
             aliceEkPub.contentEquals(other.aliceEkPub) &&
             bobEkPub.contentEquals(other.bobEkPub) &&
-            kBundle.contentEquals(other.kBundle)
+            kBundle.contentEquals(other.kBundle) &&
+            ((prevRecvToken == null && other.prevRecvToken == null) ||
+                (prevRecvToken != null && other.prevRecvToken != null && prevRecvToken.contentEquals(other.prevRecvToken))) &&
+            prevRecvTokenDeadline == other.prevRecvTokenDeadline &&
+            ((prevRecvChainKey == null && other.prevRecvChainKey == null) ||
+                (prevRecvChainKey != null && other.prevRecvChainKey != null && prevRecvChainKey.contentEquals(other.prevRecvChainKey))) &&
+            prevRecvSeq == other.prevRecvSeq
     }
 
     override fun hashCode(): Int {
@@ -94,6 +104,10 @@ data class SessionState(
         h = 31 * h + aliceEkPub.contentHashCode()
         h = 31 * h + bobEkPub.contentHashCode()
         h = 31 * h + kBundle.contentHashCode()
+        h = 31 * h + (prevRecvToken?.contentHashCode() ?: 0)
+        h = 31 * h + prevRecvTokenDeadline.hashCode()
+        h = 31 * h + (prevRecvChainKey?.contentHashCode() ?: 0)
+        h = 31 * h + prevRecvSeq.hashCode()
         return h
     }
 }

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeStoreTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeStoreTest.kt
@@ -444,4 +444,82 @@ class E2eeStoreTest {
             assertNotNull(result, "Decryption must succeed even after OPK depletion")
             assertEquals(loc.lat, result!!.second.lat, 1e-9)
         }
+
+    @Test
+    fun testDualPollingWindow() =
+        runBlocking {
+            val qr = aliceStore.createInvite("Alice")
+            val (initPayload, bobEntry) = bobStore.processScannedQr(qr)
+            val aliceEntry = aliceStore.processKeyExchangeInit(initPayload, "Bob")!!
+
+            // Bob generates OPKs, Alice stores them
+            val bundle = bobStore.generateOpkBundle(bobEntry.id, count = 1)!!
+            aliceStore.storeOpkBundle(aliceEntry.id, bundle)
+
+            // 1. Alice sends a message in epoch 0
+            val loc0 = LocationPlaintext(1.0, 1.0, 1.0, 1000L)
+            val aliceFriend0 = aliceStore.getFriend(aliceEntry.id)!!
+            val (aliceSess0, ct0) =
+                Session.encryptLocation(
+                    aliceFriend0.session,
+                    loc0,
+                    aliceFriend0.session.aliceFp,
+                    aliceFriend0.session.bobFp,
+                )
+            aliceStore.updateSession(aliceEntry.id, aliceSess0)
+
+            val payload0 = EncryptedLocationPayload(epoch = aliceSess0.epoch, seq = aliceSess0.sendSeq.toString(), ct = ct0)
+            val oldToken = aliceSess0.sendToken.toHex()
+
+            // 2. Alice rotates to epoch 1
+            val rotPayload = aliceStore.initiateEpochRotation(aliceEntry.id)!!
+            val aliceFriend1 = aliceStore.getFriend(aliceEntry.id)!!
+            assertEquals(1, aliceFriend1.session.epoch)
+            val newToken = aliceFriend1.session.recvToken.toHex() // From Bob's perspective
+
+            // 3. Bob polls old token and sees BOTH the location and the rotation
+            val batch = listOf(payload0, rotPayload)
+            val result = bobStore.processBatch(bobEntry.id, batch, tokenUsed = oldToken)!!
+
+            assertEquals(1, result.decryptedLocations.size)
+            assertEquals(loc0.lat, result.decryptedLocations[0].lat)
+            assertNotNull(result.newToken)
+
+            val bobFriend1 = bobStore.getFriend(bobEntry.id)!!
+            assertEquals(1, bobFriend1.session.epoch)
+            assertNotNull(bobFriend1.session.prevRecvToken)
+            assertContentEquals(oldToken.hexToByteArray(), bobFriend1.session.prevRecvToken)
+
+            // 4. Alice sends another message in epoch 0 (simulating delayed arrival)
+            val loc0b = LocationPlaintext(2.0, 2.0, 2.0, 1001L)
+            val (aliceSess0b, ct0b) = Session.encryptLocation(aliceSess0, loc0b, aliceSess0.aliceFp, aliceSess0.bobFp)
+            val payload0b = EncryptedLocationPayload(epoch = aliceSess0b.epoch, seq = aliceSess0b.sendSeq.toString(), ct = ct0b)
+
+            // Bob polls the old token AGAIN
+            val result2 = bobStore.processBatch(bobEntry.id, listOf(payload0b), tokenUsed = oldToken)!!
+            assertEquals(1, result2.decryptedLocations.size)
+            assertEquals(loc0b.lat, result2.decryptedLocations[0].lat)
+
+            // 5. Alice sends a message in epoch 1
+            val loc1 = LocationPlaintext(3.0, 3.0, 3.0, 1002L)
+            val (aliceSess1, ct1) =
+                Session.encryptLocation(
+                    aliceFriend1.session,
+                    loc1,
+                    aliceFriend1.session.aliceFp,
+                    aliceFriend1.session.bobFp,
+                )
+            aliceStore.updateSession(aliceEntry.id, aliceSess1)
+            val payload1 = EncryptedLocationPayload(epoch = aliceSess1.epoch, seq = aliceSess1.sendSeq.toString(), ct = ct1)
+
+            // Bob polls the NEW token
+            val result3 = bobStore.processBatch(bobEntry.id, listOf(payload1), tokenUsed = newToken)!!
+            assertEquals(1, result3.decryptedLocations.size)
+            assertEquals(loc1.lat, result3.decryptedLocations[0].lat)
+
+            // 6. Verify that prevRecvToken is cleared after successful decryption on new token
+            val bobFriendFinal = bobStore.getFriend(bobEntry.id)!!
+            assertNull(bobFriendFinal.session.prevRecvToken)
+            assertNull(bobFriendFinal.session.prevRecvChainKey)
+        }
 }

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
@@ -275,7 +275,7 @@ class KeyExchangeTest {
         // Attacker knows the discovery token.
         val tamperedMsg =
             KeyExchangeInitMessage(
-                token = deriveDiscoveryToken(qr.ekPub),
+                token = deriveDiscoveryToken(qr.discoverySecret),
                 ekPub = ekM.pub.copyOf(),
                 keyConfirmation = KeyExchange.buildKeyConfirmation(skAM, qr.ekPub, ekM.pub),
                 suggestedName = "Attacker",
@@ -299,27 +299,27 @@ class KeyExchangeTest {
 
     @Test
     fun `deriveDiscoveryToken produces 16 bytes`() {
-        val ekPub = ByteArray(32) { it.toByte() }
-        assertEquals(16, deriveDiscoveryToken(ekPub).size)
+        val secret = ByteArray(32) { it.toByte() }
+        assertEquals(16, deriveDiscoveryToken(secret).size)
     }
 
     @Test
     fun `deriveDiscoveryToken is deterministic`() {
-        val ekPub = ByteArray(32) { it.toByte() }
-        assertContentEquals(deriveDiscoveryToken(ekPub), deriveDiscoveryToken(ekPub))
+        val secret = ByteArray(32) { it.toByte() }
+        assertContentEquals(deriveDiscoveryToken(secret), deriveDiscoveryToken(secret))
     }
 
     @Test
-    fun `deriveDiscoveryToken differs for distinct ephemeral keys`() {
-        val ek1 = generateX25519KeyPair().pub
-        val ek2 = generateX25519KeyPair().pub
-        assertNotEquals(deriveDiscoveryToken(ek1).toList(), deriveDiscoveryToken(ek2).toList())
+    fun `deriveDiscoveryToken differs for distinct secrets`() {
+        val s1 = ByteArray(32) { it.toByte() }
+        val s2 = ByteArray(32) { (it + 1).toByte() }
+        assertNotEquals(deriveDiscoveryToken(s1).toList(), deriveDiscoveryToken(s2).toList())
     }
 
     @Test
-    fun `QrPayload discoveryToken matches deriveDiscoveryToken on ekPub`() {
+    fun `QrPayload discoveryToken matches deriveDiscoveryToken on discoverySecret`() {
         val (qr, _) = KeyExchange.aliceCreateQrPayload("Alice")
-        assertContentEquals(deriveDiscoveryToken(qr.ekPub), qr.discoveryToken())
+        assertContentEquals(deriveDiscoveryToken(qr.discoverySecret), qr.discoveryToken())
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/SessionTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/SessionTest.kt
@@ -237,6 +237,8 @@ class SessionTest {
                 newEpoch = 1,
                 senderFp = bobSession.aliceFp,
                 recipientFp = bobSession.bobFp,
+                currentTime = 0L,
+                timeout = 0L,
             )
 
         assertEquals(1, aliceRotated.epoch)
@@ -273,6 +275,8 @@ class SessionTest {
                 1,
                 bobSession.aliceFp,
                 bobSession.bobFp,
+                0L,
+                0L,
             )
 
         val loc = LocationPlaintext(lat = 48.8566, lng = 2.3522, acc = 5.0, ts = 1711155000L)
@@ -455,6 +459,8 @@ class SessionTest {
             newEpoch = 1,
             senderFp = bobSession.aliceFp,
             recipientFp = bobSession.bobFp,
+            currentTime = 0L,
+            timeout = 0L,
         )
         assertTrue(bobOpk.priv.all { it == 0.toByte() }, "bobOpkPriv should be zeroed")
 


### PR DESCRIPTION
Mark SessionState.myEkPriv as @Transient to prevent accidental persistence of the current epoch's ephemeral X25519 private key in plaintext JSON.

The persistence type (E2eeStore) also now explicitly zeroes out myEkPriv before saving SerializedFriendEntry for extra safety.

The private key is re-derived or zeroed after DH and does not need to survive restarts, as per the spec §5.5.

Fixes #111