### PR TITLE
Remove unused pn field from MessagePlaintext

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -36,14 +36,7 @@ object Session {
         val (sender, recipient) = if (currentState.isAlice) currentState.aliceFp to currentState.bobFp else currentState.bobFp to currentState.aliceFp
         val aad = buildMessageAad(sender, recipient, seq, dhPub, ackRemoteDhPub)
 
-        // PH-3.3 (BELT-AND-SUSPENDERS): Ensure internal 'pn' matches what we put in the header (#212)
-        val updatedPayload =
-            when (payload) {
-                is MessagePlaintext.Location -> payload.copy(pn = currentState.pn)
-                is MessagePlaintext.Keepalive -> payload.copy(pn = currentState.pn)
-            }
-
-        val plaintext = padToFixedSize(encodeMessage(updatedPayload), PADDING_SIZE)
+        val plaintext = padToFixedSize(encodeMessage(payload), PADDING_SIZE)
         val ct = aeadEncrypt(step.messageKey, step.messageNonce, plaintext, aad)
 
         val newState =
@@ -583,12 +576,10 @@ object Session {
                     // empty object
                 }
             }
-            put("pn", msg.pn)
         }.let { Json.encodeToString(it) }.encodeToByteArray()
 
     private fun decodeMessage(bytes: ByteArray): MessagePlaintext {
         val obj = Json.decodeFromString<JsonObject>(bytes.decodeToString())
-        val pn = obj["pn"]?.jsonPrimitive?.long ?: 0L
         return if (obj.containsKey("lat")) {
             MessagePlaintext.Location(
                 lat = obj["lat"]!!.jsonPrimitive.double,
@@ -596,10 +587,9 @@ object Session {
                 acc = obj["acc"]!!.jsonPrimitive.double,
                 ts = obj["ts"]!!.jsonPrimitive.long,
                 precision = obj["precision"]?.jsonPrimitive?.content?.let { LocationPrecision.valueOf(it) } ?: LocationPrecision.FINE,
-                pn = pn,
             )
         } else {
-            MessagePlaintext.Keepalive(pn = pn)
+            MessagePlaintext.Keepalive()
         }
     }
 
@@ -637,15 +627,12 @@ object Session {
 }
 
 sealed class MessagePlaintext {
-    abstract val pn: Long
-
     data class Location(
         val lat: Double,
         val lng: Double,
         val acc: Double,
         val ts: Long,
         val precision: LocationPrecision = LocationPrecision.FINE,
-        override val pn: Long = 0,
     ) : MessagePlaintext() {
         fun blur(): Location =
             if (precision == LocationPrecision.COARSE) {
@@ -659,7 +646,7 @@ sealed class MessagePlaintext {
             }
     }
 
-    data class Keepalive(override val pn: Long = 0) : MessagePlaintext()
+    class Keepalive : MessagePlaintext()
 }
 
 class SessionBrickedException(message: String) : WhereException(message)

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/GapFillTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/GapFillTest.kt
@@ -101,6 +101,6 @@ class GapFillTest {
 
             // 6. Decrypt and check pn. Bob must use bS2 because it has his new DH key B1.
             val (_, dec) = Session.decryptMessage(bS2, m1)
-            assertEquals(5L, dec.pn, "Plaintext pn should be injected by encryptMessage")
+            assertTrue(dec is MessagePlaintext.Location)
         }
 }


### PR DESCRIPTION
I have removed the `pn` field from the `MessagePlaintext` sealed class and its subclasses (`Location`, `Keepalive`) in the `shared` module. This field was redundant because it is already securely transmitted in the message header. 

I updated the encryption and decryption logic in `Session.kt` to remove the JSON serialization of this field. I also updated `GapFillTest.kt` to remove outdated assertions and verified that all other tests still compile and pass, as they were using positional arguments that remain compatible with the updated constructor signatures. 

The `pn` field remains in `SessionState` and `DecryptedHeader`, where it is still used for the protocol's chronological sorting and gap-filling logic.

---
*PR created automatically by Jules for task [13218299917683671530](https://jules.google.com/task/13218299917683671530) started by @danmarg*