### PR TITLE
Improve background location reliability (Android + iOS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ local.gradle.kts
 xcuserdata/
 *.xcworkspace/xcuserdata/
 DerivedData/
+*.xcresult/
 .build/
 *.log
 *.db

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -148,6 +148,7 @@ dependencies {
     implementation(libs.zxing.core)
     implementation(libs.zxing.android.embedded)
     implementation(libs.moko.resources.compose)
+    implementation(libs.work.runtime.ktx)
 
     debugImplementation(libs.compose.ui.test.manifest)
 }

--- a/android/src/androidMain/AndroidManifest.xml
+++ b/android/src/androidMain/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:name=".WhereApplication"

--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -7,11 +7,13 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import android.net.Network
 import android.os.IBinder
+import android.os.PowerManager
 import android.os.SystemClock
 import android.util.Log
 import androidx.annotation.VisibleForTesting
@@ -70,6 +72,7 @@ class LocationService : Service() {
     internal var uiStateStoreOverride: UiStateSource? = null
 
     private lateinit var alarmManager: AlarmManager
+    private lateinit var pollWakeLock: PowerManager.WakeLock
     private lateinit var fusedClient: com.google.android.gms.location.FusedLocationProviderClient
     private lateinit var activityRecognitionClient: ActivityRecognitionClient
     private lateinit var locationCallback: LocationCallback
@@ -129,6 +132,10 @@ class LocationService : Service() {
         startForeground(NOTIFICATION_ID, buildNotification())
 
         alarmManager = getSystemService(AlarmManager::class.java)
+        pollWakeLock = (getSystemService(Context.POWER_SERVICE) as PowerManager)
+            .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "where:poll_alarm").also {
+                it.setReferenceCounted(false)
+            }
 
         e2eeManager = e2eeManagerOverride ?: app.e2eeManager
         locationClient = locationClientOverride ?: app.locationClient
@@ -252,8 +259,11 @@ class LocationService : Service() {
         }
 
         if (intent?.action == ACTION_POLL_ALARM) {
+            // Acquire a wakelock so the CPU stays awake for the GPS fix + network send.
+            // setExactAndAllowWhileIdle wakes the CPU but doesn't hold it; without this
+            // the device can sleep again before forceLocationUpdateAndGet() completes.
+            if (!pollWakeLock.isHeld) pollWakeLock.acquire(60_000L)
             locationSource.wakePoll()
-            serviceScope.launch { doPoll() }
         }
         if (intent?.action == ACTION_FORCE_PUBLISH) {
             val friendId = intent.getStringExtra(EXTRA_FRIEND_ID)

--- a/android/src/androidMain/kotlin/net/af0/where/LocationServiceRestartWorker.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationServiceRestartWorker.kt
@@ -1,0 +1,26 @@
+package net.af0.where
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+
+class LocationServiceRestartWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        Log.i(TAG, "WorkManager heartbeat: ensuring LocationService is running")
+        applicationContext.startForegroundService(
+            Intent(applicationContext, LocationService::class.java)
+        )
+        return Result.success()
+    }
+
+    companion object {
+        private const val TAG = "LocationServiceRestartWorker"
+        const val WORK_NAME = "location_service_keepalive"
+    }
+}

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -2,26 +2,33 @@ package net.af0.where
 
 import android.Manifest
 import android.app.Application
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Looper
+import android.os.PowerManager
 import android.util.Log
 import androidx.annotation.MainThread
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.TimeUnit
 import net.af0.where.e2ee.ConnectionStatus
 import net.af0.where.e2ee.E2eeManager
 import net.af0.where.e2ee.FriendEntry
@@ -112,6 +119,9 @@ class LocationViewModel(
 
     val connectionStatus: StateFlow<ConnectionStatus> = locationSource.connectionStatus
     val diagnosticLog: StateFlow<List<String>> = e2eeManager.diagnosticLog
+
+    private val _showBatteryOptimizationDialog = MutableStateFlow(false)
+    val showBatteryOptimizationDialog: StateFlow<Boolean> = _showBatteryOptimizationDialog.asStateFlow()
 
     val ownLocation: StateFlow<UserLocation?> =
         combine(locationSource.lastLocation, isSharingLocation) { myLoc, sharing ->
@@ -471,6 +481,13 @@ class LocationViewModel(
         }
     }
 
+    fun dismissBatteryOptimizationDialog() {
+        _showBatteryOptimizationDialog.value = false
+        getApplication<Application>()
+            .getSharedPreferences("where_prefs", Context.MODE_PRIVATE)
+            .edit().putBoolean("battery_opt_asked", true).apply()
+    }
+
     @MainThread
     private fun manageForegroundService(
         sharing: Boolean,
@@ -485,6 +502,19 @@ class LocationViewModel(
                 PackageManager.PERMISSION_GRANTED
         if ((sharing && hasLocationPermission) || inForeground) {
             getApplication<Application>().startForegroundService(intent)
+            WorkManager.getInstance(getApplication()).enqueueUniquePeriodicWork(
+                LocationServiceRestartWorker.WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                PeriodicWorkRequestBuilder<LocationServiceRestartWorker>(15, TimeUnit.MINUTES).build(),
+            )
+            if (sharing) {
+                val pm = getApplication<Application>().getSystemService(Context.POWER_SERVICE) as PowerManager
+                val pkg = getApplication<Application>().packageName
+                val prefs = getApplication<Application>().getSharedPreferences("where_prefs", Context.MODE_PRIVATE)
+                if (!pm.isIgnoringBatteryOptimizations(pkg) && !prefs.getBoolean("battery_opt_asked", false)) {
+                    _showBatteryOptimizationDialog.value = true
+                }
+            }
         }
         // Intentionally no stopService() here: when sharing is paused the service must remain
         // alive for maintenance polls (ratchet keepalives, token ACKs) so the Double Ratchet

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -502,11 +502,15 @@ class LocationViewModel(
                 PackageManager.PERMISSION_GRANTED
         if ((sharing && hasLocationPermission) || inForeground) {
             getApplication<Application>().startForegroundService(intent)
-            WorkManager.getInstance(getApplication()).enqueueUniquePeriodicWork(
-                LocationServiceRestartWorker.WORK_NAME,
-                ExistingPeriodicWorkPolicy.KEEP,
-                PeriodicWorkRequestBuilder<LocationServiceRestartWorker>(15, TimeUnit.MINUTES).build(),
-            )
+            try {
+                WorkManager.getInstance(getApplication()).enqueueUniquePeriodicWork(
+                    LocationServiceRestartWorker.WORK_NAME,
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    PeriodicWorkRequestBuilder<LocationServiceRestartWorker>(15, TimeUnit.MINUTES).build(),
+                )
+            } catch (_: IllegalStateException) {
+                Log.w(TAG, "WorkManager not available")
+            }
             if (sharing) {
                 val pm = getApplication<Application>().getSystemService(Context.POWER_SERVICE) as PowerManager
                 val pkg = getApplication<Application>().packageName

--- a/android/src/androidMain/kotlin/net/af0/where/MainActivity.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/MainActivity.kt
@@ -3,7 +3,10 @@ package net.af0.where
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
+import android.os.PowerManager
+import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -228,6 +231,30 @@ class MainActivity : ComponentActivity() {
                         dismissButton = {
                             TextButton(onClick = { showCameraSettingsRationale = false }) {
                                 Text(stringResource(MR.strings.cancel))
+                            }
+                        },
+                    )
+                }
+
+                val showBatteryOptimizationDialog by viewModel.showBatteryOptimizationDialog.collectAsState()
+                if (showBatteryOptimizationDialog) {
+                    AlertDialog(
+                        onDismissRequest = { viewModel.dismissBatteryOptimizationDialog() },
+                        title = { Text("Improve background updates") },
+                        text = { Text("For reliable location sharing when the screen is off, allow Where to run without battery restrictions.") },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                viewModel.dismissBatteryOptimizationDialog()
+                                startActivity(
+                                    Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                                        data = Uri.parse("package:$packageName")
+                                    }
+                                )
+                            }) { Text("Allow") }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { viewModel.dismissBatteryOptimizationDialog() }) {
+                                Text("Skip")
                             }
                         },
                     )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ jedis = "5.2.0"
 libsodium = "0.9.5"
 security-crypto = "1.1.0-alpha06"
 moko-resources = "0.24.5"
+work = "2.9.1"
 
 [libraries]
 # Moko Resources
@@ -76,6 +77,9 @@ security-crypto = { module = "androidx.security:security-crypto", version.ref = 
 
 # Splash Screen
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version = "1.0.1" }
+
+# WorkManager
+work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 
 # Redis
 jedis = { module = "redis.clients:jedis", version.ref = "jedis" }

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -45,7 +45,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         super.init()
         m.delegate = self
         m.desiredAccuracy = kCLLocationAccuracyHundredMeters
-        m.distanceFilter = 50 // meters — heartbeat timer covers stationary case
+        m.distanceFilter = kCLDistanceFilterNone // deliver every fix so app stays awake in background
         m.headingFilter = 5 // degrees
     }
 
@@ -134,14 +134,15 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                 self.manager?.distanceFilter = 20
                 self.manager?.activityType = .automotiveNavigation
             } else {
-                // Stationary, walking, or speed unavailable: conserve battery.
-                self.manager?.distanceFilter = 50
+                // Stationary or walking: deliver every fix so the heartbeat timer
+                // can fire in background even when position doesn't change much.
+                self.manager?.distanceFilter = kCLDistanceFilterNone
                 self.manager?.activityType = .other
             }
 
             LocationSyncService.shared.sendLocation(lat: coordinate.latitude, lng: coordinate.longitude, heading: self.heading)
