### PR TITLE
Fix cleanupExpiredInvites TOCTOU Race in E2eeStore

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -471,20 +471,14 @@ class E2eeStore(
                     now - baseTime > expirySeconds
                 }
 
+            if (nextInvites.size != pendingInvites.size) {
+                saveGlobalInternal(nextInvites = nextInvites)
+            }
+
             toRemove =
                 friends.values.filter {
                     !it.isConfirmed && (now - it.lastRecvTs > expirySeconds)
                 }.map { it.id }
-
-            if (nextInvites.size != pendingInvites.size || toRemove.isNotEmpty()) {
-                val nextFriendIds = friends.keys.filterNot { toRemove.contains(it) }
-                saveGlobalInternal(nextFriendIds = nextFriendIds, nextInvites = nextInvites)
-
-                // Remove from memory
-                toRemove.forEach { id ->
-                    friends.remove(id)
-                }
-            }
         }
 
         // Clear underlying storage slots outside metadataLock, but under individual friendLocks
@@ -492,8 +486,20 @@ class E2eeStore(
         toRemove.forEach { id ->
             val friendLock = getFriendLock(id)
             friendLock.withLock {
-                storage.putString("${friendKey(id)}_a", "")
-                storage.putString("${friendKey(id)}_b", "")
+                metadataLock.withLock {
+                    val entry = friends[id] ?: return@withLock
+                    val now = currentTimeSeconds()
+                    // Re-verify expiration criteria under lock
+                    if (!entry.isConfirmed && (now - entry.lastRecvTs > expirySeconds)) {
+                        val nextFriendIds = friends.keys.filter { it != id }
+                        saveGlobalInternal(nextFriendIds = nextFriendIds)
+                        // Remove from memory
+                        friends.remove(id)
+                        // Clear the friend's storage keys.
+                        storage.putString("${friendKey(id)}_a", "")
+                        storage.putString("${friendKey(id)}_b", "")
+                    }
+                }
             }
             // Prune the lock from the map after releasing.
             locksLock.withLock {


### PR DESCRIPTION
This change fixes a Time-of-Check to Time-of-Use (TOCTOU) race condition in the friend cleanup logic of `E2eeStore`. Previously, a friend could be removed from the memory index under a global lock, but their storage was cleared later under a per-friend lock, allowing a window for concurrent writes. The fix ensures that the friend is removed and storage cleared atomically with respect to other friend-specific operations by holding both the friend lock and the metadata lock.

---
*PR created automatically by Jules for task [15310142477264917050](https://jules.google.com/task/15310142477264917050) started by @danmarg*