### PR TITLE
Align Retry vs. Follow Constants and Enforce Follow Cap

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -169,7 +169,7 @@ open class LocationClient(
         var hasIncrementedFailure = false
         var follows = 0
 
-        while (pollQueue.isNotEmpty() && follows < MAX_TOKEN_FOLLOWS_PER_POLL) {
+        while (pollQueue.isNotEmpty()) {
             val currentTokenToPoll = pollQueue.removeAt(0)
             if (polledTokens.contains(currentTokenToPoll)) continue
             polledTokens.add(currentTokenToPoll)
@@ -200,12 +200,17 @@ open class LocationClient(
                     0
                 }
 
-                val forceAck = currentDropCount >= MAX_SILENT_DROP_RETRIES
+                val forceAck = currentDropCount >= MAX_SILENT_DROP_RETRIES || follows >= MAX_TOKEN_FOLLOWS_PER_POLL
                 if (forceAck) {
-                    println(
-                        "[LocationClient] pollFriend: force-ACKing after $MAX_SILENT_DROP_RETRIES consecutive failures for ${friendId.take(8)}",
-                    )
-                    store.addDiagnosticEvent("FORCE ACK: ${friendId.take(8)} — unrecoverable failures, re-pair if desynced")
+                    if (follows >= MAX_TOKEN_FOLLOWS_PER_POLL) {
+                        println("[LocationClient] pollFriend: force-ACKing due to TOKEN FOLLOW CAP for ${friendId.take(8)}")
+                        store.addDiagnosticEvent("TOKEN FOLLOW CAP: ${friendId.take(8)}")
+                    } else {
+                        println(
+                            "[LocationClient] pollFriend: force-ACKing after $MAX_SILENT_DROP_RETRIES consecutive failures for ${friendId.take(8)}",
+                        )
+                        store.addDiagnosticEvent("FORCE ACK: ${friendId.take(8)} — unrecoverable failures, re-pair if desynced")
+                    }
                     store.resetConsecutiveSilentDrops(friendId)
                 }
 
@@ -229,6 +234,10 @@ open class LocationClient(
                     },
                 )
 
+                if (follows >= MAX_TOKEN_FOLLOWS_PER_POLL) {
+                    break
+                }
+
                 // Follow rotation
                 val updatedFriend = store.getFriend(friendId) ?: break
                 val newToken = updatedFriend.session.recvToken.toHex()
@@ -239,11 +248,6 @@ open class LocationClient(
                 println("[LocationClient] pollFriend: processBatch failed for ${friendId.take(8)}: ${e.message}")
                 throw e
             }
-        }
-
-        if (follows >= MAX_TOKEN_FOLLOWS_PER_POLL) {
-            println("[LocationClient] pollFriend: TOKEN FOLLOW CAP HIT for ${friendId.take(8)}")
-            store.addDiagnosticEvent("TOKEN FOLLOW CAP: ${friendId.take(8)}")
         }
 
         store.updateLastPollTs(friendId, currentTimeSeconds())

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/ProtocolConstants.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/ProtocolConstants.kt
@@ -13,7 +13,7 @@ internal const val INFO_HEADER_KEY = "Where-v1-HeaderKey"
 // before and after a ratchet both arrive in the same server poll window.
 // SECURITY NOTE: The follow condition requires a successful AEAD authentication,
 // so an adversary without the current chain key cannot force token advancement.
-internal const val MAX_TOKEN_FOLLOWS_PER_POLL = 50
+internal const val MAX_TOKEN_FOLLOWS_PER_POLL = 20
 internal const val MAX_DIAGNOSTIC_EVENTS = 30
 
 // After this many consecutive polls where header-parse failures blocked the ACK,


### PR DESCRIPTION
This change aligns the protocol's token follow cap (MAX_TOKEN_FOLLOWS_PER_POLL) with the silent drop retry limit (MAX_SILENT_DROP_RETRIES), setting both to 20. It also updates the `pollFriend` logic in `LocationClient.kt` to ensure that if the follow cap is reached during a single poll cycle, a force-ACK is triggered on the current token. This prevents potential livelocks in reorder or replay scenarios. The loop structure was refined to make the cap check reachable and to explicitly break the loop after the force-ACKed iteration.

---
*PR created automatically by Jules for task [5523228308772097142](https://jules.google.com/task/5523228308772097142) started by @danmarg*