### PR TITLE
Randomize mailbox poll and send order

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -55,7 +55,7 @@ open class LocationClient(
                 }
             }
 
-            val friends = store.listFriends()
+            val friends = store.listFriends().shuffled()
             val deferreds =
                 friends.map { friend ->
                     async {
@@ -157,7 +157,13 @@ open class LocationClient(
         // Multi-Token Polling (§5.3): if a transition is pending, we must poll BOTH the
         // current recvToken and the previous one, as the peer might still be sending to
         // the old epoch until they receive our first message from the new epoch.
-        val pollQueue = mutableListOf(friendBefore.session.recvToken.toHex())
+        val pollQueue = mutableListOf<String>()
+        pollQueue.add(friendBefore.session.recvToken.toHex())
+        val prev = friendBefore.session.prevRecvToken.toHex()
+        if (prev.isNotEmpty() && prev != friendBefore.session.recvToken.toHex()) {
+            pollQueue.add(prev)
+        }
+        pollQueue.shuffle()
 
         val polledTokens = mutableSetOf<String>()
         var hasIncrementedFailure = false
@@ -269,7 +275,7 @@ open class LocationClient(
         processOutboxes()
         val ts = currentTimeSeconds()
         val payload = MessagePlaintext.Location(lat = lat, lng = lng, acc = 0.0, ts = ts)
-        val activeFriends = store.listFriends().filter { it.id !in pausedFriendIds && !it.isStale }
+        val activeFriends = store.listFriends().filter { it.id !in pausedFriendIds && !it.isStale }.shuffled()
 
         var successCount = 0
         var failCount = 0
@@ -386,7 +392,7 @@ open class LocationClient(
     }
 
     private suspend fun processOutboxes() = coroutineScope {
-        val friends = store.listFriends()
+        val friends = store.listFriends().shuffled()
         friends.map { friend ->
             async {
                 val mutex = getFriendMutex(friend.id)

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/RandomizationTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/RandomizationTest.kt
@@ -1,0 +1,118 @@
+package net.af0.where.e2ee
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+
+class RandomizationTest {
+    init {
+        initializeE2eeTests()
+    }
+
+    private class CallTrackerMailbox : MailboxClient {
+        val pollTokens = mutableListOf<String>()
+        val postTokens = mutableListOf<String>()
+
+        override suspend fun post(baseUrl: String, token: String, payload: MailboxPayload) {
+            postTokens.add(token)
+        }
+
+        override suspend fun poll(baseUrl: String, token: String): List<MailboxPayload> {
+            pollTokens.add(token)
+            return emptyList()
+        }
+
+        fun reset() {
+            pollTokens.clear()
+            postTokens.clear()
+        }
+    }
+
+    @Test
+    fun testPollShufflesFriendOrder() = runTest {
+        val storage = MemoryStorage()
+        val store = E2eeStore(storage)
+        val aliceStore = E2eeStore(MemoryStorage())
+
+        // Create 5 friends
+        for (i in 1..5) {
+            val qr = aliceStore.createInvite("Friend $i")
+            val (init, session) = KeyExchange.bobProcessQr(qr, "Me")
+            store.processScannedQr(qr, "Friend $i") // This adds to 'friends' map in store
+        }
+
+        val tracker = CallTrackerMailbox()
+        val client = LocationClient("http://fake", store, tracker)
+
+        val seenOrders = mutableSetOf<List<String>>()
+
+        repeat(50) {
+            tracker.reset()
+            client.poll()
+            seenOrders.add(tracker.pollTokens.toList())
+        }
+
+        assertTrue(seenOrders.size > 1, "Should have seen multiple different poll orders for friends (got ${seenOrders.size})")
+    }
+
+    @Test
+    fun testPollFriendShufflesTokenOrder() = runTest {
+        val storage = MemoryStorage()
+        val store = E2eeStore(storage)
+        val aliceStore = E2eeStore(MemoryStorage())
+
+        // Create a friend
+        val qr = aliceStore.createInvite("Friend")
+        val (init, _) = store.processScannedQr(qr, "Friend")
+        val friendId = store.listFriends().first().id
+
+        // Manually inject tokens to poll
+        store.updateFriend(friendId) { entry ->
+            entry.copy(session = entry.session.copy(
+                recvToken = "new_token".encodeToByteArray(),
+                prevRecvToken = "old_token".encodeToByteArray()
+            ))
+        }
+
+        val tracker = CallTrackerMailbox()
+        val client = LocationClient("http://fake", store, tracker)
+
+        val seenOrders = mutableSetOf<List<String>>()
+
+        repeat(50) {
+            tracker.reset()
+            client.pollFriend(friendId)
+            // Filter to only include the initial tokens we expect
+            val initialPolls = tracker.pollTokens.filter { it == "6e65775f746f6b656e" || it == "6f6c645f746f6b656e" }
+            if (initialPolls.size >= 2) {
+                seenOrders.add(initialPolls.take(2))
+            }
+        }
+
+        assertTrue(seenOrders.size > 1, "Should have seen different orders for token polling (got ${seenOrders.size})")
+    }
+
+    @Test
+    fun testSendLocationShufflesFriendOrder() = runTest {
+        val storage = MemoryStorage()
+        val store = E2eeStore(storage)
+        val aliceStore = E2eeStore(MemoryStorage())
+
+        for (i in 1..5) {
+            val qr = aliceStore.createInvite("Friend $i")
+            store.processScannedQr(qr, "Friend $i")
+        }
+
+        val tracker = CallTrackerMailbox()
+        val client = LocationClient("http://fake", store, tracker)
+
+        val seenOrders = mutableSetOf<List<String>>()
+
+        repeat(50) {
+            tracker.reset()
+            client.sendLocation(0.0, 0.0)
+            seenOrders.add(tracker.postTokens.toList())
+        }
+
+        assertTrue(seenOrders.size > 1, "Should have seen multiple different post orders for friends (got ${seenOrders.size})")
+    }
+}


### PR DESCRIPTION
This change implements randomization of the network request order in `LocationClient` to improve traffic obfuscation. 

Key changes:
1.  **Friend Shuffling**: In `poll()`, `sendLocation()`, and `processOutboxes()`, the list of friends is now shuffled before being mapped to asynchronous network tasks. This ensures that the order in which different friends' mailboxes are accessed varies between poll cycles.
2.  **Token Shuffling**: In `pollFriend()`, the `pollQueue` is now initialized with both the current `recvToken` and the `prevRecvToken` (if different and non-empty). The queue is then shuffled before starting the polling loop, making it harder for an observer to distinguish between the primary and transitionary mailbox tokens.
3.  **Testing**: A new test suite `RandomizationTest.kt` was added to the shared module. It uses a mock `MailboxClient` to track the order of calls and asserts that multiple executions yield different sequences, ensuring the randomization logic works as intended.

These changes enhance privacy without impacting the correctness of the E2EE protocol, as the Double Ratchet implementation is already designed to handle out-of-order and multi-epoch message delivery.

---
*PR created automatically by Jules for task [2325147743668255130](https://jules.google.com/task/2325147743668255130) started by @danmarg*