-            // Ensure we also poll for updates when the OS wakes us for a location fix.
-            await LocationSyncService.shared.pollAll(updateUi: false)
+            // Don't call pollAll here — tick() fires within 1s and will poll if the
+            // interval has elapsed, without over-polling on every position jitter.
         }
     }
 

--- a/ios/Tests/WhereTests/LocationOptimizationsTests.swift
+++ b/ios/Tests/WhereTests/LocationOptimizationsTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+import CoreLocation
+import Combine
+@preconcurrency import Shared
+@testable import Where
+
+@MainActor
+class LocationOptimizationsTests: XCTestCase {
+    var service: LocationSyncService!
+    var mockLocationProvider: MockLocationProvider!
+    var mockLocationClient: MockLocationClient!
+
+    @MainActor
+    class MockLocationProvider: LocationProviding {
+        @Published var location: CLLocation? = nil
+        var locationPublisher: AnyPublisher<CLLocation?, Never> { $location.eraseToAnyPublisher() }
+        var lastLocation: CLLocation? { location }
+        
+        var requestPermissionAndStartCalled = false
+        func requestPermissionAndStart() { requestPermissionAndStartCalled = true }
+        
+        var requestImmediateLocationCalled = false
+        func requestImmediateLocation() { requestImmediateLocationCalled = true }
+        
+        func sharingStateChanged() {}
+    }
+
+    @MainActor
+    class MockLocationClient: LocationSyncServiceTests.MockLocationClient {
+        var sendLocationCallCount = 0
+        override func sendLocation(lat: Double, lng: Double, pausedFriendIds: Set<String>) async throws {
+            sendLocationCallCount += 1
+            try await super.sendLocation(lat: lat, lng: lng, pausedFriendIds: pausedFriendIds)
+        }
+    }
+
+    override func setUp() async throws {
+        self.mockLocationProvider = MockLocationProvider()
+        self.mockLocationClient = MockLocationClient()
+        let e2eeManager = Shared.E2eeManager(sqlDriver: Shared.IosSqlDriverKt.createIosSqlDriver(name: ":memory:"))
+        let userStore = Shared.UserStore(storage: LocationSyncServiceTests.MockRawKeyValueStorage())
+        self.service = LocationSyncService(e2eeManager: e2eeManager, userStore: userStore, locationClient: mockLocationClient, locationProvider: mockLocationProvider)
+        self.service.beginBackgroundTask = { _, _ in .invalid }
+        self.service.endBackgroundTask = { _ in }
+    }
+
+    func testHeartbeat_CallsRequestImmediateLocation() async throws {
+        service.isSharingLocation = true
+        service.lastSentTime = Date(timeIntervalSinceNow: -301) // > 5 mins
+        
+        // This is tricky because tick() runs in a loop with Timer.
+        // We can manually call tick() to simulate the timer fire.
+        // But tick() is private. We can test the pollAll path instead.
+        
+        await service.pollAll(updateUi: false)
+        
+        XCTAssertTrue(mockLocationProvider.requestImmediateLocationCalled, 
+            "pollAll should call requestImmediateLocation if heartbeat is due")
+    }
+
+    func testMotionAdaptiveSettings() async throws {
+        let locationManager = LocationManager.shared
+        let manager = CLLocationManager()
+        locationManager.manager = manager
+        
+        // 1. Simulate fast movement
+        let fastLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            course: 0,
+            speed: 10, // 10 m/s > 5 m/s
+            timestamp: Date()
+        )
+        
+        locationManager.locationManager(manager, didUpdateLocations: [fastLocation])
+        
+        // Wait for Task @MainActor
+        try await Task.sleep(nanoseconds: 100_000_000)
+        
+        XCTAssertEqual(manager.distanceFilter, 20)
+        XCTAssertEqual(manager.activityType, .automotiveNavigation)
+        
+        // 2. Simulate slow movement
+        let slowLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            course: 0,
+            speed: 2, // 2 m/s < 5 m/s
+            timestamp: Date()
+        )
+        
+        locationManager.locationManager(manager, didUpdateLocations: [slowLocation])
+        
+        try await Task.sleep(nanoseconds: 100_000_000)
+        
+        XCTAssertEqual(manager.distanceFilter, 50)
+        XCTAssertEqual(manager.activityType, .other)
+    }
+
+}

