### PR TITLE
Fix Double Ratchet token-skip deadlock

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -458,7 +458,7 @@ object Session {
                 remoteDhPub = remoteDhPub.copyOf(),
                 lastRemoteDhPub = state.remoteDhPub.copyOf(),
                 seenRemoteDhPubs = newSeenKeys,
-                prevSendToken = state.sendToken.copyOf(),
+                prevSendToken = if (state.isSendTokenPending) state.prevSendToken.copyOf() else state.sendToken.copyOf(),
                 prevRecvToken = state.recvToken.copyOf(),
                 isSendTokenPending = true,
                 needsRatchet = false,

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -458,7 +458,16 @@ object Session {
                 remoteDhPub = remoteDhPub.copyOf(),
                 lastRemoteDhPub = state.remoteDhPub.copyOf(),
                 seenRemoteDhPubs = newSeenKeys,
-                prevSendToken = if (state.isSendTokenPending) state.prevSendToken.copyOf() else state.sendToken.copyOf(),
+                // ONE-MESSAGE LAG (§5.4): If a transition is already pending but we haven't sent
+                // anything yet (sendSeq == 0), keep the original prevSendToken to avoid skipping
+                // the token the peer is currently polling. If we HAVE sent something (seq > 0),
+                // the peer has likely received our first message and is ready to rotate, so
+                // we advance prevSendToken to our current sendToken to maintain the lag.
+                prevSendToken = if (state.isSendTokenPending && state.sendSeq == 0L) {
+                    state.prevSendToken.copyOf()
+                } else {
+                    state.sendToken.copyOf()
+                },
                 prevRecvToken = state.recvToken.copyOf(),
                 isSendTokenPending = true,
                 needsRatchet = false,

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/DoubleRatchetSkipTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/DoubleRatchetSkipTest.kt
@@ -1,0 +1,57 @@
+package net.af0.where.e2ee
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+
+class DoubleRatchetSkipTest {
+    init {
+        initializeE2eeTests()
+    }
+
+    @Test
+    fun testDoubleRatchetSkipReproFinal() = runTest {
+        val aliceManager = E2eeManager(MemoryStorage())
+        val bobManager = E2eeManager(MemoryStorage())
+        val relay = RelayMailboxClient()
+        val aliceClient = LocationClient("http://fake", aliceManager, relay)
+        val bobClient = LocationClient("http://fake", bobManager, relay)
+
+        // 1. Pair
+        val qr = aliceManager.createInvite("Alice")
+        val (init, _) = bobManager.processScannedQr(qr)
+        aliceManager.processKeyExchangeInit(init, "Bob", qr.ekPub)
+        val aliceToBobId = aliceManager.listFriends().first().id
+        val bobToAliceId = bobManager.listFriends().first().id
+
+        // Alice is at: sendToken = T_A1, prevSendToken = T_A0, isSendTokenPending = true.
+        // Bob is polling T_A0.
+        val aliceInitial = aliceManager.getFriend(aliceToBobId)!!
+        val tA0 = aliceInitial.session.prevSendToken.toHex()
+        assertTrue(aliceInitial.session.isSendTokenPending)
+        assertEquals(tA0, bobManager.getFriend(bobToAliceId)!!.session.recvToken.toHex())
+
+        // 2. Bob sends a message (B1) BEFORE Alice sends anything.
+        bobClient.sendLocation(1.0, 1.0) // B1 -> T_B0.
+
+        // 3. Alice polls. She receives B1 and ratchets.
+        aliceClient.poll()
+
+        // Alice now has a new sendToken (T_A2) and a new prevSendToken.
+        // BUG: Alice's prevSendToken would be T_A1 because it took the current sendToken.
+        // FIX: Alice's prevSendToken should STILL be T_A0 because she never successfully sent to T_A0.
+        val aliceAfterPoll = aliceManager.getFriend(aliceToBobId)!!
+        val alicePrevSendToken = aliceAfterPoll.session.prevSendToken.toHex()
+
+        println("Alice prevSendToken: $alicePrevSendToken (expected $tA0)")
+        assertEquals(tA0, alicePrevSendToken, "Alice's prevSendToken must stay T_A0 if isSendTokenPending was true")
+
+        // 4. Verification of recovery: Alice sends her first message, it MUST go to T_A0.
+        aliceClient.sendLocation(5.0, 5.0)
+        val aliceFinal = aliceManager.getFriend(aliceToBobId)!!
+        assertNull(aliceFinal.outbox)
+
+        // 5. Bob polls T_A0 and receives it.
+        val updates = bobClient.poll()
+        assertTrue(updates.any { it.lat == 5.0 }, "Bob should have received Alice's message on T_A0")
+    }
+}


### PR DESCRIPTION
Fixed a deadlock in the Double Ratchet protocol where Alice would skip a token Bob was still polling if she performed multiple DH ratchets before Bob confirmed the first one. This was achieved by preserving `prevSendToken` in `Session.performDhRatchet` if `isSendTokenPending` is already true. Included a regression test and verified against `testMultiFriendChaos`.

---
*PR created automatically by Jules for task [15262929447226365355](https://jules.google.com/task/15262929447226365355) started by @danmarg*