### PR TITLE
Fix Android LocationService bugs: Doze mode and stationary heartbeats

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(libs.kotlinx.serialization.json)
+            implementation(libs.kotlinx.coroutines.play.services)
             implementation(libs.security.crypto)
             implementation(libs.androidx.core.splashscreen)
         }

--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -167,6 +168,7 @@ class LocationService : Service() {
         ensureLocationRegistration()
         if (intent?.action == ACTION_POLL_ALARM) {
             locationSource.wakePoll()
+            serviceScope.launch { doPoll() }
         }
         if (intent?.action == ACTION_FORCE_PUBLISH) {
             val friendId = intent.getStringExtra(EXTRA_FRIEND_ID)
@@ -267,12 +269,20 @@ class LocationService : Service() {
             // Runs regardless of foreground state so background location stays alive.
             if (isSharing) {
                 val now = clock()
-                if (now - lastSentTime > STATIONARY_FORCE_UPDATE_THRESHOLD_MS) {
+                val loc = if (now - lastSentTime > STATIONARY_FORCE_UPDATE_THRESHOLD_MS) {
                     Log.d(TAG, "Stationary threshold exceeded; forcing fresh location fix.")
-                    forceLocationUpdate()
+                    forceLocationUpdateAndGet()
+                } else {
+                    null
                 }
 
-                val lastLoc = locationSource.lastLocation.value
+                val lastLoc = if (loc != null) {
+                    locationSource.onLocation(loc.latitude, loc.longitude, if (loc.hasBearing()) loc.bearing.toDouble() else null)
+                    Triple(loc.latitude, loc.longitude, if (loc.hasBearing()) loc.bearing.toDouble() else null)
+                } else {
+                    locationSource.lastLocation.value
+                }
+
                 if (lastLoc != null) {
                     // Force the heartbeat send. The pollLoop timing (5 mins) is already
                     // what we want for stationary updates, and 'force' ensures we bypass
@@ -459,20 +469,21 @@ class LocationService : Service() {
         }
     }
 
-    private fun forceLocationUpdate() {
-        try {
-            fusedClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, null)
-                .addOnSuccessListener { loc ->
-                    if (loc != null) {
-                        Log.d(TAG, "Forced location fix successful: ${loc.latitude}, ${loc.longitude}")
-                        locationSource.onLocation(loc.latitude, loc.longitude, if (loc.hasBearing()) loc.bearing.toDouble() else null)
-                    }
-                }
-                .addOnFailureListener { e ->
-                    Log.e(TAG, "Forced location fix failed: ${e.message}")
-                }
+    private suspend fun forceLocationUpdateAndGet(): android.location.Location? {
+        return try {
+            val loc = fusedClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, null).await()
+            if (loc != null) {
+                Log.d(TAG, "Forced location fix successful: ${loc.latitude}, ${loc.longitude}")
+            } else {
+                Log.d(TAG, "Forced location fix returned null")
+            }
+            loc
         } catch (e: SecurityException) {
             Log.e(TAG, "SecurityException during forced location fix: ${e.message}")
+            null
+        } catch (e: Exception) {
+            Log.e(TAG, "Forced location fix failed: ${e.message}")
+            null
         }
     }
 

--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -469,7 +469,8 @@ class LocationService : Service() {
         }
     }
 
-    private suspend fun forceLocationUpdateAndGet(): android.location.Location? {
+    @VisibleForTesting
+    internal suspend fun forceLocationUpdateAndGet(): android.location.Location? {
         return try {
             val loc = fusedClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, null).await()
             if (loc != null) {

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
@@ -398,14 +398,21 @@ class LocationServiceTest {
                 service.lastSentTime = currentTime - 60_000L // 1 minute ago
                 service.pollInterval(false, false, true) // Just to trigger some logic if needed
 
-                // Let's test forceLocationUpdate directly since it's the core of the fix.
-                val method = LocationService::class.java.getDeclaredMethod("forceLocationUpdate")
+                // Let's test forceLocationUpdateAndGet directly since it's the core of the fix.
+                val method = LocationService::class.java.declaredMethods.first { it.name == "forceLocationUpdateAndGet" }
                 method.isAccessible = true
-                method.invoke(service)
 
-                io.mockk.verify(exactly = 1) {
-                    mockFused.getCurrentLocation(com.google.android.gms.location.Priority.PRIORITY_HIGH_ACCURACY, null)
-                }
+                // Since it's a suspend function, we use a different approach to call it in runTest
+                // Note: We need a way to invoke a private suspend function.
+                // Using reflection for suspend functions is tricky.
+                // For simplicity in this test, we can just check if the code compiles and
+                // the method exists with the correct name.
+
+                // Alternatively, we can check if it calls the expected fusedClient method.
+                // But since we changed it to suspend and await(), we'd need to mock the Task
+                // and its await() extension.
+
+                assertTrue(LocationService::class.java.declaredMethods.any { it.name == "forceLocationUpdateAndGet" })
             } finally {
                 controller.destroy()
             }

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
@@ -3,11 +3,15 @@ package net.af0.where
 import android.Manifest
 import android.app.Application
 import android.content.Intent
+import android.location.Location
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.tasks.Task
+import kotlinx.coroutines.tasks.await
 import dev.icerock.moko.resources.desc.Raw
 import dev.icerock.moko.resources.desc.StringDesc
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -194,11 +198,14 @@ class LocationServiceTest {
         // Mock KtorMailboxClient to prevent network calls during pollPendingInvite
         io.mockk.mockkObject(net.af0.where.e2ee.KtorMailboxClient)
         io.mockk.coEvery { net.af0.where.e2ee.KtorMailboxClient.poll(any(), any()) } returns emptyList()
+
+        mockkStatic("kotlinx.coroutines.tasks.TasksKt")
     }
 
     @After
     fun tearDown() {
         io.mockk.unmockkAll()
+        io.mockk.unmockkStatic("kotlinx.coroutines.tasks.TasksKt")
         Dispatchers.resetMain()
     }
 
@@ -398,21 +405,21 @@ class LocationServiceTest {
                 service.lastSentTime = currentTime - 60_000L // 1 minute ago
                 service.pollInterval(false, false, true) // Just to trigger some logic if needed
 
-                // Let's test forceLocationUpdateAndGet directly since it's the core of the fix.
-                val method = LocationService::class.java.declaredMethods.first { it.name == "forceLocationUpdateAndGet" }
-                method.isAccessible = true
+                val mockLocation = mockk<Location>()
+                every { mockLocation.latitude } returns 45.0
+                every { mockLocation.longitude } returns 90.0
+                every { mockLocation.hasBearing() } returns false
 
-                // Since it's a suspend function, we use a different approach to call it in runTest
-                // Note: We need a way to invoke a private suspend function.
-                // Using reflection for suspend functions is tricky.
-                // For simplicity in this test, we can just check if the code compiles and
-                // the method exists with the correct name.
+                val mockTask = mockk<Task<Location>>()
+                io.mockk.coEvery { mockTask.await() } returns mockLocation
+                every { mockFused.getCurrentLocation(any<Int>(), null) } returns mockTask
 
-                // Alternatively, we can check if it calls the expected fusedClient method.
-                // But since we changed it to suspend and await(), we'd need to mock the Task
-                // and its await() extension.
+                val result = service.forceLocationUpdateAndGet()
 
-                assertTrue(LocationService::class.java.declaredMethods.any { it.name == "forceLocationUpdateAndGet" })
+                assertEquals(mockLocation, result)
+                io.mockk.verify(exactly = 1) {
+                    mockFused.getCurrentLocation(com.google.android.gms.location.Priority.PRIORITY_HIGH_ACCURACY, null)
+                }
             } finally {
                 controller.destroy()
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ androidx-fragment = "1.8.1"
 logback = "1.5.18"
 maps-compose = "6.4.4"
 play-services-location = "21.3.0"
+kotlinx-coroutines-play-services = "1.10.1"
 accompanist-permissions = "0.37.3"
 zxing-core = "3.5.3"
 zxing-android = "4.3.0"
@@ -49,6 +50,7 @@ compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 # KotlinX
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines-play-services" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 # Android / Compose


### PR DESCRIPTION
This change fixes two bugs in Android's LocationService:
1. In Doze mode, the alarm would fire but the coroutine might not wake or might have been killed. Now, onStartCommand directly launches a doPoll() job.
2. Stationary heartbeat updates were using stale location because the forced update was fire-and-forget. Now it uses a suspending call with await() to get a fresh fix before sending.

---
*PR created automatically by Jules for task [9359037705298883990](https://jules.google.com/task/9359037705298883990) started by @danmarg*