### PR TITLE
Harden E2EE ratchet against disk and network failures

### DIFF
--- a/server/src/test/kotlin/net/af0/where/E2eeIntegrationTest.kt
+++ b/server/src/test/kotlin/net/af0/where/E2eeIntegrationTest.kt
@@ -313,15 +313,15 @@ class E2eeIntegrationTest {
 
         // Correct: decrypt old message (seq 1) with the session state that skipped it (bobState2).
         // This must hit the skipped message keys cache.
-        val (_, decrypted1) = Session.decryptMessage(bobState2, message)
+        val (bobState3, decrypted1) = Session.decryptMessage(bobState2, message)
         assertIs<MessagePlaintext.Location>(decrypted1)
         assertEquals(location.lat, decrypted1.lat, 1e-9)
 
-        // Wrong: decrypt old message (seq 1) with the post-rotation state (bobState2)
+        // Wrong: decrypt old message (seq 1) with the updated state (bobState3)
         // after it has ALREADY been decrypted. Key should be gone from cache.
         val threw =
             try {
-                Session.decryptMessage(bobState2, message)
+                Session.decryptMessage(bobState3, message)
                 false
             } catch (_: Exception) {
                 true

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -85,32 +85,6 @@ data class FriendEntry(
     /** Safety number (e.g., for display in UI). Stable for the lifetime of the session. */
     val safetyNumber: String get() = formatSafetyNumber(safetyNumber(session.aliceEkPub, session.bobEkPub))
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is FriendEntry) return false
-        return name == other.name &&
-            session == other.session &&
-            isInitiator == other.isInitiator &&
-            lastLat == other.lastLat &&
-            lastLng == other.lastLng &&
-            lastTs == other.lastTs &&
-            lastRecvTs == other.lastRecvTs &&
-            isConfirmed == other.isConfirmed
-    }
-
-    override fun hashCode(): Int {
-        var result = name.hashCode()
-        result = 31 * result + session.hashCode()
-        result = 31 * result + isInitiator.hashCode()
-        result = 31 * result + (lastLat?.hashCode() ?: 0)
-        result = 31 * result + (lastLng?.hashCode() ?: 0)
-        result = 31 * result + (lastTs?.hashCode() ?: 0)
-        result = 31 * result + lastRecvTs.hashCode()
-        result = 31 * result + isConfirmed.hashCode()
-        result = 31 * result + sharingEnabled.hashCode()
-        result = 31 * result + (outbox?.hashCode() ?: 0)
-        return result
-    }
 }
 
 private fun Map<Int, ByteArray>.contentEquals(other: Map<Int, ByteArray>): Boolean {
@@ -219,11 +193,17 @@ class E2eeStore(
         }
     }
 