--- a/ios/Tests/WhereTests/LocationOptimizationsTests.swift
+++ b/ios/Tests/WhereTests/LocationOptimizationsTests.swift
@@ -97,7 +97,7 @@ class LocationOptimizationsTests: XCTestCase {
         
         try await Task.sleep(nanoseconds: 100_000_000)
         
-        XCTAssertEqual(manager.distanceFilter, 50)
+        XCTAssertEqual(manager.distanceFilter, kCLDistanceFilterNone)
         XCTAssertEqual(manager.activityType, .other)
     }
 


### PR DESCRIPTION
## Summary

- **Android: CPU wakelock during poll alarm** — `setExactAndAllowWhileIdle` wakes the CPU but doesn't hold it; added a `PARTIAL_WAKE_LOCK` so the device stays awake long enough to complete the GPS fix and network send
- **Android: WorkManager 15-min keepalive** — belt-and-suspenders periodic task that restarts the foreground service if the OS kills it (OEM memory pressure, etc.)
- **Android: Battery optimization exemption prompt** — shown once when sharing is first enabled, explaining why unrestricted background operation is needed; navigates to system settings if user allows
- **Android: Remove duplicate `doPoll()` in alarm handler** — `wakePoll()` already wakes the poll loop; the extra direct launch was redundant
- **iOS: `distanceFilter = kCLDistanceFilterNone` when stationary** — with `kCLLocationAccuracyHundredMeters` (WiFi/cell only), iOS position estimates jitter every 1–5 min even when stationary; delivering every fix keeps the app awake in background so the heartbeat timer can fire. Previously `distanceFilter = 50m` suppressed all stationary jitter and the app would sleep for hours.
- **iOS: Stop over-polling on location callbacks** — removed `pollAll()` from `didUpdateLocations`; `tick()` fires within 1s when the app wakes and polls on the configured schedule, preventing a network request on every position jitter
- **gitignore: add `*.xcresult/`**

## Test plan

- [ ] Android: enable sharing, put phone face-down for 30+ min, verify updates appear at least every 5 min
- [ ] Android: on a fresh install with battery optimization active, verify the dialog appears on first share toggle
- [ ] Android: kill the app from recents while sharing, verify WorkManager restarts it within 15 min
- [ ] iOS: enable sharing, lock screen for 30+ min, verify updates appear at ~5 min intervals
- [ ] iOS: verify battery usage is not significantly higher than before (WiFi/cell location, no GPS chip)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)