### PR TITLE
Require handshake confirmation for friends

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
@@ -127,7 +127,7 @@ fun FriendsSheet(
                         ) {
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(
-                                    friend.name,
+                                    if (friend.isConfirmed) friend.name else "${friend.name} (Pending)",
                                     style = MaterialTheme.typography.bodyLarge,
                                     maxLines = 1,
                                     overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -67,8 +67,17 @@ class LocationViewModel(
 
     val pausedFriendIds: StateFlow<Set<String>> = locationSource.pausedFriendIds
 
-    val friendLocations: StateFlow<Map<String, UserLocation>> = locationSource.friendLocations
-    val friendLastPing: StateFlow<Map<String, Long>> = locationSource.friendLastPing
+    val friendLocations: StateFlow<Map<String, UserLocation>> =
+        combine(locationSource.friendLocations, friends) { locations, friendList ->
+            val confirmedIds = friendList.filter { it.isConfirmed }.map { it.id }.toSet()
+            locations.filterKeys { it in confirmedIds }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
+
+    val friendLastPing: StateFlow<Map<String, Long>> =
+        combine(locationSource.friendLastPing, friends) { pings, friendList ->
+            val confirmedIds = friendList.filter { it.isConfirmed }.map { it.id }.toSet()
+            pings.filterKeys { it in confirmedIds }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
 
     private val _inviteState = MutableStateFlow<InviteState>(InviteState.None)
     val inviteState: StateFlow<InviteState> = _inviteState

--- a/ios/Sources/Where/FriendsSheet.swift
+++ b/ios/Sources/Where/FriendsSheet.swift
@@ -61,7 +61,7 @@ struct FriendsSheet: View {
                         ForEach(friends, id: \.id) { friend in
                             HStack {
                                 VStack(alignment: .leading, spacing: 2) {
-                                    Text(friend.name)
+                                    Text(friend.isConfirmed ? friend.name : "\(friend.name) (Pending)")
                                         .font(.body)
                                     Text(friend.safetyNumber)
                                         .font(.caption2)

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -269,9 +269,12 @@ final class LocationSyncService: ObservableObject {
     }
 
     private func updateVisibleUsers() {
-        visibleUsers = friendLocations.map { (friendId, locData) in
-            Shared.UserLocation(userId: friendId, lat: locData.lat, lng: locData.lng, timestamp: locData.ts)
-        }
+        let confirmedIds = Set(friends.filter { $0.isConfirmed }.map { $0.id })
+        visibleUsers = friendLocations
+            .filter { confirmedIds.contains($0.key) }
+            .map { (friendId, locData) in
+                Shared.UserLocation(userId: friendId, lat: locData.lat, lng: locData.lng, timestamp: locData.ts)
+            }
     }
 
     // Poll timer: handles inbound friend-location polling and the outbound heartbeat.
@@ -655,6 +658,7 @@ final class LocationSyncService: ObservableObject {
                 onFriendLocationReceived(friendId: update.userId)
             }
 
+            friends = try await e2eeStore.listFriends()
             // Always update visibleUsers to ensure map is fresh when returning to foreground.
             updateVisibleUsers()
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -45,6 +45,12 @@ data class FriendEntry(
      * Long.MAX_VALUE is the unset sentinel (used for backward-compat on upgrade from old data).
      */
     val lastAckTs: Long = Long.MAX_VALUE,
+    /**
+     * True if the key exchange handshake is fully confirmed (both sides derived SK).
+     * Alice is confirmed as soon as she processes KeyExchangeInit; Bob is confirmed
+     * once he receives any valid message (Location, OPK bundle) from Alice.
+     */
+    val isConfirmed: Boolean = false,
 ) {
     /** Computed friend ID: hex(SHA-256(EK_A.pub)) — full 64 hex chars. */
     val id: String get() = session.aliceFp.toHex()
@@ -64,7 +70,8 @@ data class FriendEntry(
             lastLat == other.lastLat &&
             lastLng == other.lastLng &&
             lastTs == other.lastTs &&
-            lastAckTs == other.lastAckTs
+            lastAckTs == other.lastAckTs &&
+            isConfirmed == other.isConfirmed
     }
 
     override fun hashCode(): Int {
@@ -76,6 +83,7 @@ data class FriendEntry(
         result = 31 * result + (lastLng?.hashCode() ?: 0)
         result = 31 * result + (lastTs?.hashCode() ?: 0)
         result = 31 * result + lastAckTs.hashCode()
+        result = 31 * result + isConfirmed.hashCode()
         return result
     }
 }
@@ -128,6 +136,7 @@ class E2eeStore(
                             lastTs = s.lastTs,
                             // 0L = field absent in old serialized data; give a fresh grace period.
                             lastAckTs = if (s.lastAckTs == 0L) currentTimeSeconds() else s.lastAckTs,
+                            isConfirmed = s.isConfirmed,
                         )
                     entry.id to entry
                 }.toMutableMap()
@@ -156,6 +165,7 @@ class E2eeStore(
                             lastLng = f.lastLng,
                             lastTs = f.lastTs,
                             lastAckTs = f.lastAckTs,
+                            isConfirmed = f.isConfirmed,
                         )
                     },
                 pendingInvite = pendingInvite,
@@ -206,6 +216,7 @@ class E2eeStore(
                     isInitiator = false,
                     // Start the ack-timeout clock from pairing time.
                     lastAckTs = currentTimeSeconds(),
+                    isConfirmed = false,
                 )
             friends[entry.id] = entry
             save()
@@ -260,6 +271,7 @@ class E2eeStore(
                         isInitiator = true,
                         // Start the ack-timeout clock from pairing time.
                         lastAckTs = currentTimeSeconds(),
+                        isConfirmed = false,
                     )
                 friends[entry.id] = entry
                 pendingInvite = null
@@ -331,14 +343,16 @@ class E2eeStore(
             if (session.prevRecvToken == null && session.prevRecvChainKey == null) return@withLock
 
             session.prevRecvChainKey?.fill(0)
-            friends[id] = entry.copy(
-                session = session.copy(
-                    prevRecvToken = null,
-                    prevRecvTokenDeadline = 0L,
-                    prevRecvChainKey = null,
-                    prevRecvSeq = 0L
+            friends[id] =
+                entry.copy(
+                    session =
+                        session.copy(
+                            prevRecvToken = null,
+                            prevRecvTokenDeadline = 0L,
+                            prevRecvChainKey = null,
+                            prevRecvSeq = 0L,
+                        ),
                 )
-            )
             save()
         }
     }
@@ -727,7 +741,7 @@ class E2eeStore(
                     continue
                 }
                 val newPubMap = entry.theirOpkPubs + opks.associate { it.id to it.pub }
-                friends[friendId] = entry.copy(theirOpkPubs = newPubMap)
+                friends[friendId] = entry.copy(theirOpkPubs = newPubMap, isConfirmed = true)
             }
 
             // Step 2: Decrypt location updates BEFORE processing epoch rotation.
@@ -736,15 +750,16 @@ class E2eeStore(
             val isPrevToken = tokenUsed != null && sessionAtStart.prevRecvToken?.toHex() == tokenUsed
 
             // Construct a temporary SessionState for decryption if this is the old token.
-            var decryptionSession = if (isPrevToken && sessionAtStart.prevRecvChainKey != null) {
-                sessionAtStart.copy(
-                    epoch = sessionAtStart.epoch - 1,
-                    recvChainKey = sessionAtStart.prevRecvChainKey,
-                    recvSeq = sessionAtStart.prevRecvSeq,
-                )
-            } else {
-                sessionAtStart
-            }
+            var decryptionSession =
+                if (isPrevToken && sessionAtStart.prevRecvChainKey != null) {
+                    sessionAtStart.copy(
+                        epoch = sessionAtStart.epoch - 1,
+                        recvChainKey = sessionAtStart.prevRecvChainKey,
+                        recvSeq = sessionAtStart.prevRecvSeq,
+                    )
+                } else {
+                    sessionAtStart
+                }
 
             val sortedLocations = messages.filterIsInstance<EncryptedLocationPayload>().sortedBy { it.seqAsLong() }
             for (msg in sortedLocations) {
@@ -766,25 +781,31 @@ class E2eeStore(
 
             // Save the updated receive state back to the correct fields.
             val entryAfterDecryption = friends[friendId] ?: return@withLock PollBatchResult(decryptedLocations, null, emptyList())
-            val updatedSession = if (isPrevToken) {
-                // If we decrypted messages on the old token, update the prevRecv fields.
-                entryAfterDecryption.session.copy(
-                    prevRecvChainKey = decryptionSession.recvChainKey,
-                    prevRecvSeq = decryptionSession.recvSeq,
-                )
-            } else {
-                // If we decrypted messages on the new token, update the main recv fields.
-                var s = entryAfterDecryption.session.copy(
-                    recvChainKey = decryptionSession.recvChainKey,
-                    recvSeq = decryptionSession.recvSeq,
-                )
-                // §8.3: Stop polling the old token once we have a valid message on the new one.
-                if (decryptedLocations.isNotEmpty() && s.prevRecvToken != null) {
-                    s = s.copy(prevRecvToken = null, prevRecvTokenDeadline = 0L, prevRecvChainKey = null, prevRecvSeq = 0L)
+            val updatedSession =
+                if (isPrevToken) {
+                    // If we decrypted messages on the old token, update the prevRecv fields.
+                    entryAfterDecryption.session.copy(
+                        prevRecvChainKey = decryptionSession.recvChainKey,
+                        prevRecvSeq = decryptionSession.recvSeq,
+                    )
+                } else {
+                    // If we decrypted messages on the new token, update the main recv fields.
+                    var s =
+                        entryAfterDecryption.session.copy(
+                            recvChainKey = decryptionSession.recvChainKey,
+                            recvSeq = decryptionSession.recvSeq,
+                        )
+                    // §8.3: Stop polling the old token once we have a valid message on the new one.
+                    if (decryptedLocations.isNotEmpty() && s.prevRecvToken != null) {
+                        s = s.copy(prevRecvToken = null, prevRecvTokenDeadline = 0L, prevRecvChainKey = null, prevRecvSeq = 0L)
+                    }
+                    s
                 }
-                s
-            }
-            friends[friendId] = entryAfterDecryption.copy(session = updatedSession)
+            friends[friendId] =
+                entryAfterDecryption.copy(
+                    session = updatedSession,
+                    isConfirmed = if (decryptedLocations.isNotEmpty()) true else entryAfterDecryption.isConfirmed,
+                )
 
             // Step 3: Process epoch rotation (after location decryption).
             for (msg in messages.filterIsInstance<EpochRotationPayload>()) {
@@ -853,6 +874,7 @@ class E2eeStore(
                         session = finalSession,
                         // delete consumed OPK
                         myOpkPrivs = entry.myOpkPrivs - msg.opkId,
+                        isConfirmed = true,
                     )
                 val rotatedToken = finalSession.sendToken.toHex()
                 outgoing.add(
@@ -930,6 +952,7 @@ class E2eeStore(
                     entry.copy(
                         session = newSession ?: entry.session,
                         lastAckTs = currentTimeSeconds(),
+                        isConfirmed = true,
                     )
             }
 
@@ -1017,6 +1040,7 @@ internal data class SerializedFriendEntry(
     val lastTs: Long? = null,
     // Default 0L = field absent in old data; load() converts 0L → currentTimeSeconds().
     val lastAckTs: Long = 0L,
+    val isConfirmed: Boolean = false,
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -121,6 +121,10 @@ open class LocationClient(
 
         for (friend in store.listFriends()) {
             if (friend.id in pausedFriendIds) continue
+            // Skip friends who have not yet confirmed the handshake, UNLESS we are the
+            // initiator (Alice), in which case we must send the first message to Bob to
+            // trigger confirmation on his side.
+            if (!friend.isConfirmed && !friend.isInitiator) continue
             // Skip friends from whom Alice has not received a Ratchet Ack in 7 days.
             // This prevents sending in a stale epoch with no forward secrecy and gives
             // the user a visible signal that Bob's app is not processing location updates.

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
@@ -79,11 +79,15 @@ data class SessionState(
             aliceEkPub.contentEquals(other.aliceEkPub) &&
             bobEkPub.contentEquals(other.bobEkPub) &&
             kBundle.contentEquals(other.kBundle) &&
-            ((prevRecvToken == null && other.prevRecvToken == null) ||
-                (prevRecvToken != null && other.prevRecvToken != null && prevRecvToken.contentEquals(other.prevRecvToken))) &&
+            (
+                (prevRecvToken == null && other.prevRecvToken == null) ||
+                    (prevRecvToken != null && other.prevRecvToken != null && prevRecvToken.contentEquals(other.prevRecvToken))
+            ) &&
             prevRecvTokenDeadline == other.prevRecvTokenDeadline &&
-            ((prevRecvChainKey == null && other.prevRecvChainKey == null) ||
-                (prevRecvChainKey != null && other.prevRecvChainKey != null && prevRecvChainKey.contentEquals(other.prevRecvChainKey))) &&
+            (
+                (prevRecvChainKey == null && other.prevRecvChainKey == null) ||
+                    (prevRecvChainKey != null && other.prevRecvChainKey != null && prevRecvChainKey.contentEquals(other.prevRecvChainKey))
+            ) &&
             prevRecvSeq == other.prevRecvSeq
     }
 


### PR DESCRIPTION
Introduced an `isConfirmed` state to the key exchange process. Friends now appear as "(Pending)" until a successful handshake is verified by the receipt of an encrypted message. Initiators are allowed to send the first message to trigger this confirmation. Both Android and iOS UIs were updated to handle this state.

---
*PR created automatically by Jules for task [6493498224102682895](https://jules.google.com/task/6493498224102682895) started by @danmarg*