### PR TITLE
Fix E2EE Ratchet Desync and Batch Sorting Logic

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -674,18 +674,23 @@ class E2eeStore(
             val orderedMessages = sortedMessagesWithHeaders.sortedWith { (h1, _), (h2, _) ->
                     val b1 =
                         when {
-                            h1.dhPub.contentEquals(entry.session.remoteDhPub) -> 0
-                            h1.dhPub.contentEquals(entry.session.lastRemoteDhPub) -> 1
-                            else -> 2
+                            h1.dhPub.contentEquals(entry.session.remoteDhPub) -> 1
+                            h1.dhPub.contentEquals(entry.session.lastRemoteDhPub) -> 0
+                            entry.session.seenRemoteDhPubs.contains(h1.dhPub.toHex()) -> -1
+                            else -> 2 // Unknown NEW epoch
                         }
                     val b2 =
                         when {
-                            h2.dhPub.contentEquals(entry.session.remoteDhPub) -> 0
-                            h2.dhPub.contentEquals(entry.session.lastRemoteDhPub) -> 1
+                            h2.dhPub.contentEquals(entry.session.remoteDhPub) -> 1
+                            h2.dhPub.contentEquals(entry.session.lastRemoteDhPub) -> 0
+                            entry.session.seenRemoteDhPubs.contains(h2.dhPub.toHex()) -> -1
                             else -> 2
                         }
                     if (b1 != b2) {
                         b1.compareTo(b2)
+                    } else if (b1 == 2) {
+                        // For multiple unknown NEW epochs, sort by 'pn' to stay chronological
+                        if (h1.pn != h2.pn) h1.pn.compareTo(h2.pn) else h1.seq.compareTo(h2.seq)
                     } else {
                         h1.seq.compareTo(h2.seq)
                     }

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -372,7 +372,7 @@ open class LocationClient(
         // TOKEN TRANSITION (§5.4): If we were transitioning DH epochs, we have now
         // successfully flushed the final message of the old epoch. We must now
         // clear the pending flag and trigger the fresh keepalive.
-        finalizeTokenTransition(friendId)
+        finalizeTokenTransition(friendId, clearingToken = tokenToUse)
     }
 
     /**
@@ -380,12 +380,16 @@ open class LocationClient(
      * Clears isSendTokenPending and sends a fresh keepalive if necessary.
      * This is called by both the main send path and the outbox recovery path.
      */
-    private suspend fun finalizeTokenTransition(friendId: String) {
+    private suspend fun finalizeTokenTransition(
+        friendId: String,
+        clearingToken: String? = null,
+    ) {
         // Tightened idempotency check: only act if transition is still marked pending in store.
         val updatedFriend = store.getFriend(friendId) ?: return
-        if (updatedFriend.session.isSendTokenPending) {
+        val session = updatedFriend.session
+        if (session.isSendTokenPending && (clearingToken == null || session.prevSendToken.toHex() == clearingToken)) {
             println("[LocationClient] finalizeTokenTransition: clearing pending flag for ${friendId.take(8)}")
-            val finalSession = updatedFriend.session.copy(isSendTokenPending = false)
+            val finalSession = session.copy(isSendTokenPending = false)
             store.updateSession(friendId, finalSession)
 
             // Only send fresh keepalive if we actually rotated tokens and haven't sent it.
@@ -419,6 +423,8 @@ open class LocationClient(
                 // we must still finalize the transition now.
                 // We detect this by checking if isSendTokenPending is true and sendSeq > 0
                 // (meaning the first message of the new epoch was already sent).
+                // Note: on restart recovery, we don't know the clearingToken, so we act
+                // cautiously. If sendSeq > 0 it's likely we finished the transition.
                 if (friend.session.isSendTokenPending && friend.session.sendSeq > 0) {
                     println("[LocationClient] recovery: detected stale transition flag for ${friend.id.take(8)}, finalizing now")
                     finalizeTokenTransition(friend.id)
@@ -431,7 +437,7 @@ open class LocationClient(
                 store.clearOutbox(friend.id)
                 // TRANSACTIONAL RECOVERY (§5.4): After recovering a lost post,
                 // we must also trigger the token transition cleanup.
-                finalizeTokenTransition(friend.id)
+                finalizeTokenTransition(friend.id, clearingToken = outbox.token)
             } catch (e: Exception) {
                 if (e is ProtocolGapException) {
                     println("[LocationClient] recovery: permanent cryptodesync (gap) for ${friend.id.take(8)}, clearing outbox")
@@ -474,7 +480,7 @@ open class LocationClient(
                         println("[LocationClient] recovery: ABANDONING stuck transition outbox for ${friend.id.take(8)} after $count 429s")
                         store.addDiagnosticEvent("ABANDON OUTBOX: ${friend.id.take(8)} after $count 429s")
                         store.clearOutbox(friend.id)
-                        finalizeTokenTransition(friend.id)
+                        finalizeTokenTransition(friend.id, clearingToken = outbox.token)
                     }
                 }
                 // Otherwise: Network failure or other server error: leave in outbox for next poll

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/ProtocolRobustnessTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/ProtocolRobustnessTest.kt
@@ -1,0 +1,141 @@
+package net.af0.where.e2ee
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+
+class ProtocolRobustnessTest {
+    init {
+        initializeE2eeTests()
+    }
+
+    /**
+     * Verifies that processBatch correctly sorts messages from the previous epoch
+     * before the current epoch, ensuring chronological processing even if the
+     * relay returns them out of order.
+     */
+    @Test
+    fun testProcessBatchSortingChronological() = runTest {
+        val aliceStore = E2eeStore(MemoryStorage())
+        val bobStore = E2eeStore(MemoryStorage())
+        val relay = RelayMailboxClient()
+        val aliceClient = LocationClient("http://fake", aliceStore, relay)
+        val bobClient = LocationClient("http://fake", bobStore, relay)
+
+        val qr = aliceStore.createInvite("Alice")
+        val (initPayload, _) = bobStore.processScannedQr(qr)
+        aliceStore.processKeyExchangeInit(initPayload, "Bob", qr.ekPub)
+        val aliceId = aliceStore.listFriends().first().id
+        val bobId = bobStore.listFriends().first().id
+
+        // 1. Bob sends M1 (B1).
+        bobClient.sendLocation(1.0, 1.0)
+
+        // 2. Alice sends A1 keepalive. Bob polls and ratchets to B2.
+        aliceClient.sendKeepalive(aliceId)
+        bobClient.poll()
+
+        // 3. Bob sends M2 (B2).
+        bobClient.sendLocation(2.0, 2.0)
+
+        // 4. Now Alice's mailbox at Bob's T_B0 contains [M1 (B1), M2 (B2)].
+        val recvToken = aliceStore.getFriend(aliceId)!!.session.recvToken.toHex()
+        val messages = relay.poll("http://fake", recvToken)
+        assertEquals(2, messages.size)
+
+        // 5. Provide [M2, M1] in a batch to a FRESH Alice (so she hasn't ratcheted yet).
+        // We'll simulate this by using the existing Alice but she is still on B0.
+
+        // Reverse the batch to ensure sorting works.
+        val shuffledBatch = listOf(messages[1], messages[0])
+        val result = aliceStore.processBatch(aliceId, recvToken, shuffledBatch)
+        assertNotNull(result)
+
+        // With corrected sorting, M1 (1.0) is processed first, Alice ratchets to B1.
+        // Then M2 (2.0) is processed, Alice ratchets to B2.
+        assertEquals(listOf(1.0, 2.0), result.decryptedLocations.map { it.lat }, "Messages should be processed in chronological order")
+
+        val aliceSessionFinal = aliceStore.getFriend(aliceId)!!.session
+        assertEquals(2.0, result.decryptedLocations.last().lat)
+    }
+
+    /**
+     * Verifies the fix for the one-way ratchet desync bug.
+     * finalizedTokenTransition must NOT clear the isSendTokenPending flag
+     * if the outbox being cleared belongs to an older DH epoch than the current transition.
+     */
+    @Test
+    fun testOneWayRatchetDesyncFix() = runTest {
+        val aliceStore = E2eeStore(MemoryStorage())
+        val bobStore = E2eeStore(MemoryStorage())
+        val relay = RelayMailboxClient()
+
+        var bobPostShouldFail = false
+        val bobMailbox = object : MailboxClient by relay {
+            override suspend fun post(baseUrl: String, token: String, payload: MailboxPayload) {
+                // Post to relay successfully
+                relay.post(baseUrl, token, payload)
+                // But optionally throw NetworkException to Bob
+                if (bobPostShouldFail) {
+                    bobPostShouldFail = false
+                    throw NetworkException("Simulated response loss")
+                }
+            }
+        }
+
+        val aliceClient = LocationClient("http://fake", aliceStore, relay)
+        val bobClient = LocationClient("http://fake", bobStore, bobMailbox)
+
+        // 1. Pairing
+        val qr = aliceStore.createInvite("Alice")
+        val (initPayload, _) = bobStore.processScannedQr(qr)
+        aliceStore.processKeyExchangeInit(initPayload, "Bob", qr.ekPub)
+        val aliceId = aliceStore.listFriends().first().id
+        val bobId = bobStore.listFriends().first().id
+
+        // 2. Alice sends A1, Bob ratchets to B1.
+        aliceClient.sendKeepalive(aliceId)
+        bobClient.poll()
+
+        val bobSession1 = bobStore.getFriend(bobId)!!.session
+        assertTrue(bobSession1.isSendTokenPending)
+        val t0 = bobSession1.prevSendToken.toHex()
+
+        // 3. Bob sends M1 (B1) to T0. Response lost.
+        bobPostShouldFail = true
+        try {
+            bobClient.sendLocation(1.1, 1.1)
+        } catch (e: NetworkException) {}
+
+        val bobEntry2 = bobStore.getFriend(bobId)!!
+        assertNotNull(bobEntry2.outbox)
+        assertEquals(t0, bobEntry2.outbox!!.token)
+
+        // 4. Alice polls Bob's M1 (B1), ratchets to A2. Then Alice sends A2.
+        aliceClient.poll()
+        aliceClient.sendLocation(2.2, 2.2)
+
+        // 5. Bob polls A2, ratchets to B2.
+        // Use processBatch directly to simulate background poll without clearing outbox.
+        val bobRecvToken = bobStore.getFriend(bobId)!!.session.recvToken.toHex()
+        val msgsForBob = relay.poll("http://fake", bobRecvToken)
+        bobStore.processBatch(bobId, bobRecvToken, msgsForBob)
+
+        val bobSession3 = bobStore.getFriend(bobId)!!.session
+        assertTrue(bobSession3.isSendTokenPending, "Bob should still have pending transition for B2")
+        val t1 = bobSession3.prevSendToken.toHex()
+        assertNotEquals(t0, t1, "Epoch transition token should have advanced to T1")
+
+        // 6. Bob calls poll() which retries outbox (T0).
+        // With the FIX, this should NOT clear isSendTokenPending because T0 != T1.
+        bobClient.poll()
+
+        val bobEntry4 = bobStore.getFriend(bobId)!!
+        assertNull(bobEntry4.outbox, "Outbox T0 should be cleared")
+
+        // If the fix works, Bob's next send should still carry the B2 ratchet (to T1).
+        bobClient.sendLocation(3.3, 3.3)
+
+        val aliceUpdates = aliceClient.poll()
+        assertTrue(aliceUpdates.any { it.lat == 3.3 }, "Alice should have received Bob's message on T1")
+    }
+}


### PR DESCRIPTION
I have identified and fixed two critical bugs in the E2EE protocol implementation that could lead to token desync and incorrect message processing:

1. **One-way Ratchet Desync**: In `LocationClient.kt`, the `finalizeTokenTransition` function was too eager. If a device had a pending DH transition (routing to `prevSendToken`) but also an old outbox message from a *previous* epoch (due to a past failure), retrying that old message would incorrectly clear the `isSendTokenPending` flag. This caused the device to skip sending the transition message to the token the peer was still polling, leading to a permanent one-way desync. I fixed this by ensuring the flag is only cleared if the `clearingToken` matches the expected `prevSendToken`.

2. **Incorrect Batch Sorting**: In `E2eeStore.kt`, the `processBatch` sorting logic was prioritized backwards, processing the "Current" epoch before the "Last" epoch. This could cause decryption failures or skipped messages if a batch contained messages from both. I corrected the sort order to be chronological: `Seen < Last Epoch < Current Epoch < New Epochs`. I also added a secondary sort key (`pn`) to correctly order multiple messages arriving from future/unknown epochs in a single batch.

I've added a new test file `ProtocolRobustnessTest.kt` with targeted regression tests for both scenarios and verified that all existing tests, including the exhaustive `E2eeChaosTest`, now pass reliably.

---
*PR created automatically by Jules for task [9486900746972482186](https://jules.google.com/task/9486900746972482186) started by @danmarg*