### PR TITLE
Fix silent failure of exact alarms on Android 12+

### DIFF
--- a/android/src/androidMain/AndroidManifest.xml
+++ b/android/src/androidMain/AndroidManifest.xml
@@ -11,7 +11,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
     <application
         android:name=".WhereApplication"

--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -306,9 +306,11 @@ class LocationService : Service() {
         val intent = Intent(this, LocationService::class.java).apply { action = ACTION_POLL_ALARM }
         val pi = PendingIntent.getService(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
         val triggerAt = SystemClock.elapsedRealtime() + delayMs
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && alarmManager.canScheduleExactAlarms()) {
+        // USE_EXACT_ALARM grants unconditionally on API 33+; on older APIs fall back gracefully
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, pi)
         } else {
+            // API 31-32: SCHEDULE_EXACT_ALARM was required; on 31/32 use inexact fallback
             alarmManager.setAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, pi)
         }
     }

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationServicePermissionTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationServicePermissionTest.kt
@@ -99,8 +99,8 @@ class LocationServicePermissionTest {
 
     @Test
     fun testServiceStarts_WithoutLocationPermission_Paused() {
-        io.mockk.every { UserPrefs.isSharing(any()) } returns false
-        fakeLocationSource.setSharingLocation(false)
+        val app = context as TestWhereApplication
+        app.userStore.setSharing(false)
 
         val controller = Robolectric.buildService(LocationService::class.java)
         val service = controller.get()
@@ -132,7 +132,8 @@ class LocationServicePermissionTest {
 
     @Test
     fun testServiceStarts_WithCoarseLocationPermissionOnly() {
-        io.mockk.every { UserPrefs.isSharing(any()) } returns true
+        val app = context as TestWhereApplication
+        app.userStore.setSharing(true)
         // Android 12+ "Approximate" location grants Coarse but not Fine.
         shadowOf(context).grantPermissions(Manifest.permission.ACCESS_COARSE_LOCATION)
         shadowOf(context).denyPermissions(Manifest.permission.ACCESS_FINE_LOCATION)

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceSharingPauseTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceSharingPauseTest.kt
@@ -54,8 +54,8 @@ class LocationServiceSharingPauseTest {
     @Test
     fun testRegistrationRemovedWhenSharingPaused() =
         runTest {
-            io.mockk.every { UserPrefs.isSharing(any()) } returns true
-            fakeLocationSource.setSharingLocation(true)
+            val app = context as TestWhereApplication
+            app.userStore.setSharing(true)
 
             val controller = Robolectric.buildService(LocationService::class.java)
             val service = controller.get()
@@ -77,14 +77,14 @@ class LocationServiceSharingPauseTest {
             }
 
             // Pause sharing
-            fakeLocationSource.setSharingLocation(false)
+            app.userStore.setSharing(false)
             advanceUntilIdle()
 
             assertFalse(service.isRegistered, "Should be unregistered when sharing is paused")
             verify(exactly = 1) { mockFused.removeLocationUpdates(any<com.google.android.gms.location.LocationCallback>()) }
 
             // Resume sharing
-            fakeLocationSource.setSharingLocation(true)
+            app.userStore.setSharing(true)
             advanceUntilIdle()
 
             assertTrue(service.isRegistered, "Should be registered again when sharing is resumed")

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
@@ -189,6 +189,7 @@ class LocationServiceTest {
         val app = context as TestWhereApplication
         app.userStore.setSharing(true)
         app.userStore.setPausedFriends(emptySet())
+        app.userStore.setDisplayName("Test User")
 
         // Mock KtorMailboxClient to prevent network calls during pollPendingInvite
         io.mockk.mockkObject(net.af0.where.e2ee.KtorMailboxClient)
@@ -248,6 +249,8 @@ class LocationServiceTest {
             val mockClient = io.mockk.mockk<LocationClient>(relaxed = true)
             service.locationClientOverride = mockClient
             service.locationSourceOverride = fakeLocationSource
+            val app = context as TestWhereApplication
+            app.userStore.setSharing(true)
             io.mockk.coEvery { mockClient.pollPendingInvites() } returns emptyList()
             val mockStore = io.mockk.mockk<net.af0.where.e2ee.E2eeManager>(relaxed = true)
             service.e2eeManagerOverride = mockStore
@@ -292,6 +295,8 @@ class LocationServiceTest {
             val mockClient = io.mockk.mockk<LocationClient>(relaxed = true)
             service.locationClientOverride = mockClient
             service.locationSourceOverride = fakeLocationSource
+            val app = context as TestWhereApplication
+            app.userStore.setSharing(true)
             io.mockk.coEvery { mockClient.pollPendingInvites() } returns emptyList()
             val mockStore = io.mockk.mockk<net.af0.where.e2ee.E2eeManager>(relaxed = true)
             service.e2eeManagerOverride = mockStore
@@ -356,7 +361,8 @@ class LocationServiceTest {
             val mockClient = io.mockk.mockk<LocationClient>(relaxed = true)
             service.locationClientOverride = mockClient
             service.locationSourceOverride = fakeLocationSource
-            fakeLocationSource.setSharingLocation(true)
+            val app = context as TestWhereApplication
+            app.userStore.setSharing(true)
             fakeLocationSource.onLocation(1.0, 2.0, null)
             controller.create()
 
@@ -382,7 +388,8 @@ class LocationServiceTest {
             service.fusedClientOverride = mockFused
 
             // Initialize sharing
-            fakeLocationSource.setSharingLocation(true)
+            val app = context as TestWhereApplication
+            app.userStore.setSharing(true)
 
             controller.create()
             try {


### PR DESCRIPTION
I have replaced the `SCHEDULE_EXACT_ALARM` permission with `USE_EXACT_ALARM` in the Android manifest and updated the `LocationService` to utilize it on supported API levels (33+). This ensures that the app can schedule exact alarms for background polling without requiring users to manually grant permissions in system settings, which was previously causing silent fallbacks to inexact alarms. On Android 12 (API 31-32), the app now gracefully falls back to inexact alarms to avoid the UX friction of the manual permission request. Additionally, I refactored several unit tests that were failing due to incorrect state management, ensuring they now correctly use the global `UserStore` for location sharing preferences.

---
*PR created automatically by Jules for task [4845014424262999156](https://jules.google.com/task/4845014424262999156) started by @danmarg*