### PR TITLE
feat(e2ee): implement reliable epoch transitions via explicit ACKs

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -60,8 +60,8 @@ android {
         applicationId = "net.af0.where"
         minSdk = 26
         targetSdk = 35
-        versionCode = 51
-        versionName = "2026.05.06.1"
+        versionCode = 52
+        versionName = "2026.05.09.1"
         manifestPlaceholders["MAPS_API_KEY"] = localProperties.getProperty("MAPS_API_KEY") ?: System.getenv("MAPS_API_KEY") ?: ""
     }
 
@@ -94,6 +94,8 @@ android {
                 storePassword = ksPassword
                 keyAlias = "where"
                 keyPassword = kPassword
+            } else {
+                throw GradleException("Release signing configuration is incomplete. Please ensure KEYSTORE_FILE, KEYSTORE_PASSWORD, and KEY_PASSWORD are set via environment variables or system properties.")
             }
         }
     }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -60,8 +60,8 @@ android {
         applicationId = "net.af0.where"
         minSdk = 26
         targetSdk = 35
-        versionCode = 54
-        versionName = "2026.05.09.3"
+        versionCode = 55
+        versionName = "2026.05.10.1"
         manifestPlaceholders["MAPS_API_KEY"] = localProperties.getProperty("MAPS_API_KEY") ?: System.getenv("MAPS_API_KEY") ?: ""
     }
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -60,8 +60,8 @@ android {
         applicationId = "net.af0.where"
         minSdk = 26
         targetSdk = 35
-        versionCode = 52
-        versionName = "2026.05.09.1"
+        versionCode = 54
+        versionName = "2026.05.09.3"
         manifestPlaceholders["MAPS_API_KEY"] = localProperties.getProperty("MAPS_API_KEY") ?: System.getenv("MAPS_API_KEY") ?: ""
     }
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -85,17 +85,15 @@ android {
 
     signingConfigs {
         create("release") {
-            val ksFile = System.getenv("KEYSTORE_FILE") ?: System.getProperty("KEYSTORE_FILE") ?: ""
-            val ksPassword = System.getenv("KEYSTORE_PASSWORD") ?: System.getProperty("KEYSTORE_PASSWORD") ?: ""
-            val kPassword = System.getenv("KEY_PASSWORD") ?: System.getProperty("KEY_PASSWORD") ?: ""
+            val ksFile = System.getenv("KEYSTORE_FILE") ?: System.getProperty("KEYSTORE_FILE")
+            val ksPassword = System.getenv("KEYSTORE_PASSWORD") ?: System.getProperty("KEYSTORE_PASSWORD")
+            val kPassword = System.getenv("KEY_PASSWORD") ?: System.getProperty("KEY_PASSWORD")
 
-            if (ksFile.isNotEmpty() && ksPassword.isNotEmpty() && kPassword.isNotEmpty()) {
+            if (ksFile != null && ksPassword != null && kPassword != null) {
                 storeFile = file(ksFile)
                 storePassword = ksPassword
                 keyAlias = "where"
                 keyPassword = kPassword
-            } else {
-                throw GradleException("Release signing configuration is incomplete. Please ensure KEYSTORE_FILE, KEYSTORE_PASSWORD, and KEY_PASSWORD are set via environment variables or system properties.")
             }
         }
     }

--- a/docs/e2ee-location-sync.md
+++ b/docs/e2ee-location-sync.md
@@ -355,12 +355,20 @@ Messages may be accepted from both. When a message is decrypted:
 
 #### 5.4.3 Ack and Retirement Rules
 **Ack Rule:**
-Each message carries an `ack_remote_dh_pub` field, which is an authenticated claim inside the encrypted header: "I have successfully decrypted and processed at least one message from the peer up to this DH public key."
+Each message carries an `ack_remote_dh_pub` field, an authenticated claim inside the encrypted header defined as: **the newest peer DH public key for which at least one message has been successfully authenticated and committed to session state.** "Committed" means the AEAD tag verified and the resulting session state was durably saved to local storage; speculative ratchet steps, temporary observations, or replayed historical epochs MUST NOT advance this value.
 
 This field is the **only authoritative signal** for retiring mailbox paths. It MUST NOT be treated as informational telemetry.
 
+**`ack_remote_dh_pub` Validation:**
+Before using `ack_remote_dh_pub` for retirement decisions, the receiver MUST validate it against known state. If the value is not one of:
+- the bootstrap peer key (initial `remote_dh_pub` from session setup), or
+- the current peer `dh_pub` (most recently committed remote epoch), or
+- a peer `dh_pub` retained in `previous_pending` state,
+
+then the receiver MUST ignore `ack_remote_dh_pub` for retirement purposes and continue processing the message normally if the rest of the AEAD authentication succeeds. This prevents a malformed or replayed ack value from triggering premature epoch retirement.
+
 **Retirement Rule:**
-- **Primary Rule:** Retire `previous_pending` only after receiving an authenticated `ack_remote_dh_pub` that proves the peer has moved forward. The value MUST be compared against the peer’s previous active `dh_pub` (e.g., `ack_remote_dh_pub == local_dh_pub_prev`), not against a local epoch counter.
+- **Primary Rule:** Retire `previous_pending` only after receiving an authenticated `ack_remote_dh_pub` that passes the validation above and proves the peer has moved forward. The value MUST be compared against the peer’s previous active `dh_pub` (e.g., `ack_remote_dh_pub == local_dh_pub_prev`), not against a local epoch counter.
 - **Secondary Bounded Fallback:** If no authenticated message has arrived on the old mailbox for 7 days, and the server TTL guarantees the mailbox entry is dead, the old mailbox MAY be retired. This fallback is safe only because the server TTL bounds liveness ambiguity; timeout alone must never be the primary retirement mechanism.
 
 #### 5.4.4 Duplicate Handling and Batch Ordering
@@ -667,7 +675,7 @@ The `envelope` is a 110-byte binary blob consisting of:
 **Header Plaintext (82 bytes):**
 - `PROTOCOL_VERSION` (1 byte, `0x01`)
 - `dh_pub` (32 bytes): sender’s current DH public key.
-- `ack_remote_dh_pub` (32 bytes): the highest peer DH public key the sender has successfully processed.
+- `ack_remote_dh_pub` (32 bytes): the newest peer DH public key for which at least one message has been successfully authenticated and committed to session state (see §5.4.3).
 - `msg_num` (8 bytes, big-endian Long): sender chain message number.
 - `prev_chain_len` (8 bytes, big-endian Long): length of the previous sending chain.
 - `flags` (1 byte): optional flags, such as `TRANSITION` (0x01).

--- a/docs/e2ee-location-sync.md
+++ b/docs/e2ee-location-sync.md
@@ -88,7 +88,7 @@ For threat models that include a metadata-analyzing server, the mitigations in �
 
 - **Server compromise revealing historical locations.** *Forward secrecy (per-message):* deleting each message key `MK_n` immediately after use ensures that compromise of one key does not expose others. *Post-compromise security (per DH ratchet step):* the DH ratchet step refreshing the root key and symmetric chains limits how long a leaked chain key remains exploitable.
 - **Passive eavesdropping.** All location payloads are encrypted with ephemeral symmetric keys derived from a per-friend ratchet. A passive observer with access to ciphertext learns nothing about coordinates.
-- **Replay attacks.** Each message carries a monotonically increasing sequence counter which is also authenticated (as AEAD additional data for the body, and encrypted within the header envelope). The recipient rejects any frame with a counter it has already seen within the same DH epoch. Across-epoch replay protection utilizes a sliding window of the most recent 10 DH public keys; replays from older epochs will trigger a speculative ratchet but always fail final AEAD authentication.
+- **Replay attacks.** Each message carries a monotonically increasing message number `msg_num` which is also authenticated (as AEAD additional data for the body, and encrypted within the header envelope). The recipient rejects any frame with a counter it has already seen within the same DH epoch. Across-epoch replay protection utilizes a sliding window of the most recent 10 DH public keys; replays from older epochs will trigger a speculative ratchet but always fail final AEAD authentication.
 - **Ciphertext forgery.** ChaCha20-Poly1305 authentication tags cover both the ciphertext and associated data. In version 1, metadata (DH public key and sequence number) is sealed within an encrypted envelope, preventing a malicious server from reading or correlating them across token rotations.
 - **Ratchet hijacking.** All messages are AEAD-encrypted under keys derived from the current session root key and symmetric chains. An attacker without session state or header keys cannot forge or inject valid messages.
 - **Key mismatch at bootstrap.** The `key_confirmation` field in `KeyExchangeInit` (§4.2) detects corruption or bit-flips in `EK_B.pub` in transit. It does NOT authenticate the origin of the QR code or defeat an active MITM who can intercept and substitute the initial ephemeral key material. Trust establishment relies on TOFU + Safety Number verification (§3.4).
@@ -316,29 +316,60 @@ To handle out-of-order delivery across DH ratchet steps, the receiver maintains 
 **Out-of-Order DH Epoch Transitions:**
 If Alice ratchets her DH key from `dh_1` to `dh_2`, Bob may receive `Msg(dh_2, seq=1)` before he receives `Msg(dh_1, seq=last)`.
 1.  **Speculative Ratchet:** Bob moves to the new DH epoch upon receiving `Msg(dh_2)`.
-2.  **Decryption:** Bob decrypts the payload of `Msg(dh_2)` to extract the **encrypted `pn` field** (§7.4).
-3.  **Gap Filling:** The `pn` field tells Bob exactly how many messages Alice sent in epoch `dh_1`. Bob goes back to the old chain, derives all remaining keys up to `pn`, and stores them in the cache.
-4.  **Historical Delivery:** When `Msg(dh_1, seq=last)` eventually arrives, Bob retrieves the key from the cache, verifies the AAD (using the `pn` stored in the cache entry), and decrypts.
+2.  **Decryption:** Bob decrypts the payload of `Msg(dh_2)` to extract the **encrypted `prev_chain_len` field** (§7.4).
+3.  **Gap Filling:** The `prev_chain_len` field tells Bob exactly how many messages Alice sent in epoch `dh_1`. Bob goes back to the old chain, derives all remaining keys up to `prev_chain_len`, and stores them in the cache.
+4.  **Historical Delivery:** When `Msg(dh_1, msg_num=last)` eventually arrives, Bob retrieves the key from the cache, verifies the AAD (using the `prev_chain_len` stored in the cache entry), and decrypts.
 
 This ensures that gaps are filled deterministically even when the metadata needed for gap calculation is hidden behind the AEAD boundary.
 
-### 5.4 Routing Token Rotation and Reliability
+### 5.4 Routing Token Rotation and Reliability (Epoch Transitions)
 
 Routing tokens are derived from the current root key. Whenever the DH ratchet advances and a new root key is derived, new routing tokens are computed.
 
+A peer’s mailbox state is identified by its DH public key `dh_pub`, which serves as the canonical epoch identifier. Epoch numbers may exist as an internal convenience, but they are derived from DH ratchet progression and must never be treated as an independent source of truth.
+
 **The Mailbox Synchronization Challenge:**
-In an anonymous mailbox model, a client polling token `T_old` will never see a message posted to `T_new`. If Alice switches her send token to `T_new` immediately upon deriving a new root key, Bob (who is still polling `T_old`) will never retrieve the message containing the new DH public key Alice used to derive `T_new`.
+In an anonymous mailbox model, a client polling token `T_old` will never see a message posted to `T_new`. To prevent race conditions during epoch transitions, the protocol employs a two-epoch sliding window and authenticated acknowledgments.
 
-**Solution: One-Message Lag for Send Tokens:**
-1.  When a DH ratchet step occurs, Alice derives the new root key and the corresponding `send_token_new`.
-2.  Alice marks the new token as **pending** (`isSendTokenPending = true`).
-3.  Alice prepares her next message using the new DH epoch keys, but **posts it to the old token** (`send_token_prev`).
-    *   **Fresh Keepalive Transition:** To ensure the receiver has a valid, non-replay message waiting for them as soon as they switch tokens, Alice immediately follows the transition message with a **fresh Keepalive** encrypted under the new epoch keys and posted to `send_token_new`. This keepalive is gated on `sharingEnabled` to preserve the periodic PCS property even when active location sharing is toggled off (§5.3).
-4.  Once both messages are successfully handled, Alice switches to `send_token_new` exclusively.
-5.  Bob retrieves the message from the old token, processes the new DH key (extracting the hidden `pn` for gap filling), and immediately switches his receive token to `recv_token_new`.
+#### 5.4.1 Send Rule
+A sender MUST send to the peer mailbox token associated with the last **proven** peer DH state.
 
-**Receiver Policy:**
-A receiver switches their **receive token** immediately upon receiving a message with a new `dh_pub`. Messages are retrieved in arrival order from the server. If an old-epoch message arrives at the server *after* a new-epoch message has been retrieved and processed, the receiver has already switched tokens and the old message will be missed. This is an acceptable tradeoff for protocol simplicity.
+Formally:
+`active_send_target = token_for(highest_peer_dh_pub_seen)`
+
+- On session bootstrap, `highest_peer_dh_pub_seen` is the initial value derived from `SK`. The initial outbound target is `T_AB_0`.
+- A sender MUST NOT switch to the next token solely because it locally ratcheted.
+- A sender may switch only after the peer’s newer DH state is observed in a decrypted message and acknowledged by the protocol state machine.
+
+#### 5.4.2 Receive Rule (Two-Epoch Sliding Window)
+Each direction keeps at most two active epochs:
+- **current**: The latest verified peer epoch.
+- **previous_pending**: The prior epoch, kept only for safety during transition.
+
+Messages may be accepted from both. When a message is decrypted:
+1. If the sender `dh_pub` is newer than the local view, ratchet forward.
+2. Record that `dh_pub` as `highest_peer_dh_pub_seen`.
+3. Do not retire the previous receive path immediately. Continue accepting messages on the previous token until the retirement condition is satisfied.
+
+#### 5.4.3 Ack and Retirement Rules
+**Ack Rule:**
+Each message carries an `ack_remote_dh_pub` field, which is an authenticated claim inside the encrypted header: "I have successfully decrypted and processed at least one message from the peer up to this DH public key."
+
+**Retirement Rule:**
+- **Primary Rule:** Retire `previous_pending` only after receiving an authenticated `ack_remote_dh_pub` that proves the peer has moved forward (i.e., `ack_remote_dh_pub >= my_previous_dh_pub`).
+- **Secondary Bounded Fallback:** If no authenticated message has arrived on the old mailbox for 7 days, and the server TTL guarantees the mailbox entry is dead, the old mailbox MAY be retired. Timeout alone must never be the primary retirement mechanism.
+
+#### 5.4.4 Duplicate Handling and Batch Ordering
+**Duplicate Handling:**
+Duplicates MUST be ACKable. If a peer receives multiple copies of the same transition message, the first advances state. Subsequent duplicates must not poison the batch and should still allow the receiver to generate the authenticated ACK needed to drain the old queue.
+
+**Batch Ordering:**
+When processing a batch of messages from the server, sort them as follows:
+1. Older epoch class before newer epoch class.
+2. Within the same epoch class, lower `prev_chain_len` first.
+3. Within the same chain, lower `msg_num` first.
+
+This ensures historical messages are processed before any later ratchet step in the same batch.
 
 #### 5.4.1 Receive-Side Crash Safety
 
@@ -369,7 +400,7 @@ To maximize forward secrecy, implementations should adhere to the following hygi
     - To mitigate backup-recovery risks, this state MUST be stored using device-local, backup-excluded security controls (e.g., `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` on iOS, `KeyStore`-backed encryption with `allowBackup=false` on Android).
     - **Android 9+:** Use `setIsStrongBoxBacked(true)` if available. If hardware is unavailable, fall back to TEE-backed Keystore with `setUserAuthenticationRequired(true)` and ensure the manifest has `allowBackup=false`.
     - **JVM Memory Hygiene:** On the JVM, `Arrays.fill()` is inherently limited by garbage collector behavior, which may relocate byte arrays and leave stale copies in memory. For improved hygiene, consider using off-heap storage (`DirectByteBuffer`), Conscrypt's `SecretKey` wrappers, or native bindings to libsodium (which handles zeroization natively).
-    - **Sequence Safety:** If the sequence number `sendSeq` reaches its 64-bit maximum (`Long.MAX_VALUE`), the session is considered "bricked" (`SessionBrickedException`) and no further messages can be sent. This prevents nonce reuse. A full out-of-band session reset is required.
+    - **Sequence Safety:** If the message number `send_msg_num` reaches its 64-bit maximum (`Long.MAX_VALUE`), the session is considered "bricked" (`SessionBrickedException`) and no further messages can be sent. This prevents nonce reuse. A full out-of-band session reset is required.
     - If a device backup is nonetheless recovered by an attacker, the forward secrecy guarantee is reduced to the current DH epoch. Per-message forward secrecy is maintained against a server-side observer who does not have access to the device's persistent store.
 
 **Keychain backup and state-rollback risk:** Platform keychains may be backed up (iCloud Keychain on iOS, Google Play Backup on Android). If a backup is restored to a different device or is compromised, the attacker gains access to the stored root key and can re-derive future message keys from the backed-up epoch forward — until the next DH ratchet step heals the session.
@@ -422,7 +453,7 @@ When Alice sends a location update:
 1. She computes the plaintext: `loc = {lat, lng, accuracy, timestamp}`.
 2. For each friend `F_i` in her friend list:
    - Derive `MK_i` from Alice→F_i ratchet chain.
-   - Encrypt: `CT_i = ChaCha20-Poly1305(key=MK_i, plaintext=loc, aad=buildAad(alice_fp_i, bob_fp_i, seq_i, dh_pub_i))` where `alice_fp_i` and `bob_fp_i` are the session fingerprints for friendship i (see §8.3).
+   - Encrypt: `CT_i = ChaCha20-Poly1305(key=MK_i, plaintext=loc, aad=buildAad(alice_fp_i, bob_fp_i, msg_num_i, dh_pub_i, ack_remote_dh_pub_i))` where `alice_fp_i` and `bob_fp_i` are the session fingerprints for friendship i (see §8.3).
    - Post to `T_send_i`.
 3. The server routes each `(token_i, CT_i)` frame to the corresponding mailbox.
 
@@ -483,16 +514,16 @@ The server can still observe the timing and frequency of `POST` and `GET` reques
 
 ### 7.4 Mitigations
 
-#### 7.4.1 Metadata Obfuscation: Hidden Chain Length (pn)
+#### 7.4.1 Metadata Obfuscation: Hidden Chain Metadata
 
-Standard Double Ratchet protocols leak the length of the previous symmetric chain (`pn`) in the unencrypted header. This allows a server to observe activity patterns (e.g., "Alice sent 142 messages in her last 30-minute epoch").
+Standard Double Ratchet protocols leak the message sequence number (`msg_num`) and length of the previous symmetric chain (`prev_chain_len`) in the unencrypted header. This allows a server to observe activity patterns (e.g., "Alice sent 142 messages in her last 30-minute epoch").
 
-To mitigate this, Where moves `pn` into the **encrypted payload**:
-1. **Encrypted Envelope:** The `MessagePlaintext` JSON object includes a top-level `pn` field.
-2. **Post-Decryption Extraction:** The receiver first ratchets DH, derives the message key, decrypts the payload, and *then* reads `pn` to perform historical gap-filling of the old chain (§5.3).
-3. **Cache Storage:** When storing skipped keys for out-of-order delivery, the receiver stores the active `pn` alongside the message key: `(MK_n, Nonce_n, PN_n)`. This ensures that if the message arrives later, the AAD can be re-verified against the correct historical `pn`.
+To mitigate this, Where moves all session metadata into the **encrypted envelope header** (§9.1.1):
+1. **Encrypted Header:** The envelope header includes `dh_pub`, `ack_remote_dh_pub`, `msg_num`, and `prev_chain_len`.
+2. **Post-Decryption Extraction:** The receiver first decrypts the envelope header using the current or next `header_key` and *then* reads the metadata to perform historical gap-filling of the old chain (§5.3).
+3. **Cache Storage:** When storing skipped keys for out-of-order delivery, the receiver stores the active `prev_chain_len` alongside the message key: `(MK_n, Nonce_n, PN_n)`. This ensures that if the message arrives later, the AAD can be re-verified against the correct historical value.
 
-This removes the last piece of unauthenticated chain metadata from the wire format, leaving only `dh_pub` and `seq` visible to the server.
+This removes all session-related metadata from the server's view. The server only sees opaque mailbox tokens and encrypted blobs.
 
 #### 7.4.2 Payload padding
 
@@ -540,12 +571,11 @@ SessionState {
   root_key:           [32]byte   // current root key
   send_chain_key:     [32]byte   // CK for outgoing messages
   recv_chain_key:     [32]byte   // CK for incoming messages
-  send_token:         [16]byte   // token this client posts to
-  recv_token:         [16]byte   // token this client polls from
-  prev_send_token:    [16]byte   // one-message lookback token
-  is_token_pending:   bool       // true if next message must use prev_send_token
-  send_seq:           uint64     // outgoing monotone counter
-  recv_seq:           uint64     // highest received seq
+  send_token:         [16]byte   // token for highest_peer_dh_pub_seen
+  recv_token:         [16]byte   // token for current local ratchet key
+  prev_recv_token:    [16]byte   // token for previous local ratchet key (pending retirement)
+  send_msg_num:       uint64     // sender chain message number
+  highest_peer_dh_pub_seen: [32]byte // highest peer DH pub key successfully processed
   local_dh_pub:       [32]byte   // current local ratchet public key
   remote_dh_pub:      [32]byte   // last received remote ratchet public key
   alice_ek_pub:       [32]byte   // bootstrap public key EK_A.pub (stable)
@@ -593,14 +623,14 @@ The `dh_pub` is included in the AAD to cryptographically bind the message to the
 
 ### 8.3.1 Ordering, Replay, and Chain Advancement
 
-Each message frame carries a `seq` counter. Recipients enforce:
+Each message frame carries a `msg_num` counter. Recipients enforce:
 
-1.  **Replay rejection:** Any frame with `seq <= max_seq_received` (within the same DH epoch) is dropped, EXCEPT if the key for that sequence number is present in the **skipped message key cache**.
+1.  **Replay rejection:** Any frame with `msg_num <= max_msg_num_received` (within the same DH epoch) is dropped, EXCEPT if the key for that message number is present in the **skipped message key cache**.
 2.  **Maximum gap (MAX_GAP):** recipients MUST enforce a maximum gap (default 2000) for chain advancement to prevent resource exhaustion attacks.
-3.  **OutOfOrder Support:** If a message is skipped (e.g., recipient receives seq=10 after seq=8), the recipient advances the symmetric ratchet to seq=10 and stores the intermediate message keys in a bounded cache (100 entries).
+3.  **OutOfOrder Support:** If a message is skipped (e.g., recipient receives `msg_num=10` after `msg_num=8`), the recipient advances the symmetric ratchet to `msg_num=10` and stores the intermediate message keys in a bounded cache (100 entries).
 4.  **Transactional Commitment:** The receiving state (receiving chain, root key, skipped keys) MUST only be updated if the message AEAD authentication succeeds.
-5.  **Epoch Transition:** When a message with a new `dh_pub` is received, the `seq` counter resets to 0. All skipped message keys belonging to epochs older than the *previous* valid epoch MUST be cleared.
-6.  **Across-Epoch Replay:** Recipients MUST keep track of recently seen `dh_pub` keys (epoch identifiers) and reject any message for an epoch that has already been superseded.
+5.  **Epoch Transition:** When a message with a new `dh_pub` is received, the `msg_num` counter resets to 0. All skipped message keys belonging to epochs older than the *previous* valid epoch MUST be cleared.
+6.  **Across-Epoch Replay:** Recipients MUST keep track of recently seen `dh_pub` keys (epoch identifiers) and reject any message for an epoch that has already been superseded and retired (§5.4.3).
 
 
 ---
@@ -611,7 +641,7 @@ All messages are JSON-encoded. Every message MUST include a top-level `"v"` fiel
 
 ### 9.1 Encrypted Location Frame
 
-The mailbox payload for a standard location update is a JSON object with `type: "EncryptedMessage"`. Metadata (`dh_pub`, `seq`) is hidden within an encrypted `envelope` to prevent server correlation.
+The mailbox payload for a standard location update is a JSON object with `type: "EncryptedMessage"`. Metadata (`dh_pub`, `msg_num`, `ack_remote_dh_pub`, etc.) is hidden within an encrypted `envelope` to prevent server correlation.
 
 ```json
 {
@@ -624,15 +654,17 @@ The mailbox payload for a standard location update is a JSON object with `type: 
 
 #### 9.1.1 Envelope Structure
 
-The `envelope` is a 77-byte binary blob consisting of:
+The `envelope` is a 110-byte binary blob consisting of:
 1. **Nonce (12 bytes)**: A random nonce used for header encryption.
-2. **Encrypted Header (65 bytes)**: ChaCha20-Poly1305 ciphertext of the metadata.
+2. **Encrypted Header (98 bytes)**: ChaCha20-Poly1305 ciphertext of the metadata.
 
-**Header Plaintext (49 bytes):**
+**Header Plaintext (82 bytes):**
 - `PROTOCOL_VERSION` (1 byte, `0x01`)
-- `dh_pub` (32 bytes)
-- `seq` (8 bytes, big-endian Long)
-- `pn` (8 bytes, big-endian Long)
+- `dh_pub` (32 bytes): sender’s current DH public key.
+- `ack_remote_dh_pub` (32 bytes): the highest peer DH public key the sender has successfully processed.
+- `msg_num` (8 bytes, big-endian Long): sender chain message number.
+- `prev_chain_len` (8 bytes, big-endian Long): length of the previous sending chain.
+- `flags` (1 byte): optional flags, such as `TRANSITION` (0x01).
 
 The header is encrypted using the current `header_key` derived from the DH ratchet.
 
@@ -645,12 +677,13 @@ The `ct` field contains the ChaCha20-Poly1305 ciphertext of the location payload
 - `PROTOCOL_VERSION` (4 bytes, `0x01`)
 - `sender_fp` (32 bytes)
 - `recipient_fp` (32 bytes)
-- `seq` (8 bytes, big-endian uint64)
+- `msg_num` (8 bytes, big-endian uint64)
 - `dh_pub` (32 bytes)
+- `ack_remote_dh_pub` (32 bytes)
 
-Implementations MUST parse the `seq` field as a uint64 integer and serialize it as 8 bytes in big-endian order for AAD computation. Never hash the decimal JSON string directly.
+Implementations MUST parse the `msg_num` field as a uint64 integer and serialize it as 8 bytes in big-endian order for AAD computation. Never hash the decimal JSON string directly.
 
-Note that even though `seq` and `dh_pub` are hidden from the server in the envelope, the client uses the *decrypted* values to verify the body AAD, ensuring the body and header are cryptographically bound together.
+Note that even though metadata is hidden from the server in the envelope, the client uses the *decrypted* values to verify the body AAD, ensuring the body and header are cryptographically bound together.
 
 **Plaintext (before encryption):**
 The plaintext is a JSON object. All plaintext payloads MUST be padded with 0x80 then 0x00 bytes to a fixed 512-byte length **before** encryption. The padding is included in the plaintext and authenticated by the AEAD tag.
@@ -780,7 +813,7 @@ While this protocol shares the core **Double Ratchet** design with Signal, it ma
 
 - **Signal:** Historically identified users by stable identifiers (phone numbers, now UUIDs). "Sealed Sender" was added later as an extension to hide the sender from the server.
 - **Where:** Metadata protection is integrated into the base protocol.
-    - **Header Encryption:** Every message uses an **Encrypted Envelope** that hides the DH public key, sequence number, and previous chain length (`pn`) from the server.
+    - **Header Encryption:** Every message uses an **Encrypted Envelope** that hides the DH public key, message number (`msg_num`), and previous chain length (`prev_chain_len`) from the server.
     - **Dynamic Routing:** Instead of stable user IDs, Where uses **Pairwise Routing Tokens** derived from the session root key. These tokens rotate automatically with the DH ratchet, making it impossible for the server to correlate messages across epochs without session state.
 
 ### 12.4 Group Messaging (Sender Keys vs Per-Friend)

--- a/docs/e2ee-location-sync.md
+++ b/docs/e2ee-location-sync.md
@@ -346,7 +346,7 @@ Each direction keeps at most two active epochs:
 - **current**: The latest verified peer epoch.
 - **previous_pending**: The prior epoch, kept only for safety during transition.
 
-**Initialization:** At session bootstrap, `prev_recv_token` is unset (zero bytes / null sentinel). The polling loop MUST skip `prev_recv_token` when it is unset, and MUST NOT poll a zero-byte token. `prev_recv_token` becomes set only after the first DH ratchet step advances `recv_token`.
+**Initialization:** At session bootstrap, `prev_recv_token` is unset. The client MUST NOT poll or derive any mailbox token from an unset `prev_recv_token`. `prev_recv_token` becomes valid only after the first inbound message advances the receive ratchet and establishes a previous epoch.
 
 Messages may be accepted from both. When a message is decrypted:
 1. If the sender `dh_pub` is newer than the local view, ratchet forward.
@@ -357,31 +357,20 @@ Messages may be accepted from both. When a message is decrypted:
 **Ack Rule:**
 Each message carries an `ack_remote_dh_pub` field, an authenticated claim inside the encrypted header defined as: **the newest peer DH public key for which at least one message has been successfully authenticated and committed to session state.** "Committed" means the AEAD tag verified and the resulting session state was durably saved to local storage; speculative ratchet steps, temporary observations, or replayed historical epochs MUST NOT advance this value.
 
-This field is the **only authoritative signal** for retiring mailbox paths. It MUST NOT be treated as informational telemetry.
+`ack_remote_dh_pub` is the **only authenticated signal** that a peer has successfully processed a message for the corresponding DH epoch. Implementations MUST use it as the sole basis for retiring `previous_pending`; it MUST NOT be treated as telemetry or as an advisory hint.
 
-**`ack_remote_dh_pub` Validation:**
-Before using `ack_remote_dh_pub` for retirement decisions, the receiver MUST validate it against known state. If the value is not one of:
-- the bootstrap peer key (initial `remote_dh_pub` from session setup), or
-- the current peer `dh_pub` (most recently committed remote epoch), or
-- a peer `dh_pub` retained in `previous_pending` state,
+Before using `ack_remote_dh_pub` for retirement decisions, the receiver MUST validate it against known state. If the value is not one of the bootstrap peer key, the current peer `dh_pub`, or a peer `dh_pub` retained in `previous_pending`, then the receiver MUST ignore it for retirement purposes and continue processing the message normally if the rest of the AEAD authentication succeeds.
 
-then the receiver MUST ignore `ack_remote_dh_pub` for retirement purposes and continue processing the message normally if the rest of the AEAD authentication succeeds. This prevents a malformed or replayed ack value from triggering premature epoch retirement.
+**Retirement Rule:** Retire `previous_pending` only after receiving an authenticated `ack_remote_dh_pub` equal to the peer’s previous active `dh_pub`. Implementations MUST compare against a retained peer `dh_pub` value, not against any locally assigned epoch number.
 
-**Retirement Rule:**
-- **Primary Rule:** Retire `previous_pending` only after receiving an authenticated `ack_remote_dh_pub` that passes the validation above and proves the peer has moved forward. The value MUST be compared against the peer’s previous active `dh_pub` (e.g., `ack_remote_dh_pub == local_dh_pub_prev`), not against a local epoch counter.
-- **Secondary Bounded Fallback:** If no authenticated message has arrived on the old mailbox for 7 days, and the server TTL guarantees the mailbox entry is dead, the old mailbox MAY be retired. This fallback is safe only because the server TTL bounds liveness ambiguity; timeout alone must never be the primary retirement mechanism.
+**Secondary Bounded Fallback:** The 7-day timeout is a liveness fallback only. It MAY be used to retire an old mailbox path when server TTL guarantees that the mailbox entry can no longer deliver messages. It MUST NOT be used as a substitute for authenticated acknowledgment during normal operation.
 
 #### 5.4.4 Duplicate Handling and Batch Ordering
 **Duplicate Handling:**
 Duplicates MUST be ACKable. If a peer receives multiple copies of the same transition message, the first advances state. Subsequent duplicates must not poison the batch and should still allow the receiver to generate the authenticated ACK needed to drain the old queue.
 
 **Batch Ordering:**
-When processing a batch of messages from the server, sort them as follows:
-1. Older epoch class before newer epoch class.
-2. Within the same epoch class, lower `prev_chain_len` first.
-3. Within the same chain, lower `msg_num` first.
-
-This ensures historical messages are processed before any later ratchet step in the same batch.
+When processing a batch of messages already retrieved from the server, clients SHOULD process older epoch classes before newer ones, then lower `prev_chain_len`, then lower `msg_num`.
 
 #### 5.4.5 Receive-Side Crash Safety
 
@@ -516,9 +505,9 @@ The server's role is strictly limited to acting as a stateless message router fo
 
 To prevent the server from learning whether a routing token corresponds to a real relationship, the following invariant is mandatory:
 
-**The server MUST return an identical response (HTTP 200 OK with `[]`) for all token queries where no messages are pending, regardless of whether the token has ever been "registered" or used.**
+**The server MUST return an identical response body for all token queries where no messages are pending, regardless of whether the token has ever been used.**
 
-There is no "create mailbox" or "register token" step. Mailboxes exist implicitly upon the first `POST`. A `GET` for a non-existent token is indistinguishable from a `GET` for an empty real mailbox.
+There is no "create mailbox" or "register token" step. Mailboxes exist implicitly upon the first `POST`. A `GET` for a non-existent token MUST be indistinguishable at the API level from a `GET` for an empty real mailbox.
 
 ### 7.3 Metadata Exposure and Traffic Analysis
 
@@ -535,7 +524,7 @@ To mitigate this, Where moves all session metadata into the **encrypted envelope
 2. **Post-Decryption Extraction:** The receiver first decrypts the envelope header using the current or next `header_key` and *then* reads the metadata to perform historical gap-filling of the old chain (§5.3).
 3. **Cache Storage:** When storing skipped keys for out-of-order delivery, the receiver stores the active `prev_chain_len` alongside the message key: `(MK_n, Nonce_n, PN_n)`. This ensures that if the message arrives later, the AAD can be re-verified against the correct historical value.
 
-This removes all session-related metadata from the server's view. The server only sees opaque mailbox tokens and encrypted blobs.
+This removes session-related metadata from the server's payload view, but it does not eliminate timing, IP correlation, or polling-pattern leakage.
 
 #### 7.4.2 Payload padding
 
@@ -543,7 +532,7 @@ This removes all session-related metadata from the server's view. The server onl
 
 #### 7.4.3 Polling Strategy
 
-To prevent timing-based social-graph inference, Bob MUST poll at a **constant rate** regardless of whether messages are expected. Polling more frequently when a location update is expected, or less frequently when offline, creates a timing side-channel the server can exploit to infer when friends are actively sharing.
+To prevent timing-based social-graph inference, Bob SHOULD poll at a roughly constant rate regardless of whether messages are expected. Polling more frequently when a location update is expected, or less frequently when offline, creates a timing side-channel the server can exploit to infer when friends are actively sharing. Implementations that deviate from constant-rate polling — due to battery optimizations, foreground/background transitions, or movement-triggered updates — increase the risk that the server can infer presence, movement state, or session activity from polling patterns alone.
 
 **Polling cadence is a UX/battery parameter, not a cryptographic one.** The polling interval should be set based on freshness requirements and battery budget. A 60–120 second poll interval provides acceptable location freshness for a mapping application without the battery drain of 10-second polling, and without revealing fine-grained app-foreground state to the server. Recommended default: **60 seconds**.
 
@@ -585,7 +574,7 @@ SessionState {
   recv_chain_key:     [32]byte        // CK for incoming messages
   send_token:         [16]byte        // token for highest_peer_dh_pub_seen
   recv_token:         [16]byte        // token for current local ratchet key
-  prev_recv_token:    [16]byte        // token for previous local ratchet key (pending retirement); zero = unset
+  prev_recv_token:    [16]byte        // token for previous local ratchet key (pending retirement); unset at bootstrap
   send_msg_num:       uint64          // sender chain message number
   recv_msg_num:       uint64          // highest received msg_num in the current epoch (for replay rejection)
   highest_peer_dh_pub_seen: [32]byte  // highest peer DH pub key successfully processed
@@ -642,7 +631,7 @@ Each message frame carries a `msg_num` counter. Recipients enforce:
 1.  **Replay rejection:** Any frame with `msg_num <= max_msg_num_received` (within the same DH epoch) is dropped, EXCEPT if the key for that message number is present in the **skipped message key cache**.
 2.  **Maximum gap (MAX_GAP):** recipients MUST enforce a maximum gap (default 2000) for chain advancement to prevent resource exhaustion attacks.
 3.  **OutOfOrder Support:** If a message is skipped (e.g., recipient receives `msg_num=10` after `msg_num=8`), the recipient advances the symmetric ratchet to `msg_num=10` and stores the intermediate message keys in a bounded cache (100 entries).
-4.  **Transactional Commitment:** The receiving state (receiving chain, root key, skipped keys) MUST only be updated if the message AEAD authentication succeeds.
+4.  **Transactional Commitment:** The receiving state (receiving chain, root key, skipped keys) MUST only be updated if the message AEAD authentication succeeds. The receiving state MUST not be committed earlier.
 5.  **Epoch Transition:** When a message with a new `dh_pub` is received, the `msg_num` counter resets to 0. All skipped message keys belonging to epochs older than the *previous* valid epoch MUST be cleared.
 6.  **Across-Epoch Replay:** Recipients MUST reject any message for an epoch that has already been superseded and retired (§5.4.3). Retired peer DH public keys are stored in `retired_dh_pubs` (§8.2, max 10 entries, evict oldest when full). When a `previous_pending` epoch is retired, its `dh_pub` is added to this set. Any incoming message whose `dh_pub` matches an entry in `retired_dh_pubs` MUST be dropped without further processing.
 
@@ -762,12 +751,12 @@ The server maintains a persistent map of **mailboxes** indexed by 16-byte routin
 
 1. **POST /inbox/{token}:**
    - Push the payload into the corresponding queue.
-   - Apply a TTL of 7 days. This aligns with the client re-pair timeout: if Bob has not polled within 7 days, the session will be abandoned on both sides regardless.
+   - Apply a TTL of 7 days. This is a server retention policy, not a cryptographic guarantee. The 7-day window is only used as a bounded liveness fallback in the client retirement logic.
    - The server MUST durably persist the payload before returning `204 No Content`. Clients treat any non-2xx response as delivery failure and retain the outbox for retry.
 
 2. **GET /inbox/{token}:**
    - Return up to 50 messages from the front of the queue. **Does not delete them.**
-   - **Constant-Time Invariant:** The server MUST return an identical response (HTTP 200 OK with `[]`) for non-existent tokens. To prevent timing side-channels, the lookup logic must ensure that the time taken to respond for a "hit" (active token) versus a "miss" (empty/unknown token) is indistinguishable to an attacker.
+   - **Empty-Response Invariant:** The server MUST return an identical response body for non-existent tokens. Server implementations SHOULD minimize timing differences between "hit" and "miss" cases. A server that does not will increase the risk of token-existence oracle attacks, allowing a metadata-analyzing adversary to confirm whether a given token has ever been used and thereby partially reconstruct the social graph.
 
 3. **DELETE /inbox/{token}?n={count}:**
    - Remove the first `count` messages from the queue. Called by the client after session state has been durably saved to local storage (§5.4.1).
@@ -784,7 +773,7 @@ The server exposes the mailbox API: `POST /inbox/{token}`, `GET /inbox/{token}`,
 
 ### 10.4 Server Cannot Decrypt or Link
 
-With this design:
+With this design, and assuming only the advertised mailbox API and payload encryption:
 - The server has no knowledge of any session keys or identity keys.
 - The server does not know the sender or recipient identity—only the opaque routing token.
 - A full server compromise reveals only the timing and frequency of anonymous posts and polls. Social graph and content remain hidden.
@@ -818,7 +807,7 @@ While this protocol shares the core **Double Ratchet** design with Signal, it ma
 ### 12.1 Identity and Handshake (No X3DH)
 
 - **Signal:** Uses **X3DH** (Extended Triple Diffie-Hellman) which relies on long-term **Identity Keys (IK)** and a central server to host Signed Prekeys and One-time Prekeys. This enables asynchronous session establishment (Alice can message Bob even if he is offline).
-- **Where:** Uses an **ephemeral-only handshake**. There are no long-term identity keys. "Identity" is scoped to a single friendship session ("Session as Identity"). This eliminates the need for a central PKI or prekey server and ensures that no stable device identifier is ever exposed to the server. Key exchange is synchronous and out-of-band (QR code or secure link).
+- **Where:** Uses an **ephemeral-only bootstrap handshake**. There are no long-term identity keys. "Identity" is scoped to a single friendship session ("Session as Identity"). This eliminates the need for a central PKI or prekey server and ensures that no stable device identifier is ever exposed to the server. Key exchange is synchronous and out-of-band (QR code or secure link).
 
 ### 12.2 Cryptographic Primitives (ChaChaPoly vs AES-GCM)
 
@@ -857,4 +846,4 @@ While this protocol shares the core **Double Ratchet** design with Signal, it ma
 
 3. **Multi-Device Support.** Full session synchronization across multiple devices (e.g., phone and tablet) is a complex challenge planned for future work.
 
-4. **Session Expiry and Staleness Handling.** If Alice stops sharing (app uninstalled, account deleted, extended offline period), Bob's client continues polling indefinitely against a token that will never receive new messages. To provide UX signals, `FriendEntry.isStale` is a heuristic that returns true if no messages have been received for more than 7 days (`ACK_TIMEOUT_SECONDS`). Clients SHOULD surface a "no recent location" warning to the user based on this flag.
+4. **Session Expiry and Staleness Handling.** If Alice stops sharing (app uninstalled, account deleted, extended offline period), Bob's client continues polling indefinitely against a token that will never receive new messages. To provide UX signals, `FriendEntry.isStale` is a heuristic that returns true if no messages have been received for more than 7 days (`ACK_TIMEOUT_SECONDS`). Clients SHOULD surface a "no recent location" warning to the user based on this flag. This is a UX heuristic, not a protocol retirement rule.

--- a/docs/e2ee-location-sync.md
+++ b/docs/e2ee-location-sync.md
@@ -337,7 +337,7 @@ A sender MUST send to the peer mailbox token associated with the last **proven**
 Formally:
 `active_send_target = token_for(highest_peer_dh_pub_seen)`
 
-- On session bootstrap, `highest_peer_dh_pub_seen` is the initial value derived from `SK`. The initial outbound target is `T_AB_0`.
+- **Bootstrap Rule:** At session bootstrap, neither party has any prior peer DH state. `highest_peer_dh_pub_seen` is initialized to the peer's bootstrap ephemeral public key: Alice initializes it to `EK_B.pub`; Bob initializes it to `EK_A.pub`. Consequently, the `ack_remote_dh_pub` field in the first outbound message MUST be set to that same bootstrap key (`EK_B.pub` for Alice, `EK_A.pub` for Bob). Until the first decrypted peer message arrives and updates this belief, the initial outbound target remains `T_AB_0` and no alternate token is permitted.
 - A sender MUST NOT switch to the next token solely because it locally ratcheted.
 - A sender may switch only after the peer’s newer DH state is observed in a decrypted message and acknowledged by the protocol state machine.
 
@@ -345,6 +345,8 @@ Formally:
 Each direction keeps at most two active epochs:
 - **current**: The latest verified peer epoch.
 - **previous_pending**: The prior epoch, kept only for safety during transition.
+
+**Initialization:** At session bootstrap, `prev_recv_token` is unset (zero bytes / null sentinel). The polling loop MUST skip `prev_recv_token` when it is unset, and MUST NOT poll a zero-byte token. `prev_recv_token` becomes set only after the first DH ratchet step advances `recv_token`.
 
 Messages may be accepted from both. When a message is decrypted:
 1. If the sender `dh_pub` is newer than the local view, ratchet forward.
@@ -355,9 +357,11 @@ Messages may be accepted from both. When a message is decrypted:
 **Ack Rule:**
 Each message carries an `ack_remote_dh_pub` field, which is an authenticated claim inside the encrypted header: "I have successfully decrypted and processed at least one message from the peer up to this DH public key."
 
+This field is the **only authoritative signal** for retiring mailbox paths. It MUST NOT be treated as informational telemetry.
+
 **Retirement Rule:**
-- **Primary Rule:** Retire `previous_pending` only after receiving an authenticated `ack_remote_dh_pub` that proves the peer has moved forward (i.e., `ack_remote_dh_pub >= my_previous_dh_pub`).
-- **Secondary Bounded Fallback:** If no authenticated message has arrived on the old mailbox for 7 days, and the server TTL guarantees the mailbox entry is dead, the old mailbox MAY be retired. Timeout alone must never be the primary retirement mechanism.
+- **Primary Rule:** Retire `previous_pending` only after receiving an authenticated `ack_remote_dh_pub` that proves the peer has moved forward. The value MUST be compared against the peer’s previous active `dh_pub` (e.g., `ack_remote_dh_pub == local_dh_pub_prev`), not against a local epoch counter.
+- **Secondary Bounded Fallback:** If no authenticated message has arrived on the old mailbox for 7 days, and the server TTL guarantees the mailbox entry is dead, the old mailbox MAY be retired. This fallback is safe only because the server TTL bounds liveness ambiguity; timeout alone must never be the primary retirement mechanism.
 
 #### 5.4.4 Duplicate Handling and Batch Ordering
 **Duplicate Handling:**
@@ -371,7 +375,7 @@ When processing a batch of messages from the server, sort them as follows:
 
 This ensures historical messages are processed before any later ratchet step in the same batch.
 
-#### 5.4.1 Receive-Side Crash Safety
+#### 5.4.5 Receive-Side Crash Safety
 
 The GET → process → DELETE sequence is the receive-side analogue of the send-side transactional outbox:
 
@@ -568,20 +572,22 @@ Each friendship maintains a standard Double Ratchet state:
 
 ```
 SessionState {
-  root_key:           [32]byte   // current root key
-  send_chain_key:     [32]byte   // CK for outgoing messages
-  recv_chain_key:     [32]byte   // CK for incoming messages
-  send_token:         [16]byte   // token for highest_peer_dh_pub_seen
-  recv_token:         [16]byte   // token for current local ratchet key
-  prev_recv_token:    [16]byte   // token for previous local ratchet key (pending retirement)
-  send_msg_num:       uint64     // sender chain message number
-  highest_peer_dh_pub_seen: [32]byte // highest peer DH pub key successfully processed
-  local_dh_pub:       [32]byte   // current local ratchet public key
-  remote_dh_pub:      [32]byte   // last received remote ratchet public key
-  alice_ek_pub:       [32]byte   // bootstrap public key EK_A.pub (stable)
-  bob_ek_pub:         [32]byte   // bootstrap public key EK_B.pub (stable)
-  alice_fp:           [32]byte   // SHA-256(EK_A.pub) (stable)
-  bob_fp:             [32]byte   // SHA-256(EK_B.pub) (stable)
+  root_key:           [32]byte        // current root key
+  send_chain_key:     [32]byte        // CK for outgoing messages
+  recv_chain_key:     [32]byte        // CK for incoming messages
+  send_token:         [16]byte        // token for highest_peer_dh_pub_seen
+  recv_token:         [16]byte        // token for current local ratchet key
+  prev_recv_token:    [16]byte        // token for previous local ratchet key (pending retirement); zero = unset
+  send_msg_num:       uint64          // sender chain message number
+  recv_msg_num:       uint64          // highest received msg_num in the current epoch (for replay rejection)
+  highest_peer_dh_pub_seen: [32]byte  // highest peer DH pub key successfully processed
+  local_dh_pub:       [32]byte        // current local ratchet public key
+  remote_dh_pub:      [32]byte        // last received remote ratchet public key
+  alice_ek_pub:       [32]byte        // bootstrap public key EK_A.pub (stable)
+  bob_ek_pub:         [32]byte        // bootstrap public key EK_B.pub (stable)
+  alice_fp:           [32]byte        // SHA-256(EK_A.pub) (stable)
+  bob_fp:             [32]byte        // SHA-256(EK_B.pub) (stable)
+  retired_dh_pubs:    Set<[32]byte>   // bounded set of retired peer DH pub keys (max 10) for across-epoch replay rejection
 }
 ```
 
@@ -630,7 +636,7 @@ Each message frame carries a `msg_num` counter. Recipients enforce:
 3.  **OutOfOrder Support:** If a message is skipped (e.g., recipient receives `msg_num=10` after `msg_num=8`), the recipient advances the symmetric ratchet to `msg_num=10` and stores the intermediate message keys in a bounded cache (100 entries).
 4.  **Transactional Commitment:** The receiving state (receiving chain, root key, skipped keys) MUST only be updated if the message AEAD authentication succeeds.
 5.  **Epoch Transition:** When a message with a new `dh_pub` is received, the `msg_num` counter resets to 0. All skipped message keys belonging to epochs older than the *previous* valid epoch MUST be cleared.
-6.  **Across-Epoch Replay:** Recipients MUST keep track of recently seen `dh_pub` keys (epoch identifiers) and reject any message for an epoch that has already been superseded and retired (§5.4.3).
+6.  **Across-Epoch Replay:** Recipients MUST reject any message for an epoch that has already been superseded and retired (§5.4.3). Retired peer DH public keys are stored in `retired_dh_pubs` (§8.2, max 10 entries, evict oldest when full). When a `previous_pending` epoch is retired, its `dh_pub` is added to this set. Any incoming message whose `dh_pub` matches an entry in `retired_dh_pubs` MUST be dropped without further processing.
 
 
 ---
@@ -708,6 +714,8 @@ For a **Keepalive**:
 ### 9.2 Poll Request (Bob → Server)
 
 Bob retrieves pending messages by performing a `GET` request to his pairwise receive token: `GET /inbox/{hex(recv_token_T)}`. There is no JSON payload for the poll request itself.
+
+During an epoch transition, Bob MUST also poll `prev_recv_token` if it is set (non-zero): `GET /inbox/{hex(prev_recv_token)}`. Both polls occur within the same polling cycle. `prev_recv_token` is unset at bootstrap and after it has been retired per §5.4.3.
 
 The server returns a JSON array of `MailboxPayload` objects, or an empty array `[]` if no messages are pending (§7.2).
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeManager.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeManager.kt
@@ -399,13 +399,14 @@ class E2eeManager(
             )
 
             PersistenceAction.Update(updatedEntry) to PollBatchResult(
-                result.decryptedLocations, 
-                result.anySuccess, 
-                result.silentDrops > 0, 
-                result.anyReplay, 
-                failCount, 
-                hadStateUpdate
+                decryptedLocations = result.decryptedLocations,
+                anySuccess = result.anySuccess,
+                hadSilentDrops = result.silentDrops > 0 || (messages.size > encryptedMessages.size),
+                anyReplay = result.anyReplay,
+                failCount = failCount,
+                hadStateUpdate = hadStateUpdate
             )
+
         }
     }
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeProtocol.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeProtocol.kt
@@ -141,7 +141,7 @@ internal object E2eeProtocol {
         return when {
             h.dhPub.contentEquals(session.remoteDhPub) -> 1
             h.dhPub.contentEquals(session.lastRemoteDhPub) -> 0
-            session.seenRemoteDhPubs.contains(h.dhPub.toHex()) -> 3 // Ancient epoch (already superseded)
+            session.retiredDhPubs.contains(h.dhPub.toHex()) -> 3 // Ancient epoch (already superseded)
             else -> 2 // Unknown NEW epoch
         }
     }

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
@@ -171,6 +171,7 @@ object KeyExchange {
                 sendToken = newSendToken,
                 localDhPriv = newLocalDh.priv.copyOf(),
                 localDhPub = newLocalDh.pub.copyOf(),
+                prevLocalDhPub = session.localDhPub.copyOf(),
                 prevSendToken = session.sendToken.copyOf(),
                 isSendTokenPending = true,
                 pn = session.sendSeq,
@@ -258,13 +259,14 @@ object KeyExchange {
             recvSeq = 0L,
             localDhPriv = myDhPriv.copyOf(),
             localDhPub = myDhPub.copyOf(),
+            prevLocalDhPub = ByteArray(0), // No previous local DH at bootstrap
             remoteDhPub = theirDhPub.copyOf(),
             aliceEkPub = (if (isAlice) myDhPub else theirDhPub).copyOf(),
             bobEkPub = (if (isAlice) theirDhPub else myDhPub).copyOf(),
             aliceFp = aliceFp.copyOf(),
             bobFp = bobFp.copyOf(),
             prevSendToken = sendToken.copyOf(),
-            prevRecvToken = recvToken.copyOf(),
+            prevRecvToken = ByteArray(0),
             isSendTokenPending = false,
             isAlice = isAlice,
             pn = 0L,
@@ -272,6 +274,7 @@ object KeyExchange {
             headerKey = recvHeaderKey,
             sendHeaderKey = sendHeaderKey,
             nextHeaderKey = nextHeaderKey,
+            retiredDhPubs = emptySet()
         )
     }
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -223,7 +223,10 @@ open class LocationClient(
                 }
 
                 // ACK logic: progress (success/replay/state) or unrecoverable failure (forceAck)
-                val safeToAck = result.anySuccess || result.anyReplay || result.hadStateUpdate || forceAck
+                val safeToAck = (result.anySuccess && !result.hadSilentDrops) ||
+                    (result.anyReplay && result.failCount == 0) ||
+                    result.hadStateUpdate ||
+                    forceAck
 
                 if (safeToAck) {
                     try {

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -163,6 +163,14 @@ open class LocationClient(
         if (prev.isNotEmpty() && prev != friendBefore.session.recvToken.toHex()) {
             pollQueue.add(prev)
         }
+
+        // Also poll retired tokens to catch up peers that are multiple epochs behind
+        friendBefore.session.retiredRecvTokens.forEach { tokenBytes ->
+            val token = tokenBytes.toHex()
+            if (!pollQueue.contains(token)) {
+                pollQueue.add(token)
+            }
+        }
         pollQueue.shuffle()
 
         val polledTokens = mutableSetOf<String>()
@@ -214,11 +222,8 @@ open class LocationClient(
                     store.resetConsecutiveSilentDrops(friendId)
                 }
 
-                // ACK logic
-                val safeToAck = (result.anySuccess && !result.hadSilentDrops) ||
-                    (result.anyReplay && result.failCount == 0) ||
-                    result.hadStateUpdate ||
-                    forceAck
+                // ACK logic: progress (success/replay/state) or unrecoverable failure (forceAck)
+                val safeToAck = result.anySuccess || result.anyReplay || result.hadStateUpdate || forceAck
 
                 if (safeToAck) {
                     try {
@@ -406,7 +411,6 @@ open class LocationClient(
                         val isStale = staleSince != null && (currentTimeMillis() - staleSince) > PENDING_TRANSITION_TIMEOUT_MS
                         if (isStale) {
                             println("[LocationClient] pending transition stale for ${friend.id.take(8)}")
-                            store.addDiagnosticEvent("STALE ROLLBACK: ${friend.id.take(8)}")
                             store.abandonPendingTransition(friend.id)
                             return@async
                         }
@@ -414,10 +418,6 @@ open class LocationClient(
 
                     val outbox = friend.outbox
                     if (outbox == null) {
-                        if (friend.session.isSendTokenPending && friend.session.sendSeq > 1) {
-                            println("[LocationClient] recovery: detected stale transition flag for ${friend.id.take(8)}, finalizing now")
-                            finalizeTokenTransition(friend.id)
-                        }
                         return@async
                     }
 
@@ -434,12 +434,13 @@ open class LocationClient(
                         }
                         val statusCode = (e as? ServerException)?.statusCode
                         if (statusCode == 404 || statusCode == 410) {
-                            if (friend.session.isSendTokenPending &&
+                            val isTransitionToken = friend.session.isSendTokenPending && 
                                 outbox.token == friend.session.prevSendToken.toHex()
-                            ) {
-                                println("[LocationClient] recovery: DESYNC: transition lost for ${friend.id.take(8)}")
-                                store.addDiagnosticEvent("DESYNC: transition lost for ${friend.id.take(8)}")
-                                store.clearOutboxAndUpdateSession(friend.id, friend.session.copy(isSendTokenPending = false))
+                            
+                            if (isTransitionToken) {
+                                println("[LocationClient] recovery: mailbox gone (404/410) for ${friend.id.take(8)} during outbox retry. Clearing outbox and pending transition.")
+                                store.clearOutbox(friend.id)
+                                finalizeTokenTransition(friend.id, clearingToken = outbox.token)
                             } else {
                                 store.clearOutbox(friend.id)
                             }

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/ProtocolConstants.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/ProtocolConstants.kt
@@ -19,13 +19,14 @@ internal const val MAX_DIAGNOSTIC_EVENTS = 30
 // After this many consecutive polls where header-parse failures blocked the ACK,
 // force-ACK the batch to break a permanent livelock. The dropped messages are
 // accepted as lost; the session may need re-pairing if they contained DH keys.
-internal const val MAX_SILENT_DROP_RETRIES = 20
+internal const val MAX_SILENT_DROP_RETRIES = 100
 internal const val MAX_GAP = 10000
 internal const val MAX_SKIPPED_KEYS = 10000
 internal const val MAX_SKIPPED_EPOCHS = 10
 internal const val MAX_KEY_AGE_MS = 604_800_000L // 7 days in milliseconds
-internal const val PENDING_TRANSITION_TIMEOUT_MS = MAX_KEY_AGE_MS // 7 days
-internal const val MAX_SEEN_DH_PUBS = 10
+internal const val PENDING_TRANSITION_TIMEOUT_MS = 3_600_000L // 1 hour
+internal const val MAX_SEEN_DH_PUBS = 50
+
 const val PROTOCOL_VERSION = 1
 const val SUPPORTED_MAX_VERSION = 1
 internal const val AAD_PREFIX = "Where-v1-Message"

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/ProtocolConstants.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/ProtocolConstants.kt
@@ -24,7 +24,7 @@ internal const val MAX_GAP = 10000
 internal const val MAX_SKIPPED_KEYS = 10000
 internal const val MAX_SKIPPED_EPOCHS = 10
 internal const val MAX_KEY_AGE_MS = 604_800_000L // 7 days in milliseconds
-internal const val PENDING_TRANSITION_TIMEOUT_MS = 3_600_000L // 1 hour
+internal const val PENDING_TRANSITION_TIMEOUT_MS = MAX_KEY_AGE_MS // 7 days
 internal const val MAX_SEEN_DH_PUBS = 50
 
 const val PROTOCOL_VERSION = 1

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -30,10 +30,11 @@ object Session {
         val step = kdfCk(currentState.sendChainKey)
         val seq = currentState.sendSeq + 1
         val dhPub = currentState.localDhPub
+        val ackRemoteDhPub = currentState.remoteDhPub
 
         // AAD directionality: include sender and recipient fingerprints explicitly.
         val (sender, recipient) = if (currentState.isAlice) currentState.aliceFp to currentState.bobFp else currentState.bobFp to currentState.aliceFp
-        val aad = buildMessageAad(sender, recipient, seq, dhPub)
+        val aad = buildMessageAad(sender, recipient, seq, dhPub, ackRemoteDhPub)
 
         // PH-3.3 (BELT-AND-SUSPENDERS): Ensure internal 'pn' matches what we put in the header (#212)
         val updatedPayload =
@@ -53,7 +54,7 @@ object Session {
             )
 
         // Seal the metadata into an envelope (#186)
-        val envelope = encryptHeader(currentState.sendHeaderKey, dhPub, seq, currentState.pn)
+        val envelope = encryptHeader(currentState.sendHeaderKey, dhPub, ackRemoteDhPub, seq, currentState.pn)
 
         // Memory Hygiene
         step.messageKey.zeroize()
@@ -117,6 +118,7 @@ object Session {
             }
 
         val remoteDhPub = header.dhPub
+        val ackRemoteDhPub = header.ackRemoteDhPub
         val isNewDhEpoch = !remoteDhPub.contentEquals(cleanState.remoteDhPub)
         val seq = header.seq
 
@@ -137,7 +139,7 @@ object Session {
             val nonce = cachedKey.copyOfRange(32, 44)
 
             // Use the new buildMessageAad signature (pn is now inside the ciphertext)
-            val aad = buildMessageAad(sender, recipient, seq, remoteDhPub)
+            val aad = buildMessageAad(sender, recipient, seq, remoteDhPub, ackRemoteDhPub)
 
             val plaintext =
                 try {
@@ -190,7 +192,7 @@ object Session {
 
         if (isNewDhEpoch) {
             // Unified error message to satisfy existing brittle test assertions (§9.2)
-            if (remoteDhPub.contentEquals(cleanState.lastRemoteDhPub) || cleanState.seenRemoteDhPubs.contains(remoteDhPub.toHex())) {
+            if (remoteDhPub.contentEquals(cleanState.lastRemoteDhPub) || cleanState.retiredDhPubs.contains(remoteDhPub.toHex())) {
                 throw ReplayException("replay: dhPub already superseded (out-of-order window closed)")
             }
 
@@ -216,7 +218,11 @@ object Session {
         // very old skipped keys. We'll clear keys belonging to epochs no longer in our seen window.
         if (isNewDhEpoch) {
             val validEpochs = mutableSetOf(remoteDhPub.toHex(), cleanState.remoteDhPub.toHex())
-            validEpochs.addAll(speculativeState.seenRemoteDhPubs)
+            validEpochs.addAll(speculativeState.retiredDhPubs)
+            // Include the key we are about to retire to avoid aggressive pruning during the transition turn.
+            if (!cleanState.lastRemoteDhPub.isEmpty()) {
+                validEpochs.add(cleanState.lastRemoteDhPub.toHex())
+            }
 
             val it = derivationSkippedKeys.entries.iterator()
             while (it.hasNext()) {
@@ -276,7 +282,7 @@ object Session {
             // AAD directionality: peer is the sender, I am the recipient.
             val (sender, recipient) =
                 if (cleanState.isAlice) cleanState.bobFp to cleanState.aliceFp else cleanState.aliceFp to cleanState.bobFp
-            val aad = buildMessageAad(sender, recipient, seq, remoteDhPub)
+            val aad = buildMessageAad(sender, recipient, seq, remoteDhPub, ackRemoteDhPub)
 
             val plaintext =
                 try {
@@ -284,19 +290,33 @@ object Session {
                 } catch (e: Exception) {
                     // Decryption failure: We still want to persist the ratcheted state if the header
                     // authenticated, to prevent permanent DH desync (§5.5).
+                    
+                    // Retirement Rule (§5.4.3): proves the peer has moved forward (matches current local DH key).
+                    val isValidAck = ackRemoteDhPub.contentEquals(cleanState.localDhPub) ||
+                        ackRemoteDhPub.contentEquals(cleanState.prevLocalDhPub) ||
+                        ackRemoteDhPub.contentEquals(cleanState.aliceEkPub) ||
+                        ackRemoteDhPub.contentEquals(cleanState.bobEkPub)
+
+                    // We retire the transition window once the peer has acknowledged our current local key
+                    // (the one they just saw) or our next local key (if they already saw our ratchet).
+                    val shouldRetirePrevToken = isValidAck && (
+                        ackRemoteDhPub.contentEquals(cleanState.localDhPub) || 
+                        ackRemoteDhPub.contentEquals(speculativeState.localDhPub)
+                    )
+                    val newRetiredDhPubs = if (!cleanState.lastRemoteDhPub.isEmpty() && (shouldRetirePrevToken || isNewDhEpoch)) {
+                        (speculativeState.retiredDhPubs + cleanState.lastRemoteDhPub.toHex()).toList().takeLast(MAX_SEEN_DH_PUBS).toSet()
+                    } else {
+                        speculativeState.retiredDhPubs
+                    }
+
                     val failedState =
                         speculativeState.deepCopy().copy(
                             recvChainKey = chainKey.copyOf(),
                             recvSeq = seq,
                             skippedMessageKeys = derivationSkippedKeys.mapValues { it.value.copyOf() },
                             needsRatchet = cleanState.needsRatchet || isNewDhEpoch,
-                            prevRecvToken = if (isNewDhEpoch) cleanState.recvToken.copyOf() else cleanState.prevRecvToken.copyOf(),
-                            seenRemoteDhPubs =
-                                if (isNewDhEpoch) {
-                                    (speculativeState.seenRemoteDhPubs + cleanState.remoteDhPub.toHex()).toList().takeLast(MAX_SEEN_DH_PUBS).toSet()
-                                } else {
-                                    speculativeState.seenRemoteDhPubs
-                                },
+                            prevRecvToken = if (shouldRetirePrevToken) ByteArray(0) else if (isNewDhEpoch) cleanState.recvToken.copyOf() else cleanState.prevRecvToken.copyOf(),
+                            retiredDhPubs = newRetiredDhPubs,
                         )
                     // Also wipe any message keys derived during this failed call
                     addedSkippedKeys.forEach { it.zeroize() }
@@ -362,6 +382,23 @@ object Session {
                 finalEpochHeaderKeys = cleanState.skippedEpochHeaderKeys
             }
 
+            // Retirement Rule (§5.4.3): proves the peer has moved forward (matches current local DH key).
+            val isValidAck = ackRemoteDhPub.contentEquals(cleanState.localDhPub) ||
+                ackRemoteDhPub.contentEquals(cleanState.prevLocalDhPub) ||
+                ackRemoteDhPub.contentEquals(cleanState.aliceEkPub) ||
+                ackRemoteDhPub.contentEquals(cleanState.bobEkPub)
+
+            // We retire the transition window once the peer has acknowledged our current local key
+            // (the one they just saw) or our next local key (if they already saw our ratchet).
+            val shouldRetirePrevToken = isValidAck && (
+                ackRemoteDhPub.contentEquals(cleanState.localDhPub) || 
+                ackRemoteDhPub.contentEquals(speculativeState.localDhPub)
+            )
+            val newRetiredDhPubs = if (!cleanState.lastRemoteDhPub.isEmpty() && (shouldRetirePrevToken || isNewDhEpoch)) {
+                (speculativeState.retiredDhPubs + cleanState.lastRemoteDhPub.toHex()).toList().takeLast(MAX_SEEN_DH_PUBS).toSet()
+            } else {
+                speculativeState.retiredDhPubs
+            }
             val newState =
                 speculativeState.deepCopy().copy(
                     recvChainKey = chainKey, // Move ownership
@@ -369,13 +406,8 @@ object Session {
                     skippedMessageKeys = finalSkippedKeys,
                     skippedEpochHeaderKeys = finalEpochHeaderKeys,
                     needsRatchet = cleanState.needsRatchet || isNewDhEpoch,
-                    prevRecvToken = if (isNewDhEpoch) cleanState.recvToken.copyOf() else cleanState.prevRecvToken.copyOf(),
-                    seenRemoteDhPubs =
-                        if (isNewDhEpoch) {
-                            (speculativeState.seenRemoteDhPubs + cleanState.remoteDhPub.toHex()).toList().takeLast(MAX_SEEN_DH_PUBS).toSet()
-                        } else {
-                            speculativeState.seenRemoteDhPubs
-                        },
+                    prevRecvToken = if (shouldRetirePrevToken) ByteArray(0) else if (isNewDhEpoch) cleanState.recvToken.copyOf() else cleanState.prevRecvToken.copyOf(),
+                    retiredDhPubs = newRetiredDhPubs,
                 )
 
             return newState to decoded
@@ -426,14 +458,6 @@ object Session {
                 deriveRoutingToken(stepSend.newRootKey, bobFp, aliceFp)
             }
 
-        // Track seen DH keys to avoid re-ratcheting to old epochs
-        val newSeenKeys = LinkedHashSet(state.seenRemoteDhPubs)
-        newSeenKeys.add(state.remoteDhPub.toHex())
-        if (newSeenKeys.size > MAX_SEEN_DH_PUBS) {
-            val oldest = newSeenKeys.first()
-            newSeenKeys.remove(oldest)
-        }
-
         // HEADER ENCRYPTION TRANSITION (#186):
         // Standard advancement logic:
         // 1. headerKey matches what we just used to decrypt the first message.
@@ -455,9 +479,10 @@ object Session {
                 pr = state.recvSeq,
                 localDhPriv = newLocalDh.priv.copyOf(),
                 localDhPub = newLocalDh.pub.copyOf(),
+                prevLocalDhPub = state.localDhPub.copyOf(),
                 remoteDhPub = remoteDhPub.copyOf(),
                 lastRemoteDhPub = state.remoteDhPub.copyOf(),
-                seenRemoteDhPubs = newSeenKeys,
+                retiredDhPubs = state.retiredDhPubs,
                 prevSendToken = state.sendToken.copyOf(),
                 prevRecvToken = state.recvToken.copyOf(),
                 isSendTokenPending = true,
@@ -478,27 +503,30 @@ object Session {
     internal fun encryptHeader(
         key: ByteArray,
         dhPub: ByteArray,
+        ackRemoteDhPub: ByteArray,
         seq: Long,
         pn: Long,
     ): ByteArray {
-        val plaintext = ByteArray(1 + 32 + 8 + 8)
+        val plaintext = ByteArray(1 + 32 + 32 + 8 + 8 + 1)
         plaintext[0] = PROTOCOL_VERSION.toByte()
         dhPub.copyInto(plaintext, 1)
-        longToBeBytes(seq).copyInto(plaintext, 33)
-        longToBeBytes(pn).copyInto(plaintext, 41)
+        ackRemoteDhPub.copyInto(plaintext, 33)
+        longToBeBytes(seq).copyInto(plaintext, 65)
+        longToBeBytes(pn).copyInto(plaintext, 73)
+        plaintext[81] = 0 // flags
 
         val nonce = randomBytes(HEADER_NONCE_SIZE)
         val ct = aeadEncrypt(key, nonce, plaintext, aad = ByteArray(0))
         return nonce + ct
     }
 
-    data class DecryptedHeader(val dhPub: ByteArray, val seq: Long, val pn: Long)
+    data class DecryptedHeader(val dhPub: ByteArray, val ackRemoteDhPub: ByteArray, val seq: Long, val pn: Long)
 
     internal fun decryptHeader(
         key: ByteArray,
         envelope: ByteArray,
     ): DecryptedHeader {
-        if (envelope.size < HEADER_NONCE_SIZE + HEADER_TAG_SIZE + 49) {
+        if (envelope.size < HEADER_NONCE_SIZE + HEADER_TAG_SIZE + 82) {
             throw ProtocolException("header envelope too small")
         }
         val nonce = envelope.copyOfRange(0, HEADER_NONCE_SIZE)
@@ -515,9 +543,10 @@ object Session {
         }
 
         val dhPub = plaintext.copyOfRange(1, 33)
-        val seq = bytesToLong(plaintext.copyOfRange(33, 41))
-        val pn = bytesToLong(plaintext.copyOfRange(41, 49))
-        return DecryptedHeader(dhPub, seq, pn)
+        val ackRemoteDhPub = plaintext.copyOfRange(33, 65)
+        val seq = bytesToLong(plaintext.copyOfRange(65, 73))
+        val pn = bytesToLong(plaintext.copyOfRange(73, 81))
+        return DecryptedHeader(dhPub, ackRemoteDhPub, seq, pn)
     }
 
     private fun buildMessageAad(
@@ -525,13 +554,15 @@ object Session {
         recipientFp: ByteArray,
         seq: Long,
         dhPub: ByteArray,
+        ackRemoteDhPub: ByteArray,
     ): ByteArray {
         return AAD_PREFIX.encodeToByteArray() +
             intToBeBytes(PROTOCOL_VERSION) +
             senderFp +
             recipientFp +
             longToBeBytes(seq) +
-            dhPub
+            dhPub +
+            ackRemoteDhPub
     }
 
     private fun encodeMessage(msg: MessagePlaintext): ByteArray =

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -378,7 +378,8 @@ object Session {
             }
 
             // Retirement Rule (§5.4.3): proves the peer has moved forward (matches current local DH key).
-            val isValidAck = ackRemoteDhPub.contentEquals(cleanState.localDhPub) ||
+            val isValidAck =
+                ackRemoteDhPub.contentEquals(cleanState.localDhPub) ||
                 ackRemoteDhPub.contentEquals(cleanState.prevLocalDhPub) ||
                 ackRemoteDhPub.contentEquals(cleanState.aliceEkPub) ||
                 ackRemoteDhPub.contentEquals(cleanState.bobEkPub)

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -385,8 +385,8 @@ object Session {
 
             // We retire the transition window once the peer has acknowledged our current local key
             // (the one they just saw) or our next local key (if they already saw our ratchet).
-            val shouldRetirePrevToken = isValidAck && (
-                ackRemoteDhPub.contentEquals(cleanState.localDhPub) || 
+            val shouldRetirePrevToken = isNewDhEpoch && isValidAck && (
+                ackRemoteDhPub.contentEquals(cleanState.localDhPub) ||
                 ackRemoteDhPub.contentEquals(speculativeState.localDhPub)
             )
             val newRetiredDhPubs = if (!cleanState.lastRemoteDhPub.isEmpty() && (shouldRetirePrevToken || isNewDhEpoch)) {

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -303,10 +303,16 @@ object Session {
                         ackRemoteDhPub.contentEquals(cleanState.localDhPub) || 
                         ackRemoteDhPub.contentEquals(speculativeState.localDhPub)
                     )
-                    val newRetiredDhPubs = if (!cleanState.lastRemoteDhPub.isEmpty() && (shouldRetirePrevToken || isNewDhEpoch)) {
+                    val newRetiredDhPubs = if (!cleanState.lastRemoteDhPub.isEmpty() && isNewDhEpoch) {
                         (speculativeState.retiredDhPubs + cleanState.lastRemoteDhPub.toHex()).toList().takeLast(MAX_SEEN_DH_PUBS).toSet()
                     } else {
                         speculativeState.retiredDhPubs
+                    }
+
+                    val newRetiredRecvTokens = if (isNewDhEpoch) {
+                        (speculativeState.retiredRecvTokens + cleanState.recvToken.copyOf()).takeLast(MAX_SEEN_DH_PUBS)
+                    } else {
+                        speculativeState.retiredRecvTokens
                     }
 
                     val failedState =
@@ -315,8 +321,9 @@ object Session {
                             recvSeq = seq,
                             skippedMessageKeys = derivationSkippedKeys.mapValues { it.value.copyOf() },
                             needsRatchet = cleanState.needsRatchet || isNewDhEpoch,
-                            prevRecvToken = if (shouldRetirePrevToken) ByteArray(0) else if (isNewDhEpoch) cleanState.recvToken.copyOf() else cleanState.prevRecvToken.copyOf(),
+                            prevRecvToken = if (isNewDhEpoch) cleanState.recvToken.copyOf() else cleanState.prevRecvToken.copyOf(),
                             retiredDhPubs = newRetiredDhPubs,
+                            retiredRecvTokens = newRetiredRecvTokens,
                         )
                     // Also wipe any message keys derived during this failed call
                     addedSkippedKeys.forEach { it.zeroize() }

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -291,18 +291,6 @@ object Session {
                     // Decryption failure: We still want to persist the ratcheted state if the header
                     // authenticated, to prevent permanent DH desync (§5.5).
                     
-                    // Retirement Rule (§5.4.3): proves the peer has moved forward (matches current local DH key).
-                    val isValidAck = ackRemoteDhPub.contentEquals(cleanState.localDhPub) ||
-                        ackRemoteDhPub.contentEquals(cleanState.prevLocalDhPub) ||
-                        ackRemoteDhPub.contentEquals(cleanState.aliceEkPub) ||
-                        ackRemoteDhPub.contentEquals(cleanState.bobEkPub)
-
-                    // We retire the transition window once the peer has acknowledged our current local key
-                    // (the one they just saw) or our next local key (if they already saw our ratchet).
-                    val shouldRetirePrevToken = isValidAck && (
-                        ackRemoteDhPub.contentEquals(cleanState.localDhPub) || 
-                        ackRemoteDhPub.contentEquals(speculativeState.localDhPub)
-                    )
                     val newRetiredDhPubs = if (!cleanState.lastRemoteDhPub.isEmpty() && isNewDhEpoch) {
                         (speculativeState.retiredDhPubs + cleanState.lastRemoteDhPub.toHex()).toList().takeLast(MAX_SEEN_DH_PUBS).toSet()
                     } else {

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -399,6 +399,12 @@ object Session {
             } else {
                 speculativeState.retiredDhPubs
             }
+            val newRetiredRecvTokens = if (isNewDhEpoch) {
+                (speculativeState.retiredRecvTokens + cleanState.recvToken.copyOf()).takeLast(MAX_SEEN_DH_PUBS)
+            } else {
+                speculativeState.retiredRecvTokens
+            }
+
             val newState =
                 speculativeState.deepCopy().copy(
                     recvChainKey = chainKey, // Move ownership
@@ -408,6 +414,7 @@ object Session {
                     needsRatchet = cleanState.needsRatchet || isNewDhEpoch,
                     prevRecvToken = if (shouldRetirePrevToken) ByteArray(0) else if (isNewDhEpoch) cleanState.recvToken.copyOf() else cleanState.prevRecvToken.copyOf(),
                     retiredDhPubs = newRetiredDhPubs,
+                    retiredRecvTokens = newRetiredRecvTokens,
                 )
 
             return newState to decoded
@@ -483,6 +490,7 @@ object Session {
                 remoteDhPub = remoteDhPub.copyOf(),
                 lastRemoteDhPub = state.remoteDhPub.copyOf(),
                 retiredDhPubs = state.retiredDhPubs,
+                retiredRecvTokens = (state.retiredRecvTokens + state.recvToken.copyOf()).takeLast(MAX_SEEN_DH_PUBS),
                 prevSendToken = state.sendToken.copyOf(),
                 prevRecvToken = state.recvToken.copyOf(),
                 isSendTokenPending = true,

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
@@ -72,6 +72,8 @@ data class SessionState(
     // Recent DH public keys seen (to reject replays from epochs older than lastRemoteDhPub)
     // Stored as hex strings for O(1) lookup and clean serialization.
     val retiredDhPubs: Set<String> = emptySet(),
+    // Recent receiving tokens seen (to catch up peers that are multiple epochs behind)
+    val retiredRecvTokens: List<@Serializable(with = ByteArrayBase64Serializer::class) ByteArray> = emptyList(),
     // Header keys for prior epochs that still have skipped message keys in the cache.
     // Keyed by remoteDhPub.toHex(); needed to decrypt the envelope of late-arriving
     // messages from an epoch we have already ratcheted past.
@@ -114,6 +116,7 @@ data class SessionState(
             bobFp = bobFp.copyOf(),
             prevSendToken = prevSendToken.copyOf(),
             prevRecvToken = prevRecvToken.copyOf(),
+            retiredRecvTokens = retiredRecvTokens.map { it.copyOf() },
             skippedMessageKeys = skippedMessageKeys.mapValues { it.value.copyOf() },
             skippedEpochHeaderKeys = skippedEpochHeaderKeys.mapValues { it.value.copyOf() },
             headerKey = headerKey.copyOf(),

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
@@ -48,6 +48,7 @@ data class SessionState(
     // localDhPriv MUST be persisted across app restarts to allow DH ratcheting.
     @Serializable(with = ByteArrayBase64Serializer::class) val localDhPriv: ByteArray,
     @Serializable(with = ByteArrayBase64Serializer::class) val localDhPub: ByteArray,
+    @Serializable(with = ByteArrayBase64Serializer::class) val prevLocalDhPub: ByteArray = ByteArray(0),
     @Serializable(with = ByteArrayBase64Serializer::class) val remoteDhPub: ByteArray,
     // The DH public key from the epoch immediately preceding remoteDhPub. Used for
     // bucketed out-of-order message processing to prevent epoch rotation from
@@ -70,7 +71,7 @@ data class SessionState(
         > = emptyMap(),
     // Recent DH public keys seen (to reject replays from epochs older than lastRemoteDhPub)
     // Stored as hex strings for O(1) lookup and clean serialization.
-    val seenRemoteDhPubs: Set<String> = emptySet(),
+    val retiredDhPubs: Set<String> = emptySet(),
     // Header keys for prior epochs that still have skipped message keys in the cache.
     // Keyed by remoteDhPub.toHex(); needed to decrypt the envelope of late-arriving
     // messages from an epoch we have already ratcheted past.
@@ -104,6 +105,7 @@ data class SessionState(
             recvToken = recvToken.copyOf(),
             localDhPriv = localDhPriv.copyOf(),
             localDhPub = localDhPub.copyOf(),
+            prevLocalDhPub = prevLocalDhPub.copyOf(),
             remoteDhPub = remoteDhPub.copyOf(),
             lastRemoteDhPub = lastRemoteDhPub.copyOf(),
             aliceEkPub = aliceEkPub.copyOf(),
@@ -130,6 +132,7 @@ data class SessionState(
             recvSeq == other.recvSeq &&
             localDhPriv.contentEquals(other.localDhPriv) &&
             localDhPub.contentEquals(other.localDhPub) &&
+            prevLocalDhPub.contentEquals(other.prevLocalDhPub) &&
             remoteDhPub.contentEquals(other.remoteDhPub) &&
             lastRemoteDhPub.contentEquals(other.lastRemoteDhPub) &&
             aliceEkPub.contentEquals(other.aliceEkPub) &&
@@ -141,7 +144,7 @@ data class SessionState(
             isAlice == other.isAlice &&
             skippedMessageKeys.size == other.skippedMessageKeys.size &&
             skippedMessageKeys.all { (k, v) -> other.skippedMessageKeys[k]?.contentEquals(v) == true } &&
-            seenRemoteDhPubs == other.seenRemoteDhPubs &&
+            retiredDhPubs == other.retiredDhPubs &&
             skippedEpochHeaderKeys.size == other.skippedEpochHeaderKeys.size &&
             skippedEpochHeaderKeys.all { (k, v) -> other.skippedEpochHeaderKeys[k]?.contentEquals(v) == true } &&
             pn == other.pn &&
@@ -163,6 +166,7 @@ data class SessionState(
         h = 31 * h + recvSeq.hashCode()
         h = 31 * h + localDhPriv.contentHashCode()
         h = 31 * h + localDhPub.contentHashCode()
+        h = 31 * h + prevLocalDhPub.contentHashCode()
         h = 31 * h + remoteDhPub.contentHashCode()
         h = 31 * h + lastRemoteDhPub.contentHashCode()
         h = 31 * h + aliceEkPub.contentHashCode()
@@ -176,7 +180,7 @@ data class SessionState(
         var skipHash = 0
         skippedMessageKeys.forEach { (k, v) -> skipHash += 31 * k.hashCode() + v.contentHashCode() }
         h = 31 * h + skipHash
-        h = 31 * h + seenRemoteDhPubs.hashCode()
+        h = 31 * h + retiredDhPubs.hashCode()
         var epochHkHash = 0
         skippedEpochHeaderKeys.forEach { (k, v) -> epochHkHash += 31 * k.hashCode() + v.contentHashCode() }
         h = 31 * h + epochHkHash
@@ -205,8 +209,8 @@ fun SessionState.assertInvariants() {
     check(skippedEpochHeaderKeys.size <= MAX_SKIPPED_EPOCHS) {
         "skippedEpochHeaderKeys overflow: ${skippedEpochHeaderKeys.size} > $MAX_SKIPPED_EPOCHS"
     }
-    check(seenRemoteDhPubs.size <= MAX_SEEN_DH_PUBS) {
-        "seenRemoteDhPubs overflow: ${seenRemoteDhPubs.size} > $MAX_SEEN_DH_PUBS"
+    check(retiredDhPubs.size <= MAX_SEEN_DH_PUBS) {
+        "retiredDhPubs overflow: ${retiredDhPubs.size} > $MAX_SEEN_DH_PUBS"
     }
     if (isSendTokenPending) {
         check(!prevSendToken.contentEquals(sendToken) || sendSeq == 0L) {

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/AckRetirementTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/AckRetirementTest.kt
@@ -85,4 +85,4 @@ private fun exchangeKeys(): Pair<SessionState, SessionState> {
     return aliceSession to bobSession
 }
 
-private fun ByteArray.isEmpty(): Boolean = this.all { it == 0.toByte() } || this.size == 0
+private fun ByteArray.isEmpty(): Boolean = this.size == 0

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/AckRetirementTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/AckRetirementTest.kt
@@ -1,0 +1,88 @@
+package net.af0.where.e2ee
+
+import kotlin.test.*
+
+class AckRetirementTest {
+    init {
+        initializeE2eeTests()
+    }
+
+    @Test
+    fun `prevRecvToken is retired only after peer acks localDhPub`() {
+        val (aliceSession, bobSession) = exchangeKeys()
+        val loc = MessagePlaintext.Location(1.0, 2.0, 3.0, 4L)
+
+        // 1. Alice (A1) sends to Bob (B0). Alice acks B0.
+        val (alice1, msgA1) = Session.encryptMessage(aliceSession, loc)
+        
+        // Bob receives Alice's A1. A1 acks B0. Bob ratchets B0 -> B1.
+        // SpeculativeState.localDhPub = B1. SpeculativeState.prevLocalDhPub = B0.
+        // ackRemoteDhPub = B0. MATCH with prevLocalDhPub!
+        // Bob retires T0 (bootstrap window).
+        val (bob1, _) = Session.decryptMessage(bobSession, msgA1)
+        assertTrue(bob1.prevRecvToken.isEmpty(), "Bob's prevRecvToken (bootstrap) should be retired after Alice acks B0")
+        
+        // 2. Bob (B1) sends to Alice (A1). Bob acks A1.
+        val (bob2, msgB1) = Session.encryptMessage(bob1, loc)
+        
+        // Alice receives Bob's B1. B1 acks A1. Alice ratchets A1 -> A2.
+        // SpeculativeState.localDhPub = A2. SpeculativeState.prevLocalDhPub = A1.
+        // ackRemoteDhPub = A1. MATCH!
+        // Alice retires T1 (bootstrap window).
+        val (alice2, _) = Session.decryptMessage(alice1, msgB1)
+        assertTrue(alice2.prevRecvToken.isEmpty(), "Alice's prevRecvToken (bootstrap) should be retired after Bob acks A1")
+        
+        // 3. Alice (A2) sends to Bob (B1). Alice acks B1.
+        val (alice3, msgA2) = Session.encryptMessage(alice2, loc)
+        
+        // Bob receives Alice's A2. A2 acks B1. Bob ratchets B1 -> B2.
+        // SpeculativeState.localDhPub = B2. SpeculativeState.prevLocalDhPub = B1.
+        // ackRemoteDhPub = B1. MATCH!
+        // Bob retires T1 (derived from Alice-at-A1).
+        val (bob3, _) = Session.decryptMessage(bob2, msgA2)
+        assertTrue(bob3.prevRecvToken.isEmpty(), "Bob's prevRecvToken should be retired after Alice acks B1 (triggering ratchet to B2)")
+    }
+
+    @Test
+    fun `retiredDhPubs correctly rejects messages from ancient epochs`() {
+        val (aliceSession, bobSession) = exchangeKeys()
+        val loc = MessagePlaintext.Location(1.0, 2.0, 3.0, 4L)
+
+        // Epoch 0: A0, B0
+        val aliceInitialDh = aliceSession.aliceEkPub.copyOf()
+        
+        // Perform turns to advance Alice to A3, Bob to B3.
+        var aS = aliceSession
+        var bS = bobSession
+        repeat(3) {
+            val (aS1, msgA) = Session.encryptMessage(aS, loc)
+            val (bS1, _) = Session.decryptMessage(bS, msgA)
+            val (bS2, msgB) = Session.encryptMessage(bS1, loc)
+            val (aS2, _) = Session.decryptMessage(aS1, msgB)
+            aS = aS2
+            bS = bS2
+        }
+        
+        // Alice is at A3. remoteDhPub is B2. lastRemoteDhPub is B1. retiredDhPubs contains B0.
+        assertTrue(aS.retiredDhPubs.contains(bS.bobEkPub.toHex()), "Alice's retiredDhPubs should contain Bob's bootstrap key after enough turns")
+
+        // Attacker tries to replay a message from Bob's bootstrap epoch (B0)
+        val recycledEnvelope = Session.encryptHeader(aS.headerKey, bS.bobEkPub, aS.localDhPub, 1L, 0L)
+        val recycledPayload = EncryptedMessagePayload(envelope = recycledEnvelope, ct = ByteArray(32))
+
+        assertFailsWith<ReplayException> {
+            Session.decryptMessage(aS, recycledPayload)
+        }
+    }
+}
+
+private fun exchangeKeys(): Pair<SessionState, SessionState> {
+    val aliceName = "Alice"
+    val bobName = "Bob"
+    val (qr, aliceEkPriv) = KeyExchange.aliceCreateQrPayload(aliceName)
+    val (initMsg, bobSession) = KeyExchange.bobProcessQr(qr, bobName)
+    val aliceSession = KeyExchange.aliceProcessInit(initMsg, aliceEkPriv, qr.ekPub)
+    return aliceSession to bobSession
+}
+
+private fun ByteArray.isEmpty(): Boolean = this.all { it == 0.toByte() } || this.size == 0

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/DualPostReplayTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/DualPostReplayTest.kt
@@ -66,7 +66,7 @@ class DualPostReplayTest {
 
         // Create a message with a NEW DH key but TAMPERED ciphertext
         val attackerEk = generateX25519KeyPair()
-        val envelope = Session.encryptHeader(bobSession.headerKey, attackerEk.pub, 1L, 0L)
+        val envelope = Session.encryptHeader(bobSession.headerKey, attackerEk.pub, bobSession.remoteDhPub, 1L, 0L)
         val badMsg =
             EncryptedMessagePayload(
                 envelope = envelope,

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
@@ -160,8 +160,8 @@ class E2eeChaosTest {
     @Test
     fun testMultiFriendChaos() = runMultiFriendChaos(iterations = 20, minChaos = 0.0, maxChaos = 0.1)
 
+//  @Ignore
     @Test
-    @Ignore
     fun testMultiFriendChaosHighStress() = runMultiFriendChaos(iterations = 50, minChaos = 0.3, maxChaos = 0.5)
 
     private fun runMultiFriendChaos(

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
@@ -275,8 +275,13 @@ class E2eeChaosTest {
                 node.setChaos(0.0)
                 node.chaosMailbox.expireMailboxProbability = 0.0
                 node.chaosMailbox.resetExpirations()
-                // Use direct relay for recovery to ensure stable re-sync
-                node.client = LocationClient("http://fake", node.store, relay)
+                node.restart()
+                // Clear any stuck pending transition from chaos phase
+                node.store.listFriends().forEach { friend ->
+                    if (friend.session.isSendTokenPending && friend.outbox != null) {
+                        node.store.abandonPendingTransition(friend.id)
+                    }
+                }
             }
 
             repeat(1000) { i ->

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
@@ -275,35 +275,26 @@ class E2eeChaosTest {
                 node.setChaos(0.0)
                 node.chaosMailbox.expireMailboxProbability = 0.0
                 node.chaosMailbox.resetExpirations()
-                node.restart()
+                // Use direct relay for recovery to ensure stable re-sync
+                node.client = LocationClient("http://fake", node.store, relay)
             }
 
-            repeat(500) {
+            repeat(1000) { i ->
                 nodes.forEach { node ->
                     try {
+                        if (i % 50 == 0) {
+                            try {
+                                node.client.sendLocation(999.0, 999.0)
+                            } catch (e: Exception) {
+                                // Ignored
+                            }
+                        }
                         val updates = node.client.poll()
                         updates.forEach { update ->
                             node.receivedLocations.getOrPut(update.userId) { mutableSetOf() }.add(update.lat.toInt())
                         }
-                    } catch (_: Exception) {
-                    }
-                }
-            }
-            // Send recovery signal
-            nodes.forEach { node ->
-                try {
-                    node.client.sendLocation(999.0, 999.0)
-                } catch (_: Exception) {
-                }
-            }
-            repeat(500) {
-                nodes.forEach { node ->
-                    try {
-                        val updates = node.client.poll()
-                        updates.forEach { update ->
-                            node.receivedLocations.getOrPut(update.userId) { mutableSetOf() }.add(update.lat.toInt())
-                        }
-                    } catch (_: Exception) {
+                    } catch (e: Exception) {
+                        // Ignored
                     }
                 }
             }

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
@@ -276,12 +276,6 @@ class E2eeChaosTest {
                 node.chaosMailbox.expireMailboxProbability = 0.0
                 node.chaosMailbox.resetExpirations()
                 node.restart()
-                // Clear any stuck pending transition from chaos phase
-                node.store.listFriends().forEach { friend ->
-                    if (friend.session.isSendTokenPending && friend.outbox != null) {
-                        node.store.abandonPendingTransition(friend.id)
-                    }
-                }
             }
 
             repeat(1000) { i ->

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeProtocolTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeProtocolTest.kt
@@ -29,7 +29,7 @@ class E2eeProtocolTest {
             localDhPub = localKeyPair.pub,
             remoteDhPub = remoteDhPubCurrent,
             lastRemoteDhPub = remoteDhPubLast,
-            seenRemoteDhPubs = seenKeys,
+            retiredDhPubs = seenKeys,
             isAlice = true,
             aliceFp = ByteArray(32),
             bobFp = ByteArray(32),
@@ -43,11 +43,13 @@ class E2eeProtocolTest {
             isSendTokenPending = false
         )
 
+        val dummyAck = ByteArray(32)
+
         // Mock headers for different buckets
-        val hCurrent = Session.DecryptedHeader(remoteDhPubCurrent, 10, 5) // Bucket 1
-        val hLast = Session.DecryptedHeader(remoteDhPubLast, 8, 4)       // Bucket 0
-        val hAncient = Session.DecryptedHeader(remoteDhPubAncient, 6, 3) // Bucket 3 (was -1)
-        val hNew = Session.DecryptedHeader(remoteDhPubNew, 12, 6)         // Bucket 2
+        val hCurrent = Session.DecryptedHeader(remoteDhPubCurrent, dummyAck, 10, 5) // Bucket 1
+        val hLast = Session.DecryptedHeader(remoteDhPubLast, dummyAck, 8, 4)       // Bucket 0
+        val hAncient = Session.DecryptedHeader(remoteDhPubAncient, dummyAck, 6, 3) // Bucket 3 (was -1)
+        val hNew = Session.DecryptedHeader(remoteDhPubNew, dummyAck, 12, 6)         // Bucket 2
 
         // Payloads (mapped by their headers)
         val pCurrent = EncryptedMessagePayload(1, byteArrayOf(), byteArrayOf())

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/EnvelopeTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/EnvelopeTest.kt
@@ -10,16 +10,18 @@ class EnvelopeTest {
     fun testEnvelopeEncryptionDecryption() {
         val key = randomBytes(32)
         val dhPub = randomBytes(32)
+        val ackRemoteDhPub = randomBytes(32)
         val seq = 123L
         val pn = 45L
 
-        val envelope = Session.encryptHeader(key, dhPub, seq, pn)
+        val envelope = Session.encryptHeader(key, dhPub, ackRemoteDhPub, seq, pn)
 
-        // Envelope should be 12 (nonce) + 49 (plain) + 16 (tag) = 77 bytes
-        assertEquals(77, envelope.size)
+        // Envelope should be 12 (nonce) + 82 (plain) + 16 (tag) = 110 bytes
+        assertEquals(110, envelope.size)
 
         val decrypted = Session.decryptHeader(key, envelope)
         assertTrue(dhPub.contentEquals(decrypted.dhPub))
+        assertTrue(ackRemoteDhPub.contentEquals(decrypted.ackRemoteDhPub))
         assertEquals(seq, decrypted.seq)
         assertEquals(pn, decrypted.pn)
     }
@@ -29,8 +31,9 @@ class EnvelopeTest {
         val key1 = randomBytes(32)
         val key2 = randomBytes(32)
         val dhPub = randomBytes(32)
+        val ackRemoteDhPub = randomBytes(32)
 
-        val envelope = Session.encryptHeader(key1, dhPub, 1L, 0L)
+        val envelope = Session.encryptHeader(key1, dhPub, ackRemoteDhPub, 1L, 0L)
 
         assertFailsWith<AuthenticationException> {
             Session.decryptHeader(key2, envelope)
@@ -40,7 +43,9 @@ class EnvelopeTest {
     @Test
     fun testEnvelopeCorruption() {
         val key = randomBytes(32)
-        val envelope = Session.encryptHeader(key, randomBytes(32), 1L, 0L)
+        val dhPub = randomBytes(32)
+        val ackRemoteDhPub = randomBytes(32)
+        val envelope = Session.encryptHeader(key, dhPub, ackRemoteDhPub, 1L, 0L)
 
         // Corrupt a byte in the encrypted portion
         envelope[20] = (envelope[20].toInt() xor 0xFF).toByte()

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/SessionTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/SessionTest.kt
@@ -217,7 +217,7 @@ class SessionTest {
 
         // Create a message with a NEW DH key but corrupted ciphertext
         val newAliceDh = generateX25519KeyPair()
-        val envelope = Session.encryptHeader(bobSession.headerKey, newAliceDh.pub, 1L, 0L)
+        val envelope = Session.encryptHeader(bobSession.headerKey, newAliceDh.pub, bobSession.remoteDhPub, 1L, 0L)
         val badMsg =
             EncryptedMessagePayload(
                 envelope = envelope,
@@ -288,7 +288,7 @@ class SessionTest {
 
         // Attacker sends seq = 2^63 - 1
         val largeSeq = Long.MAX_VALUE
-        val envelope = Session.encryptHeader(bobSession.headerKey, bobSession.remoteDhPub, largeSeq, 0L)
+        val envelope = Session.encryptHeader(bobSession.headerKey, bobSession.remoteDhPub, bobSession.remoteDhPub, largeSeq, 0L)
         val message = EncryptedMessagePayload(envelope = envelope, ct = dummyCt)
 
         val startTime = currentTimeMillis()
@@ -494,20 +494,20 @@ class SessionTest {
                 aliceManager.processBatch(aliceToBobId, aliceRecvToken, listOf(bMsg))
             }
 
-            // 2. Perform two turns to ensure seenRemoteDhPubs is populated with Bob's old keys.
-            // Turn 1: Alice sees Bob's B0, sends A1. Bob sees A1, rotates to B1. Bob sends B1. Alice sees B1, rotates to A2. seen={B0}
+            // 2. Perform two turns to ensure retiredDhPubs is populated with Bob's old keys.
+            // Turn 1: Alice sees Bob's B0, sends A1. Bob sees A1, rotates to B1. Bob sends B1. Alice sees B1, rotates to A2. retired={B0}
             handshakeTurn()
-            // Turn 2: Alice sends A2. Bob sees A2, rotates to B2. Bob sends B2. Alice sees B2, rotates to A3. seen={B0, B1}
+            // Turn 2: Alice sends A2. Bob sees A2, rotates to B2. Bob sends B2. Alice sees B2, rotates to A3. retired={B0, B1}
             handshakeTurn()
 
-            // 3. Alice's seenRemoteDhPubs should now contain Bob's initial and intermediate keys
+            // 3. Alice's retiredDhPubs should now contain Bob's initial and intermediate keys
             val bobInitialDh = initPayload.ekPub
             val aliceSession = aliceManager.getFriend(aliceToBobId)!!.session
 
-            assertTrue(aliceSession.seenRemoteDhPubs.contains(bobInitialDh.toHex()), "seenRemoteDhPubs should have Bob's initial DH")
+            assertTrue(aliceSession.retiredDhPubs.contains(bobInitialDh.toHex()), "retiredDhPubs should have Bob's initial DH")
 
             // 4. Attacker tries to send a message (seq=1) using Bob's initial DH key
-            val recycledEnvelope = Session.encryptHeader(aliceSession.headerKey, bobInitialDh, 1L, 0L)
+            val recycledEnvelope = Session.encryptHeader(aliceSession.headerKey, bobInitialDh, aliceSession.localDhPub, 1L, 0L)
             val recycledPayload = EncryptedMessagePayload(envelope = recycledEnvelope, ct = ByteArray(32))
 
             assertFailsWith<ReplayException> {


### PR DESCRIPTION
Key changes:
- Update SessionState to track retiredDhPubs and prevLocalDhPub.
- Add ack_remote_dh_pub to metadata envelope (increasing header to 82 bytes).
- Implement explicit retirement rule (§5.4.3): prevRecvToken is only cleared
  after peer acknowledges our current or next local DH key.
- Move lastRemoteDhPub to retiredDhPubs on epoch rotation to prevent
  long-term replays.
- Update AAD to cryptographically bind ack_remote_dh_pub.
- Ensure state transitions are committed even on payload decryption
  failures (if header authenticates) to prevent DH desync.
