### PR TITLE
Enable R8 minification and resource shrinking for Android release builds

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -84,6 +84,12 @@ android {
 
     buildTypes {
         release {
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
             signingConfig = signingConfigs.getByName("release")
             buildConfigField("String", "SERVER_HTTP_URL", "\"https://where.af0.net\"")
         }

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,32 @@
+# Where — Android ProGuard/R8 rules
+
+# Kotlin Serialization
+# https://github.com/Kotlin/kotlinx.serialization#android
+-keepattributes *Annotation*, EnclosingMethod, InnerClasses, Signature
+-keep,allowobfuscation,allowshrinking class kotlinx.serialization.json.** { *; }
+-keepclassmembers class net.af0.where.e2ee.** {
+    *** Companion;
+    *** $serializer;
+}
+-keepclassmembers class net.af0.where.model.** {
+    *** Companion;
+    *** $serializer;
+}
+
+# E2EE protocol and models
+# We keep these to ensure that the protocol structure remains stable and
+# that serialization/deserialization works correctly across versions.
+-keep class net.af0.where.e2ee.** { *; }
+-keep class net.af0.where.model.** { *; }
+
+# Libsodium KMP (com.ionspin.kotlin.crypto)
+# These rules are necessary because libsodium uses JNI, and R8 might
+# strip or rename classes/methods that are called from native code.
+-keep class com.ionspin.kotlin.crypto.** { *; }
+-keepclassmembers class com.ionspin.kotlin.crypto.** {
+    native <methods>;
+}
+
+# Google Maps
+-keep class com.google.android.gms.maps.** { *; }
+-keep interface com.google.android.gms.maps.** { *; }


### PR DESCRIPTION
I have enabled R8 minification and resource shrinking for Android release builds to address the security concerns mentioned in Issue #97.

Key changes:
1.  **Enabled R8 in `android/build.gradle.kts`**: Set `isMinifyEnabled = true` and `isShrinkResources = true` for the `release` buildType.
2.  **Added `android/proguard-rules.pro`**: Created a new ProGuard rules file with critical keep rules for:
    *   `kotlinx.serialization`: Ensures serializable classes and their serializers are not stripped or renamed.
    *   `net.af0.where.e2ee.**` and `net.af0.where.model.**`: Preserves the E2EE protocol logic and data models for stability and correct serialization.
    *   `com.ionspin.kotlin.crypto.**`: Protects the libsodium KMP JNI bindings from being broken by R8.
    *   `com.google.android.gms.maps.**`: Standard rules for Google Maps integration.

These steps ensure that the release APK is obfuscated and optimized while remaining fully functional.

---
*PR created automatically by Jules for task [10510845724003420111](https://jules.google.com/task/10510845724003420111) started by @danmarg*