### PR TITLE
Refactor Header Key Pruning in Session.kt

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -213,10 +213,19 @@ object Session {
         val addedSkippedKeys = mutableListOf<ByteArray>()
 
         // If we entered a new DH epoch, standard DR says we should eventually clear
-        // very old skipped keys. We'll clear keys belonging to epochs older than 'lastRemoteDhPub'.
+        // very old skipped keys. We'll clear keys belonging to epochs no longer in our seen window.
         if (isNewDhEpoch) {
             val validEpochs = mutableSetOf(remoteDhPub.toHex(), cleanState.remoteDhPub.toHex())
-            derivationSkippedKeys.keys.retainAll { k -> validEpochs.any { e -> k.startsWith(e) } }
+            validEpochs.addAll(speculativeState.seenRemoteDhPubs)
+
+            val it = derivationSkippedKeys.entries.iterator()
+            while (it.hasNext()) {
+                val entry = it.next()
+                if (validEpochs.none { e -> entry.key.startsWith(e) }) {
+                    entry.value.zeroize()
+                    it.remove()
+                }
+            }
         }
 
         val pnGaps =

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/PruningReproTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/PruningReproTest.kt
@@ -1,0 +1,75 @@
+package net.af0.where.e2ee
+
+import kotlin.test.*
+
+class PruningReproTest {
+    init {
+        initializeE2eeTests()
+    }
+
+    data class ExchangeResult(
+        val aliceSession: SessionState,
+        val bobSession: SessionState,
+    )
+
+    private fun exchangeKeys(): ExchangeResult {
+        val (qr, aliceEkPriv) = KeyExchange.aliceCreateQrPayload("Alice")
+        val (msg, bobSession) = KeyExchange.bobProcessQr(qr, "Bob")
+        val aliceSession = KeyExchange.aliceProcessInit(msg, aliceEkPriv, qr.ekPub)
+
+        return ExchangeResult(aliceSession, bobSession)
+    }
+
+    @Test
+    fun testPruningAggression() {
+        var (aSess, bSess) = exchangeKeys()
+        val loc = MessagePlaintext.Location(0.0, 0.0, 0.0, 0L)
+
+        // Epoch 1 (Alice's initial E1)
+        val e1Hex = aSess.localDhPub.toHex()
+
+        // Alice sends M1_1 (skipped), then M1_2 (received).
+        val (aS1_1, m1_1) = Session.encryptMessage(aSess, loc)
+        val (aS1_2, m1_2) = Session.encryptMessage(aS1_1, loc)
+        val (bS1_2, _) = Session.decryptMessage(bSess, m1_2)
+        aSess = aS1_2
+        bSess = bS1_2
+
+        assertTrue(bSess.skippedMessageKeys.containsKey("$e1Hex:1"), "Bob should have skipped key for E1:1")
+
+        // Alice ratchets to Epoch 2.
+        // Bob must send a message for Alice to ratchet.
+        val (bS_to_a1, bMsg1) = Session.encryptMessage(bSess, loc)
+        val (aS2_pre, _) = Session.decryptMessage(aSess, bMsg1)
+        // Alice sends M2_2 (E2), Bob receives.
+        val (aS2_1, m2_1) = Session.encryptMessage(aS2_pre, loc)
+        val (aS2_2, m2_2) = Session.encryptMessage(aS2_1, loc)
+
+        val e2Hex = aS2_2.localDhPub.toHex()
+        assertNotEquals(e1Hex, e2Hex)
+
+        val (bS2_2, _) = Session.decryptMessage(bS_to_a1, m2_2)
+        aSess = aS2_2
+        bSess = bS2_2
+
+        assertTrue(bSess.skippedMessageKeys.containsKey("$e1Hex:1"), "Bob should still have E1:1 after ratcheting to E2")
+        assertTrue(bSess.skippedMessageKeys.containsKey("$e2Hex:1"), "Bob should have skipped key for E2:1")
+
+        // Alice ratchets to Epoch 3.
+        val (bS_to_a2, bMsg2) = Session.encryptMessage(bSess, loc)
+        val (aS3_pre, _) = Session.decryptMessage(aSess, bMsg2)
+        // Alice sends M3_2 (E3), Bob receives.
+        val (aS3_1, m3_1) = Session.encryptMessage(aS3_pre, loc)
+        val (aS3_2, m3_2) = Session.encryptMessage(aS3_1, loc)
+
+        val e3Hex = aS3_2.localDhPub.toHex()
+        assertNotEquals(e2Hex, e3Hex)
+
+        val (bS3_2, _) = Session.decryptMessage(bS_to_a2, m3_2)
+        aSess = aS3_2
+        bSess = bS3_2
+
+        // This used to fail with aggressive pruning
+        assertTrue(bSess.skippedMessageKeys.containsKey("$e1Hex:1"), "Bob should still have E1:1 after ratcheting to E3")
+    }
+}


### PR DESCRIPTION
Refactored the aggressive pruning of skipped epoch header keys in Session.kt. Previously, the cache was pruned to only keep the current and immediate previous epoch, causing valid keys to be dropped during rapid ratcheting. The new implementation includes all hex fingerprints currently stored in `seenRemoteDhPubs` in the `validEpochs` set. Additionally, implemented manual iteration over the cache to ensure all evicted keys are zeroized for proper memory hygiene. Verified the fix with a new regression test and existing session tests.

---
*PR created automatically by Jules for task [8384984061411760438](https://jules.google.com/task/8384984061411760438) started by @danmarg*