-    private fun save() {
+    private fun save(
+        friendsOverride: Map<String, FriendEntry>? = null,
+        pendingInvitesOverride: List<PendingInvite>? = null,
+    ) {
+        val friendsToSave = friendsOverride ?: friends
+        val invitesToSave = pendingInvitesOverride ?: pendingInvites
+
         val serialized =
             SerializedStore(
                 friends =
-                    friends.values.map { f ->
+                    friendsToSave.values.map { f ->
                         SerializedFriendEntry(
                             friendId = f.id,
                             name = f.name,
@@ -241,10 +221,17 @@ class E2eeStore(
                             lastDecryptFailed = f.lastDecryptFailed,
                         )
                     },
-                pendingInvites = pendingInvites,
+                pendingInvites = invitesToSave,
             )
         try {
             storage.putString(STORAGE_KEY, json.encodeToString(serialized))
+            // Only update in-memory state if write succeeds
+            if (friendsOverride != null) {
+                friends = friendsOverride.toMutableMap()
+            }
+            if (pendingInvitesOverride != null) {
+                pendingInvites = pendingInvitesOverride.toMutableList()
+            }
         } catch (e: Exception) {
             addDiagnosticEvent("STORAGE WRITE FAILED: ${e.message}")
             throw e
@@ -261,24 +248,23 @@ class E2eeStore(
                 throw IllegalStateException("Too many pending invites. Please cancel some before creating a new one.")
             }
             val (payload, ekPriv) = KeyExchange.aliceCreateQrPayload(suggestedName)
-            pendingInvites.add(PendingInvite(payload, ekPriv))
-            save()
+            val newInvites = pendingInvites + PendingInvite(payload, ekPriv)
+            save(pendingInvitesOverride = newInvites)
             payload
         }
 
     /** Alice: Discard all pending invites (e.g. user resets the app state). */
     suspend fun clearAllInvites() {
         stateLock.withLock {
-            pendingInvites.clear()
-            save()
+            save(pendingInvitesOverride = emptyList())
         }
     }
 
     /** Alice: Discard a specific pending invite. */
     suspend fun clearInvite(ekPub: ByteArray) {
         stateLock.withLock {
-            pendingInvites.removeAll { it.qrPayload.ekPub.contentEquals(ekPub) }
-            save()
+            val newInvites = pendingInvites.filterNot { it.qrPayload.ekPub.contentEquals(ekPub) }
+            save(pendingInvitesOverride = newInvites)
         }
     }
 
@@ -292,8 +278,9 @@ class E2eeStore(
             if (idx != -1) {
                 val invite = pendingInvites[idx]
                 if (invite.exportedAt == null) {
-                    pendingInvites[idx] = invite.copy(exportedAt = currentTimeSeconds())
-                    save()
+                    val newInvites = pendingInvites.toMutableList()
+                    newInvites[idx] = invite.copy(exportedAt = currentTimeSeconds())
+                    save(pendingInvitesOverride = newInvites)
                 }
             }
         }
@@ -326,8 +313,8 @@ class E2eeStore(
                     lastRecvTs = currentTimeSeconds(),
                     isConfirmed = false,
                 )
-            friends[entry.id] = entry
-            save()
+            val newFriends = friends + (entry.id to entry)
+            save(friendsOverride = newFriends)
             val payload =
                 KeyExchangeInitPayload(
                     v = initMsg.protocolVersion,
@@ -389,9 +376,10 @@ class E2eeStore(
                         // Alice is confirmed as soon as she processes Bob's KeyExchangeInit
                         isConfirmed = true,
                     )
-                friends[entry.id] = entry
-                pendingInvites.remove(pending)
-                save()
+
+                val newFriends = friends + (entry.id to entry)
+                val newInvites = pendingInvites.filter { it != pending }
+                save(friendsOverride = newFriends, pendingInvitesOverride = newInvites)
                 entry
             } catch (e: AuthenticationException) {
                 throw e // key_confirmation or token mismatch failure — surface to caller
@@ -410,24 +398,25 @@ class E2eeStore(
     suspend fun cleanupExpiredInvites(expirySeconds: Long = 48 * 3600L) {
         stateLock.withLock {
             val now = currentTimeSeconds()
-            val initialSize = pendingInvites.size
-            pendingInvites.removeAll {
-                val baseTime = it.exportedAt ?: it.createdAt
-                now - baseTime > expirySeconds
-            }
+            val newInvites =
+                pendingInvites.filterNot {
+                    val baseTime = it.exportedAt ?: it.createdAt
+                    now - baseTime > expirySeconds
+                }
 
-            val unconfirmedBefore = friends.size
             val toRemove =
                 friends.values.filter {
                     !it.isConfirmed && (now - it.lastRecvTs > expirySeconds)
                 }.map { it.id }
-            toRemove.forEach { friends.remove(it) }
 
-            if (pendingInvites.size != initialSize || friends.size != unconfirmedBefore) {
+            if (newInvites.size != pendingInvites.size || toRemove.isNotEmpty()) {
+                val newFriends = friends.toMutableMap()
+                toRemove.forEach { newFriends.remove(it) }
+
                 println(
-                    "[E2eeStore] Cleaned up ${initialSize - pendingInvites.size} invites and ${unconfirmedBefore - friends.size} unconfirmed friends",
+                    "[E2eeStore] Cleaned up ${pendingInvites.size - newInvites.size} invites and ${friends.size - newFriends.size} unconfirmed friends",
                 )
-                save()
+                save(friendsOverride = newFriends, pendingInvitesOverride = newInvites)
             }
         }
     }
@@ -442,15 +431,17 @@ class E2eeStore(
     ) {
         stateLock.withLock {
             val entry = friends[id] ?: return@withLock
-            friends[id] = entry.copy(name = newName)
-            save()
+            val newFriends = friends + (id to entry.copy(name = newName))
+            save(friendsOverride = newFriends)
         }
     }
 
     suspend fun deleteFriend(id: String) {
         stateLock.withLock {
-            if (friends.remove(id) != null) {
-                save()
+            if (friends.containsKey(id)) {
+                val newFriends = friends.toMutableMap()
+                newFriends.remove(id)
+                save(friendsOverride = newFriends)
             }
         }
     }
@@ -485,13 +476,17 @@ class E2eeStore(
             // Determine which token to use for posting
             val tokenToUse = if (newSession.isSendTokenPending) newSession.prevSendToken else newSession.sendToken
 
-            friends[friendId] =
-                entry.copy(
-                    session = newSession,
-                    outbox = EncryptedOutboxMessage(token = tokenToUse.toHex(), payload = message),
-                    lastSentTs = currentTimeSeconds(),
-                )
-            save()
+            val newFriends =
+                friends +
+                    (
+                        friendId to
+                            entry.copy(
+                                session = newSession,
+                                outbox = EncryptedOutboxMessage(token = tokenToUse.toHex(), payload = message),
+                                lastSentTs = currentTimeSeconds(),
+                            )
+                    )
+            save(friendsOverride = newFriends)
             message
         }
 
@@ -501,8 +496,8 @@ class E2eeStore(
     ) {
         stateLock.withLock {
             val entry = friends[id] ?: return@withLock
-            friends[id] = entry.copy(session = newSession)
-            save()
+            val newFriends = friends + (id to entry.copy(session = newSession))
+            save(friendsOverride = newFriends)
         }
     }
 
@@ -517,12 +512,16 @@ class E2eeStore(
     ) {
         stateLock.withLock {
             val entry = friends[id] ?: return@withLock
-            friends[id] =
-                entry.copy(
-                    session = newSession,
-                    outbox = EncryptedOutboxMessage(token = token, payload = message),
-                )
-            save()
+            val newFriends =
+                friends +
+                    (
+                        id to
+                            entry.copy(
+                                session = newSession,
+                                outbox = EncryptedOutboxMessage(token = token, payload = message),
+                            )
+                    )
+            save(friendsOverride = newFriends)
         }
     }
 
@@ -531,8 +530,8 @@ class E2eeStore(
         stateLock.withLock {
             val entry = friends[id] ?: return@withLock
             if (entry.outbox != null) {
-                friends[id] = entry.copy(outbox = null)
-                save()
+                val newFriends = friends + (id to entry.copy(outbox = null))
+                save(friendsOverride = newFriends)
             }
         }
     }
@@ -541,8 +540,8 @@ class E2eeStore(
     suspend fun clearOutboxAndUpdateSession(id: String, newSession: SessionState) {
         stateLock.withLock {
             val entry = friends[id] ?: return@withLock
-            friends[id] = entry.copy(session = newSession, outbox = null)
-            save()
+            val newFriends = friends + (id to entry.copy(session = newSession, outbox = null))
+            save(friendsOverride = newFriends)
         }
     }
 
@@ -554,8 +553,8 @@ class E2eeStore(
     ) {
         stateLock.withLock {
             val entry = friends[id] ?: return@withLock
-            friends[id] = entry.copy(lastLat = lat, lastLng = lng, lastTs = ts)
-            save()
+            val newFriends = friends + (id to entry.copy(lastLat = lat, lastLng = lng, lastTs = ts))
+            save(friendsOverride = newFriends)
         }
     }
 
@@ -565,8 +564,8 @@ class E2eeStore(
     ) {
         stateLock.withLock {
             val entry = friends[id] ?: return@withLock
-            friends[id] = entry.copy(lastSentTs = ts)
-            save()
+            val newFriends = friends + (id to entry.copy(lastSentTs = ts))
+            save(friendsOverride = newFriends)
         }
     }
 
@@ -576,8 +575,8 @@ class E2eeStore(
     ) {
         stateLock.withLock {
             val entry = friends[id] ?: return@withLock
-            friends[id] = entry.copy(lastPollTs = ts)
-            save()
+            val newFriends = friends + (id to entry.copy(lastPollTs = ts))
+            save(friendsOverride = newFriends)
         }
     }
 
@@ -587,8 +586,8 @@ class E2eeStore(
     ) {
         stateLock.withLock {
             val entry = friends[id] ?: return@withLock
-            friends[id] = transform(entry)
-            save()
+            val newFriends = friends + (id to transform(entry))
+            save(friendsOverride = newFriends)
         }
     }
 
@@ -718,24 +717,32 @@ class E2eeStore(
 
             val lastLocation = decryptedLocations.lastOrNull()
 
-            friends[friendId] =
-                entry.copy(
-                    session = currentSession,
-                    // Bob becomes confirmed once he receives any valid message from Alice
-                    isConfirmed = entry.isConfirmed || anySuccess,
-                    lastRecvTs = if (hadActivity) currentTimeSeconds() else entry.lastRecvTs,
-                    lastLat = lastLocation?.lat ?: entry.lastLat,
-                    lastLng = lastLocation?.lng ?: entry.lastLng,
-                    lastTs = lastLocation?.ts ?: entry.lastTs,
-                    lastDecryptFailed = if (orderedMessages.isNotEmpty()) (failCount > 0 && !anySuccess) else entry.lastDecryptFailed,
-                )
+            val totalProcessed = orderedMessages.size
+            val silentDrops = encryptedMessages.size - totalProcessed
+            val isFailedBatch = (totalProcessed > 0 && !anySuccess && failCount > 0) || (silentDrops > 0 && !anySuccess)
+
+            val newFriends =
+                friends +
+                    (
+                        friendId to
+                            entry.copy(
+                                session = currentSession,
+                                // Bob becomes confirmed once he receives any valid message from Alice
+                                isConfirmed = entry.isConfirmed || anySuccess,
+                                lastRecvTs = if (hadActivity) currentTimeSeconds() else entry.lastRecvTs,
+                                lastLat = lastLocation?.lat ?: entry.lastLat,
+                                lastLng = lastLocation?.lng ?: entry.lastLng,
+                                lastTs = lastLocation?.ts ?: entry.lastTs,
+                                lastDecryptFailed = if (encryptedMessages.isNotEmpty()) isFailedBatch else entry.lastDecryptFailed,
+                            )
+                    )
 
             // The recvToken must only change if we had a successful decryption (§7.2).
             check(currentSession.recvToken.contentEquals(entry.session.recvToken) || anySuccess) {
                 "recvToken changed without any successful decryption — invariant violated"
             }
 
-            save()
+            save(friendsOverride = newFriends)
             PollBatchResult(decryptedLocations, anySuccess, hadSilentDrops)
         }
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -51,7 +51,6 @@ object Session {
         val envelope = encryptHeader(state.sendHeaderKey, dhPub, seq, state.pn)
 
         // Memory Hygiene
-        state.sendChainKey.zeroize()
         step.messageKey.zeroize()
         step.messageNonce.zeroize()
         plaintext.zeroize()
@@ -161,8 +160,7 @@ object Session {
 
             // Remove used key from cache
             val newCache = LinkedHashMap(cleanState.skippedMessageKeys)
-            val removed = newCache.remove(cacheKey)
-            removed?.zeroize()
+            newCache.remove(cacheKey)
 
             // If no more skipped keys exist for this epoch, drop the cached epoch header key.
             val epochHex = remoteDhPub.toHex()
@@ -357,14 +355,6 @@ object Session {
                             speculativeState.seenRemoteDhPubs
                         },
                 )
-
-            // Memory Hygiene
-            if (isNewDhEpoch) {
-                cleanState.localDhPriv.zeroize()
-                cleanState.rootKey.zeroize()
-                cleanState.sendChainKey.zeroize()
-                cleanState.recvChainKey.zeroize()
-            }
 
             return newState to decoded
         } catch (e: Exception) {

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/ChaosInfrastructure.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/ChaosInfrastructure.kt
@@ -1,0 +1,60 @@
+package net.af0.where.e2ee
+
+import kotlin.random.Random
+
+class ChaosStorage(private val storage: E2eeStorage) : E2eeStorage {
+    var failNextWrite = false
+    var failWriteProbability = 0.0
+
+    override fun getString(key: String): String? = storage.getString(key)
+
+    override fun putString(key: String, value: String) {
+        if (failNextWrite || Random.nextDouble() < failWriteProbability) {
+            failNextWrite = false
+            throw Exception("Simulated disk write failure")
+        }
+        storage.putString(key, value)
+    }
+}
+
+class ChaosMailboxClient(private val client: MailboxClient) : MailboxClient {
+    var failNextPost = false
+    var failPostProbability = 0.0
+    var failNextPoll = false
+    var failPollProbability = 0.0
+    var corruptNextPayload = false
+    var corruptPayloadProbability = 0.0
+
+    override suspend fun post(baseUrl: String, token: String, payload: MailboxPayload) {
+        if (failNextPost || Random.nextDouble() < failPostProbability) {
+            failNextPost = false
+            throw NetworkException("Simulated network failure on POST")
+        }
+        client.post(baseUrl, token, payload)
+    }
+
+    override suspend fun poll(baseUrl: String, token: String): List<MailboxPayload> {
+        if (failNextPoll || Random.nextDouble() < failPollProbability) {
+            failNextPoll = false
+            throw NetworkException("Simulated network failure on POLL")
+        }
+        val messages = client.poll(baseUrl, token)
+        return if (corruptNextPayload || Random.nextDouble() < corruptPayloadProbability) {
+            corruptNextPayload = false
+            messages.map { msg ->
+                if (msg is EncryptedMessagePayload) {
+                    msg.copy(ct = msg.ct.map { (it.toInt() xor 0xFF).toByte() }.toByteArray())
+                } else {
+                    msg
+                }
+            }
+        } else {
+            messages
+        }
+    }
+
+    override suspend fun ack(baseUrl: String, token: String, count: Int) {
+        // ACKs are typically non-fatal in the real client, but we can fail them too
+        client.ack(baseUrl, token, count)
+    }
+}

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/DesyncReproTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/DesyncReproTest.kt
@@ -1,0 +1,55 @@
+package net.af0.where.e2ee
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+
+class DesyncReproTest {
+    init {
+        initializeE2eeTests()
+    }
+
+    @Test
+    fun testProcessBatchDivergenceStuckBug() = runTest {
+        val storage = MemoryStorage()
+        val chaosStorage = ChaosStorage(storage)
+        val store = E2eeStore(chaosStorage)
+
+        val aliceStore = E2eeStore(MemoryStorage())
+        val qr = aliceStore.createInvite("Alice")
+        val (initPayload, bobEntry) = store.processScannedQr(qr)
+        aliceStore.processKeyExchangeInit(initPayload, "Bob", qr.ekPub)
+
+        val aliceToBobId = aliceStore.listFriends().first().id
+        val bobToAliceId = bobEntry.id
+
+        // 1. Alice sends a message
+        val (aSess, msg) = Session.encryptMessage(aliceStore.getFriend(aliceToBobId)!!.session, MessagePlaintext.Location(1.0, 1.0, 1.0, 1000L))
+        aliceStore.updateSession(aliceToBobId, aSess)
+
+        // 2. Bob processes batch, but DISK WRITE FAILS
+        chaosStorage.failNextWrite = true
+        val recvToken = store.getFriend(bobToAliceId)!!.session.recvToken.toHex()
+
+        assertFailsWith<Exception> {
+            store.processBatch(bobToAliceId, recvToken, listOf(msg))
+        }
+
+        // 3. Verify NO divergence (due to our fix)
+        val inMemorySeq = store.getFriend(bobToAliceId)!!.session.recvSeq
+        assertEquals(0L, inMemorySeq, "In-memory state should NOT be ratcheted if disk write failed")
+
+        val reloadedStore = E2eeStore(storage)
+        val onDiskSeq = reloadedStore.getFriend(bobToAliceId)!!.session.recvSeq
+        assertEquals(0L, onDiskSeq, "On-disk state should NOT be ratcheted")
+
+        // 4. Bob tries to process the SAME batch again (because he didn't ACK)
+        // This time disk write succeeds
+        val result = store.processBatch(bobToAliceId, recvToken, listOf(msg))
+        assertNotNull(result)
+        assertTrue(result.anySuccess, "Should NOW have success because in-memory state didn't diverge")
+
+        // 5. Verify we are NOT STUCK
+        val finalInMemorySeq = store.getFriend(bobToAliceId)!!.session.recvSeq
+        assertEquals(1L, finalInMemorySeq, "In-memory state should now be at 1")
+    }
+}

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
@@ -1,0 +1,181 @@
+package net.af0.where.e2ee
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+import kotlin.random.Random
+
+class E2eeChaosTest {
+    init {
+        initializeE2eeTests()
+    }
+
+    @Test
+    fun testChaosRecovery() = runTest {
+        val aliceBaseStorage = MemoryStorage()
+        val bobBaseStorage = MemoryStorage()
+
+        val aliceChaosStorage = ChaosStorage(aliceBaseStorage)
+        val bobChaosStorage = ChaosStorage(bobBaseStorage)
+
+        var aliceStore = E2eeStore(aliceChaosStorage)
+        var bobStore = E2eeStore(bobChaosStorage)
+
+        val relay = RelayMailboxClient()
+        val aliceChaosMailbox = ChaosMailboxClient(relay)
+        val bobChaosMailbox = ChaosMailboxClient(relay)
+
+        var aliceClient = LocationClient("http://fake", aliceStore, aliceChaosMailbox)
+        var bobClient = LocationClient("http://fake", bobStore, bobChaosMailbox)
+
+        // 1. Initial pairing (no chaos yet)
+        val qr = aliceStore.createInvite("Alice")
+        val (initPayload, bobEntry) = bobStore.processScannedQr(qr)
+        aliceStore.processKeyExchangeInit(initPayload, "Bob", qr.ekPub)
+
+        val aliceToBobId = aliceStore.listFriends().first().id
+        val bobToAliceId = bobEntry.id
+
+        // 2. Start Chaos
+        aliceChaosStorage.failWriteProbability = 0.3
+        bobChaosStorage.failWriteProbability = 0.3
+        aliceChaosMailbox.failPostProbability = 0.3
+        aliceChaosMailbox.failPollProbability = 0.3
+        bobChaosMailbox.failPostProbability = 0.3
+        bobChaosMailbox.failPollProbability = 0.3
+
+        aliceChaosMailbox.corruptPayloadProbability = 0.1
+        bobChaosMailbox.corruptPayloadProbability = 0.1
+
+        println("Starting Chaos Phase...")
+
+        val successfulLocationsReceivedByBob = mutableSetOf<Int>()
+        val successfulLocationsReceivedByAlice = mutableSetOf<Int>()
+
+        repeat(200) { i ->
+            // Randomly restart stores (simulates app kill/memory loss)
+            if (Random.nextDouble() < 0.2) {
+                aliceStore = E2eeStore(aliceChaosStorage)
+                aliceClient = LocationClient("http://fake", aliceStore, aliceChaosMailbox)
+            }
+            if (Random.nextDouble() < 0.2) {
+                bobStore = E2eeStore(bobChaosStorage)
+                bobClient = LocationClient("http://fake", bobStore, bobChaosMailbox)
+            }
+
+            // Alice tries to send location i
+            try {
+                aliceClient.sendLocation(i.toDouble(), 0.0)
+            } catch (e: Exception) {
+                // Ignore failures during chaos
+            }
+
+            // Bob tries to poll
+            try {
+                val updates = bobClient.poll()
+                updates.forEach { successfulLocationsReceivedByBob.add(it.lat.toInt()) }
+            } catch (e: Exception) {
+                // Ignore failures during chaos
+            }
+
+            // Bob tries to send location i
+            try {
+                bobClient.sendLocation(0.0, i.toDouble())
+            } catch (e: Exception) {
+                // Ignore failures during chaos
+            }
+
+            // Alice tries to poll
+            try {
+                val updates = aliceClient.poll()
+                updates.forEach { successfulLocationsReceivedByAlice.add(it.lng.toInt()) }
+            } catch (e: Exception) {
+                // Ignore failures during chaos
+            }
+        }
+
+        println("Chaos Phase complete. Bob received ${successfulLocationsReceivedByBob.size} locations, Alice received ${successfulLocationsReceivedByAlice.size}")
+
+        // 3. Recovery Phase: Turn off all chaos and see if they can still talk
+        println("Starting Recovery Phase...")
+        aliceChaosStorage.failWriteProbability = 0.0
+        bobChaosStorage.failWriteProbability = 0.0
+        aliceChaosMailbox.failPostProbability = 0.0
+        aliceChaosMailbox.failPollProbability = 0.0
+        bobChaosMailbox.failPostProbability = 0.0
+        bobChaosMailbox.failPollProbability = 0.0
+        aliceChaosMailbox.corruptPayloadProbability = 0.0
+        bobChaosMailbox.corruptPayloadProbability = 0.0
+
+        // One more round of restarts to ensure they recover from their LAST DISK STATE
+        aliceStore = E2eeStore(aliceChaosStorage)
+        aliceClient = LocationClient("http://fake", aliceStore, aliceChaosMailbox)
+        bobStore = E2eeStore(bobChaosStorage)
+        bobClient = LocationClient("http://fake", bobStore, bobChaosMailbox)
+
+        // Final catch-up: several rounds of polls
+        repeat(10) {
+            try {
+                val bUpdates = bobClient.poll()
+                bUpdates.forEach { successfulLocationsReceivedByBob.add(it.lat.toInt()) }
+                val aUpdates = aliceClient.poll()
+                aUpdates.forEach { successfulLocationsReceivedByAlice.add(it.lng.toInt()) }
+            } catch (e: Exception) {
+                println("Poll failed during recovery: ${e.message}")
+            }
+        }
+
+        // Send one final verified message each way
+        val finalLat = 9999.0
+        val finalLng = 8888.0
+
+        var aliceSuccess = false
+        var bobSuccess = false
+
+        repeat(20) {
+            if (!aliceSuccess) {
+                try {
+                    aliceClient.sendLocation(finalLat, 0.0)
+                    aliceSuccess = true
+                } catch (e: Exception) {
+                    println("Alice final send failed: ${e.message}")
+                }
+            }
+            try {
+                val updates = bobClient.poll()
+                if (updates.any { it.lat == finalLat }) {
+                    bobSuccess = true
+                }
+            } catch (e: Exception) {
+                println("Bob final poll failed: ${e.message}")
+            }
+
+            if (!bobSuccess) {
+                try {
+                    bobClient.sendLocation(0.0, finalLng)
+                    bobSuccess = true
+                } catch (e: Exception) {
+                    println("Bob final send failed: ${e.message}")
+                }
+            }
+            try {
+                val updates = aliceClient.poll()
+                if (updates.any { it.lng == finalLng }) {
+                    aliceSuccess = true
+                }
+            } catch (e: Exception) {
+                println("Alice final poll failed: ${e.message}")
+            }
+        }
+
+        if (!bobSuccess) {
+            val aliceEntry = aliceStore.getFriend(aliceToBobId)!!
+            val bobEntryFinal = bobStore.getFriend(bobToAliceId)!!
+            println("ALICE SESSION: sendToken=${aliceEntry.session.sendToken.toHex().take(8)} prevSendToken=${aliceEntry.session.prevSendToken.toHex().take(8)} isPending=${aliceEntry.session.isSendTokenPending} outbox=${aliceEntry.outbox?.token?.take(8)}")
+            println("BOB SESSION:   recvToken=${bobEntryFinal.session.recvToken.toHex().take(8)}")
+            println("RELAY INBOX TOKENS: ${relay.inbox.keys.map { it.take(8) }}")
+        }
+
+        assertTrue(bobSuccess, "Bob should eventually receive Alice's final message")
+        assertTrue(aliceSuccess, "Alice should eventually receive Bob's final message")
+    }
+}


### PR DESCRIPTION
This PR hardens the E2EE location sharing protocol by ensuring atomicity between in-memory state updates and persistent storage. It addresses a core desync vulnerability where failed disk writes left the system in a corrupted intermediate state.

Key changes:
- Refactored `E2eeStore` to implement atomic transactions: in-memory maps are only updated if `storage.putString` succeeds.
- Modified `Session.kt` to avoid zeroizing byte arrays belonging to the input `SessionState`, ensuring that the previous state remains valid for retries if persistence fails.
- Improved error reporting in `processBatch` to correctly set `lastDecryptFailed` for silent drops and partial batch failures.
- Added `ChaosInfrastructure.kt` to simulate storage and network failures in tests.
- Added `E2eeChaosTest.kt` for high-load stress testing of the synchronization protocol.
- Added `DesyncReproTest.kt` with a deterministic reproduction of the state divergence bug.
- Removed manual `equals`/`hashCode` in `FriendEntry` to prevent bugs when adding new fields.

---
*PR created automatically by Jules for task [13698959162535059820](https://jules.google.com/task/13698959162535059820) started by @danmarg*