### PR TITLE
Introduce dedicated exception types and improve status reporting

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationRepository.kt
@@ -146,12 +146,22 @@ object LocationRepository : LocationSource {
 
     override fun onConnectionError(e: Throwable) {
         val msg =
-            when {
-                e.message?.contains("Unable to resolve host", ignoreCase = true) == true -> "Network error: Could not connect to the server. Please check your internet connection."
-                e.message?.contains("timeout", ignoreCase = true) == true -> "Network error: The connection timed out. Please try again."
-                e.message?.contains("ConnectException", ignoreCase = true) == true -> "Network error: Could not establish a connection. Please check your network."
-                e.message?.contains("500", ignoreCase = true) == true -> "Server error: Something went wrong on our end. Please try again later."
-                else -> "An unexpected error occurred. Please try re-pairing your device." // Generic fallback, sanitized
+            when (e) {
+                is net.af0.where.e2ee.ConnectException -> "No connection: Could not reach the server."
+                is net.af0.where.e2ee.TimeoutException -> "Request timed out. Please try again."
+                is net.af0.where.e2ee.ServerException -> "Server error ${e.statusCode}: Something went wrong on the server."
+                is net.af0.where.e2ee.AuthenticationException -> "Authentication failed. Please try re-pairing."
+                is net.af0.where.e2ee.ProtocolException -> "Protocol error: Session may be out of sync."
+                is net.af0.where.e2ee.CryptoException -> "Security error: Cryptographic validation failed."
+                is net.af0.where.e2ee.NetworkException -> "Network error: ${e.message}"
+                else -> {
+                    when {
+                        e.message?.contains("Unable to resolve host", ignoreCase = true) == true -> "No connection: Could not reach the server."
+                        e.message?.contains("timeout", ignoreCase = true) == true -> "Request timed out."
+                        e.message?.contains("ConnectException", ignoreCase = true) == true -> "No connection: Could not establish a connection."
+                        else -> "An unexpected error occurred. Please try again."
+                    }
+                }
             }
         _connectionStatus.value = ConnectionStatus.Error(msg)
     }

--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -223,7 +223,7 @@ class LocationService : Service() {
     internal suspend fun doPoll() {
         try {
             Log.d(TAG, "Polling for location updates")
-            val updates = locationClient.poll()
+            val updates = locationClient.poll(isForeground = locationSource.isAppInForeground.value)
             Log.d(TAG, "Got ${updates.size} location updates")
             withContext(Dispatchers.Main) {
                 val now = System.currentTimeMillis()

--- a/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MapScreen.kt
@@ -116,6 +116,7 @@ fun MapScreen(
 
     var showFriends by remember { mutableStateOf(false) }
     var zoomToUserId by remember { mutableStateOf<String?>(null) }
+    var showErrorAlert by remember { mutableStateOf(false) }
     val context = androidx.compose.ui.platform.LocalContext.current
 
     val initialPosition =
@@ -268,7 +269,13 @@ fun MapScreen(
                 modifier =
                     Modifier
                         .weight(1f)
-                        .clickable { zoomToUserId = "__own__" },
+                        .clickable {
+                            if (connectionStatus is ConnectionStatus.Error) {
+                                showErrorAlert = true
+                            } else {
+                                zoomToUserId = "__own__"
+                            }
+                        },
                 shape = MaterialTheme.shapes.medium,
                 color = Color.Black.copy(alpha = 0.7f),
             ) {
@@ -329,6 +336,17 @@ fun MapScreen(
             onRemove = onRemoveFriend,
             onDismiss = { showFriends = false },
             onZoomTo = { zoomToUserId = it },
+        )
+    }
+
+    if (showErrorAlert && connectionStatus is ConnectionStatus.Error) {
+        AlertDialog(
+            onDismissRequest = { showErrorAlert = false },
+            title = { Text("Connection Error") },
+            text = { Text(connectionStatus.message) },
+            confirmButton = {
+                TextButton(onClick = { showErrorAlert = false }) { Text("OK") }
+            },
         )
     }
 }

--- a/ios/Sources/Where/ContentView.swift
+++ b/ios/Sources/Where/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     @State private var showScanner = false
     @State private var scannedUrl: String? = nil
     @State private var zoomTarget: CLLocationCoordinate2D? = nil
+    @State private var showErrorAlert = false
 
     @State private var newFriendName: String = ""
 
@@ -75,7 +76,9 @@ struct ContentView: View {
                     .clipShape(Capsule())
                     .contentShape(Capsule())
                     .onTapGesture {
-                        if let loc = locationManager.location {
+                        if case .error = syncService.connectionStatus {
+                            showErrorAlert = true
+                        } else if let loc = locationManager.location {
                             zoomTarget = CLLocationCoordinate2D(latitude: loc.coordinate.latitude, longitude: loc.coordinate.longitude)
                         }
                     }
@@ -226,6 +229,13 @@ struct ContentView: View {
         }
         .onOpenURL { url in
             syncService.processQrUrl(url.absoluteString)
+        }
+        .alert("Connection Error", isPresented: $showErrorAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            if case .error(let msg) = syncService.connectionStatus {
+                Text(msg)
+            }
         }
     }
 }

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -729,15 +729,39 @@ final class LocationSyncService: ObservableObject {
     private func updateStatus(_ error: Error?) {
         if let error = error {
             let msg: String
-            let desc = error.localizedDescription.lowercased()
-            if desc.contains("timeout") {
-                msg = "timeout"
-            } else if desc.contains("not resolved") || desc.contains("connection") {
-                msg = "no connection"
-            } else if let nsError = error as NSError?, nsError.domain == "Where" {
-                msg = "server error \(nsError.code)"
+            if let whereEx = error as? Shared.WhereException {
+                if let netEx = whereEx as? Shared.NetworkException {
+                    if netEx is Shared.ConnectException {
+                        msg = "No connection"
+                    } else if netEx is Shared.TimeoutException {
+                        msg = "Request timed out"
+                    } else if let serverEx = netEx as? Shared.ServerException {
+                        msg = "Server error \(serverEx.statusCode)"
+                    } else {
+                        msg = "Network error"
+                    }
+                } else if let cryptoEx = whereEx as? Shared.CryptoException {
+                    if cryptoEx is Shared.AuthenticationException {
+                        msg = "Authentication failed"
+                    } else if cryptoEx is Shared.ProtocolException {
+                        msg = "Protocol error"
+                    } else {
+                        msg = "Security error"
+                    }
+                } else {
+                    msg = "Internal error"
+                }
             } else {
-                msg = String(desc.prefix(32))
+                let desc = error.localizedDescription.lowercased()
+                if desc.contains("timeout") {
+                    msg = "Timeout"
+                } else if desc.contains("not resolved") || desc.contains("connection") {
+                    msg = "No connection"
+                } else if let nsError = error as NSError?, nsError.domain == "Where" {
+                    msg = "Server error \(nsError.code)"
+                } else {
+                    msg = String(desc.prefix(32))
+                }
             }
             connectionStatus = .error(message: msg)
         } else {

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -646,7 +646,7 @@ final class LocationSyncService: ObservableObject {
             backgroundTask.end()
         }
         do {
-            let updates = try await locationClient.poll()
+            let updates = try await locationClient.poll(isForeground: isInForeground())
             logger.debug("Got \(updates.count) location updates")
             for update in updates {
                 try? await e2eeStore.updateLastLocation(id: update.userId, lat: update.lat, lng: update.lng, ts: Int64(Date().timeIntervalSince1970))

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeMailboxClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeMailboxClient.kt
@@ -2,6 +2,9 @@ package net.af0.where.e2ee
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
@@ -44,13 +47,17 @@ object E2eeMailboxClient {
         token: String,
         payload: MailboxPayload,
     ) {
-        val response =
-            client.post("$baseUrl/inbox/$token") {
-                contentType(ContentType.Application.Json)
-                setBody(payload)
+        try {
+            val response =
+                client.post("$baseUrl/inbox/$token") {
+                    contentType(ContentType.Application.Json)
+                    setBody(payload)
+                }
+            if (response.status != HttpStatusCode.NoContent && response.status != HttpStatusCode.OK) {
+                throw ServerException(response.status.value, "Failed to post to mailbox")
             }
-        if (response.status != HttpStatusCode.NoContent && response.status != HttpStatusCode.OK) {
-            throw Exception("Failed to post to mailbox: ${response.status}")
+        } catch (e: Exception) {
+            throw mapException(e)
         }
     }
 
@@ -64,10 +71,31 @@ object E2eeMailboxClient {
         baseUrl: String,
         token: String,
     ): List<MailboxPayload> {
-        val response = client.get("$baseUrl/inbox/$token")
-        if (response.status != HttpStatusCode.OK) {
-            throw Exception("Failed to poll mailbox: ${response.status}")
+        try {
+            val response = client.get("$baseUrl/inbox/$token")
+            if (response.status != HttpStatusCode.OK) {
+                throw ServerException(response.status.value, "Failed to poll mailbox")
+            }
+            return response.body()
+        } catch (e: Exception) {
+            throw mapException(e)
         }
-        return response.body()
+    }
+
+    private fun mapException(e: Exception): Exception {
+        return when (e) {
+            is ConnectTimeoutException, is HttpRequestTimeoutException, is SocketTimeoutException ->
+                TimeoutException("Network timeout", e)
+            is io.ktor.utils.io.errors.IOException -> {
+                val msg = e.message ?: "Connection failed"
+                if (msg.contains("resolve", ignoreCase = true) || msg.contains("connect", ignoreCase = true)) {
+                    ConnectException(msg, e)
+                } else {
+                    NetworkException(msg, e)
+                }
+            }
+            is WhereException -> e
+            else -> NetworkException(e.message ?: "Unknown network error", e)
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Exceptions.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Exceptions.kt
@@ -1,0 +1,28 @@
+package net.af0.where.e2ee
+
+/** Base class for all Where-specific exceptions. */
+open class WhereException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+/** Base class for network-related errors. */
+open class NetworkException(message: String, cause: Throwable? = null) : WhereException(message, cause)
+
+/** Thrown when a connection to the server cannot be established. */
+class ConnectException(message: String, cause: Throwable? = null) : NetworkException(message, cause)
+
+/** Thrown when a network request times out. */
+class TimeoutException(message: String, cause: Throwable? = null) : NetworkException(message, cause)
+
+/** Thrown when the server returns an error response. */
+class ServerException(val statusCode: Int, message: String) : NetworkException("Server error $statusCode: $message")
+
+/** Base class for cryptographic and protocol validation errors. */
+open class CryptoException(message: String, cause: Throwable? = null) : WhereException(message, cause)
+
+/** Thrown when decryption fails (e.g., bad MAC, invalid padding). */
+class DecryptionException(message: String, cause: Throwable? = null) : CryptoException(message, cause)
+
+/** Thrown when authentication fails (e.g., bad signature or key confirmation). */
+class AuthenticationException(message: String, cause: Throwable? = null) : CryptoException(message, cause)
+
+/** Thrown when a protocol-level validation fails (e.g., seq replay, huge gap). */
+class ProtocolException(message: String) : CryptoException(message)

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
@@ -90,7 +90,7 @@ object KeyExchange {
     /**
      * Alice: verify Bob's key_confirmation, recompute SK, and derive the sender session state.
      * Alice MUST zero aliceEkPriv immediately after this call.
-     * Throws IllegalArgumentException if key_confirmation fails.
+     * Throws AuthenticationException if key_confirmation fails.
      */
     fun aliceProcessInit(
         msg: KeyExchangeInitMessage,
@@ -100,8 +100,8 @@ object KeyExchange {
         val sk = x25519(aliceEkPriv, msg.ekPub)
 
         // Verify key confirmation before proceeding.
-        require(verifyKeyConfirmation(sk, aliceEkPub, msg.ekPub, msg.keyConfirmation)) {
-            "KeyExchangeInit key_confirmation failed — aborting key exchange"
+        if (!verifyKeyConfirmation(sk, aliceEkPub, msg.ekPub, msg.keyConfirmation)) {
+            throw AuthenticationException("KeyExchangeInit key_confirmation failed — aborting key exchange")
         }
 
         val aliceFp = fingerprint(aliceEkPub)

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -25,9 +25,10 @@ open class LocationClient(
      *
      * Poll calls are serialized to prevent concurrent ratchet state mutations.
      *
+     * @param isForeground Whether the app is currently in the foreground.
      * @return List of new [UserLocation] updates received since the last poll.
      */
-    suspend fun poll(): List<UserLocation> =
+    suspend fun poll(isForeground: Boolean = true): List<UserLocation> =
         pollMutex.withLock {
             val allUpdates = mutableListOf<UserLocation>()
             var lastError: Exception? = null
@@ -36,7 +37,8 @@ open class LocationClient(
 
             // If we have no friends, do a "health check" poll against a dummy token
             // to ensure connectivity and surface network errors even when the user is alone.
-            if (friends.isEmpty()) {
+            // We only do this in the foreground to save on battery/server costs.
+            if (friends.isEmpty() && isForeground) {
                 try {
                     E2eeMailboxClient.poll(baseUrl, "00000000000000000000000000000000")
                 } catch (e: ServerException) {

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -32,8 +32,23 @@ open class LocationClient(
             val allUpdates = mutableListOf<UserLocation>()
             var lastError: Exception? = null
 
+            val friends = store.listFriends()
+
+            // If we have no friends, do a "health check" poll against a dummy token
+            // to ensure connectivity and surface network errors even when the user is alone.
+            if (friends.isEmpty()) {
+                try {
+                    E2eeMailboxClient.poll(baseUrl, "00000000000000000000000000000000")
+                } catch (e: ServerException) {
+                    // 404 is expected for a dummy token, means we reached the server.
+                    if (e.statusCode != 404) lastError = e
+                } catch (e: Exception) {
+                    lastError = e
+                }
+            }
+
             // 1. Poll each friend's current mailbox
-            for (friend in store.listFriends()) {
+            for (friend in friends) {
                 try {
                     val friendUpdates = pollFriend(friend.id)
                     allUpdates.addAll(friendUpdates)

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -91,9 +91,10 @@ object Session {
      * @param senderFp    32-byte fingerprint of the sender.
      * @param recipientFp 32-byte fingerprint of the recipient.
      * @return Pair(newState, plaintext).
-     * @throws IllegalArgumentException if GCM authentication fails, the seq gap is too large, or seq is a replay.
+     * @throws ProtocolException if seq is a replay or the gap is too large.
+     * @throws AuthenticationException if GCM authentication fails.
      */
-    @Throws(IllegalArgumentException::class)
+    @Throws(WhereException::class)
     fun decryptLocation(
         state: SessionState,
         ct: ByteArray,
@@ -101,15 +102,17 @@ object Session {
         senderFp: ByteArray,
         recipientFp: ByteArray,
     ): Pair<SessionState, LocationPlaintext> {
-        require(seq > state.recvSeq) { "replay — seq $seq must be greater than state.recvSeq ${state.recvSeq}" }
+        if (seq <= state.recvSeq) {
+            throw ProtocolException("replay — seq $seq must be greater than state.recvSeq ${state.recvSeq}")
+        }
 
         val stepsNeeded = seq - state.recvSeq
         // stepsNeeded is always >= 1 because seq starts at 1 and recvSeq starts at 0 (or resets
         // to 0 on epoch rotation). The number of *missed* messages is (stepsNeeded - 1), so
         // we allow stepsNeeded up to MAX_GAP + 1 to permit exactly MAX_GAP
         // missed messages.
-        require(stepsNeeded <= MAX_GAP + 1) {
-            "seq gap ${stepsNeeded - 1} exceeds maximum $MAX_GAP — session may be desynchronized"
+        if (stepsNeeded > MAX_GAP + 1) {
+            throw ProtocolException("seq gap ${stepsNeeded - 1} exceeds maximum $MAX_GAP — session may be desynchronized")
         }
 
         // Advance the receive chain key to reach the correct seq (handles gaps).
@@ -126,7 +129,14 @@ object Session {
         val finalStep = step!!
 
         val aad = buildLocationAad(senderFp, recipientFp, state.epoch, seq)
-        val plaintext = aeadDecrypt(finalStep.messageKey, finalStep.messageNonce, ct, aad)
+        val plaintext =
+            try {
+                aeadDecrypt(finalStep.messageKey, finalStep.messageNonce, ct, aad)
+            } catch (e: Exception) {
+                finalStep.messageKey.fill(0)
+                finalStep.messageNonce.fill(0)
+                throw AuthenticationException("decryption failed: bad MAC", e)
+            }
         val unpadded =
             try {
                 unpad(plaintext)
@@ -134,7 +144,7 @@ object Session {
                 finalStep.messageKey.fill(0)
                 finalStep.messageNonce.fill(0)
                 plaintext.fill(0)
-                throw e
+                throw DecryptionException("unpadding failed", e)
             }
         val location = decodeLocation(unpadded)
 
@@ -425,8 +435,15 @@ internal fun decryptEpochRotationCt(
     val salt = epochBe
     val kRot = hkdfSha256(rootKey, salt, INFO_EPOCH_ROTATION.encodeToByteArray(), 32)
     val aad = senderFp + recipientFp + routingToken
-    val plaintext = aeadDecrypt(kRot, nonce, ct, aad)
-    require(plaintext.size == 4 + 4 + 32 + 8) { "bad EpochRotation plaintext size: ${plaintext.size}" }
+    val plaintext =
+        try {
+            aeadDecrypt(kRot, nonce, ct, aad)
+        } catch (e: Exception) {
+            throw AuthenticationException("EpochRotation decryption failed", e)
+        }
+    if (plaintext.size != 4 + 4 + 32 + 8) {
+        throw ProtocolException("bad EpochRotation plaintext size: ${plaintext.size}")
+    }
     val decodedEpoch = bytesToInt(plaintext, 0)
     val opkId = bytesToInt(plaintext, 4)
     val newEkPub = plaintext.copyOfRange(8, 40)
@@ -471,8 +488,15 @@ internal fun decryptRatchetAckCt(
     val salt = epochBe
     val kAck = hkdfSha256(rootKey, salt, INFO_RATCHET_ACK.encodeToByteArray(), 32)
     val aad = senderFp + recipientFp + routingToken
-    val plaintext = aeadDecrypt(kAck, nonce, ct, aad)
-    require(plaintext.size == 4 + 8 + 32) { "bad RatchetAck plaintext size: ${plaintext.size}" }
+    val plaintext =
+        try {
+            aeadDecrypt(kAck, nonce, ct, aad)
+        } catch (e: Exception) {
+            throw AuthenticationException("RatchetAck decryption failed", e)
+        }
+    if (plaintext.size != 4 + 8 + 32) {
+        throw ProtocolException("bad RatchetAck plaintext size: ${plaintext.size}")
+    }
     val decodedEpochSeen = bytesToInt(plaintext, 0)
     val ts = bytesToLong(plaintext, 4)
     val newEkPub = plaintext.copyOfRange(12, 44)

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
@@ -98,7 +98,7 @@ class KeyExchangeTest {
             try {
                 KeyExchange.aliceProcessInit(badMsg, aliceEkPriv, qr.ekPub)
                 false
-            } catch (_: IllegalArgumentException) {
+            } catch (_: AuthenticationException) {
                 true
             }
         assertTrue(threw)

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/SessionTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/SessionTest.kt
@@ -103,8 +103,8 @@ class SessionTest {
         // Second delivery of the same seq must be rejected.
         try {
             Session.decryptLocation(bobNew, ct, seq, bobNew.aliceFp, bobNew.bobFp)
-            kotlin.test.fail("Expected IllegalArgumentException for replay")
-        } catch (e: IllegalArgumentException) {
+            kotlin.test.fail("Expected ProtocolException for replay")
+        } catch (e: ProtocolException) {
             assertTrue(e.message?.contains("replay") == true)
         }
     }
@@ -133,8 +133,8 @@ class SessionTest {
         for ((seq, ct) in cts) {
             try {
                 Session.decryptLocation(bSess, ct, seq, bSess.aliceFp, bSess.bobFp)
-                kotlin.test.fail("Expected IllegalArgumentException for lower seq")
-            } catch (e: IllegalArgumentException) {
+                kotlin.test.fail("Expected ProtocolException for lower seq")
+            } catch (e: ProtocolException) {
                 assertTrue(e.message?.contains("replay") == true)
             }
         }
@@ -180,8 +180,8 @@ class SessionTest {
         }
         try {
             Session.decryptLocation(bobSession, lastCt, aSess.sendSeq, bobSession.aliceFp, bobSession.bobFp)
-            kotlin.test.fail("Expected IllegalArgumentException for gap exceeding MAX_GAP")
-        } catch (e: IllegalArgumentException) {
+            kotlin.test.fail("Expected ProtocolException for gap exceeding MAX_GAP")
+        } catch (e: ProtocolException) {
             assertTrue(e.message?.contains("exceeds maximum") == true)
         }
     }
@@ -197,8 +197,8 @@ class SessionTest {
         val startTime = currentTimeMillis()
         try {
             Session.decryptLocation(bobSession, dummyCt, largeSeq, bobSession.aliceFp, bobSession.bobFp)
-            kotlin.test.fail("Expected IllegalArgumentException for large seq")
-        } catch (e: IllegalArgumentException) {
+            kotlin.test.fail("Expected ProtocolException for large seq")
+        } catch (e: ProtocolException) {
             assertTrue(e.message?.contains("exceeds maximum") == true)
         }
         val duration = currentTimeMillis() - startTime


### PR DESCRIPTION
This change introduces a shared exception hierarchy (WhereException) for network and cryptographic errors, allowing the Android and iOS apps to surface localized, meaningful error messages. It also ensures that the iOS status icon correctly reflects connectivity issues even when no friends are being polled by adding a health check to the shared polling logic.

---
*PR created automatically by Jules for task [8072039256918439608](https://jules.google.com/task/8072039256918439608) started by @danmarg*