### PR TITLE
Remove USE_EXACT_ALARM permission and switch to inexact alarms

### DIFF
--- a/android/src/androidMain/AndroidManifest.xml
+++ b/android/src/androidMain/AndroidManifest.xml
@@ -11,7 +11,6 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
     <application
         android:name=".WhereApplication"

--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -316,13 +316,9 @@ class LocationService : Service() {
         val intent = Intent(this, LocationService::class.java).apply { action = ACTION_POLL_ALARM }
         val pi = PendingIntent.getService(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
         val triggerAt = SystemClock.elapsedRealtime() + delayMs
-        // USE_EXACT_ALARM grants unconditionally on API 33+; on older APIs fall back gracefully
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, pi)
-        } else {
-            // API 31-32: SCHEDULE_EXACT_ALARM was required; on 31/32 use inexact fallback
-            alarmManager.setAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, pi)
-        }
+        // We use inexact alarms to comply with Play Store policies regarding USE_EXACT_ALARM.
+        // setAndAllowWhileIdle ensures the alarm fires even in Doze mode, albeit with some jitter.
+        alarmManager.setAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, pi)
     }
 
     private fun cancelDozeAlarm() {


### PR DESCRIPTION
The USE_EXACT_ALARM permission is restricted to alarm and calendar apps on the Google Play Store. Since this app is for location sharing, using it could lead to rejection. This change removes the permission and switches to the inexact `setAndAllowWhileIdle` method for background polling, which is the recommended alternative for maintaining functionality in Doze mode without requiring the restricted permission.

---
*PR created automatically by Jules for task [5542718105924533147](https://jules.google.com/task/5542718105924533147) started by @danmarg*