### PR TITLE
Android+iOS: improve background location reliability

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -338,7 +338,7 @@ class LocationService : Service() {
         val request =
             LocationRequest.Builder(currentPriority, currentInterval)
                 .setMinUpdateIntervalMillis(1_000L) // PASSIVE PIGGYBACKING (§1.1): Allow high-freq updates from other apps.
-                .setMinUpdateDistanceMeters(10f)
+                .setMinUpdateDistanceMeters(0f)
                 .setMaxUpdateDelayMillis(60_000L)
                 .build()
 
@@ -497,7 +497,9 @@ class LocationService : Service() {
                 }
             }
             val interval = pollInterval(rapid, inForeground, isSharing)
-            if (interval >= 5 * 60 * 1000L) scheduleDozeAlarm(interval)
+            // Always schedule a doze alarm as a fallback wakeup, even during rapid polling.
+            // Without this, backgrounding during key exchange can silently stall the service.
+            scheduleDozeAlarm(maxOf(interval, STATIONARY_FORCE_UPDATE_THRESHOLD_MS))
             locationSource.awaitPollWake(interval)
             cancelDozeAlarm()
         }
@@ -632,8 +634,8 @@ class LocationService : Service() {
             sendLock.withLock {
                 val canSend =
                     force || lastSentTime == 0L ||
-                        !isHeartbeat ||
-                        (isHeartbeat && now - lastSentTime > 300_000L)
+                        (!isHeartbeat && now - lastSentTime > MIN_SEND_INTERVAL_MS) ||
+                        (isHeartbeat && now - lastSentTime > HEARTBEAT_INTERVAL_MS)
                 if (canSend) {
                     lastSentTime = now
                     true
@@ -739,6 +741,12 @@ class LocationService : Service() {
          * flow even when the OS throttles streaming updates in sleep mode.
          */
         const val STATIONARY_FORCE_UPDATE_THRESHOLD_MS = 5 * 60 * 1000L
+
+        /** Minimum interval between non-heartbeat (movement-triggered) location sends. */
+        const val MIN_SEND_INTERVAL_MS = 30_000L
+
+        /** Interval between heartbeat sends when stationary. */
+        const val HEARTBEAT_INTERVAL_MS = 300_000L
 
         /** Overridable in tests. */
         var clock: () -> Long = { System.currentTimeMillis() }

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -114,10 +114,14 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         let coordinate = loc.coordinate
         let speed = loc.speed
 
+        // Acquire the background task synchronously before yielding to MainActor.
+        // If we deferred this into the Task body, iOS could suspend the process in the
+        // gap between the delegate callback returning and the Task actually executing.
+        let identifier = MainActor.assumeIsolated {
+            UIApplication.shared.beginBackgroundTask(withName: "LocationUpdate") { }
+        }
+
         Task { @MainActor in
-            let identifier = UIApplication.shared.beginBackgroundTask(withName: "LocationUpdate") {
-                // Task expired
-            }
             defer {
                 if identifier != .invalid {
                     UIApplication.shared.endBackgroundTask(identifier)
@@ -162,7 +166,13 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     }
 
     nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        // Required for requestLocation()
+        // kCLErrorLocationUnknown is transient; the system retries automatically.
+        // Any other error means requestLocation() gave up — schedule a fresh attempt.
+        if (error as? CLError)?.code != .locationUnknown {
+            Task { @MainActor in
+                self.requestImmediateLocation()
+            }
+        }
     }
 
     nonisolated func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -166,13 +166,9 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     }
 
     nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        // kCLErrorLocationUnknown is transient; the system retries automatically.
-        // Any other error means requestLocation() gave up — schedule a fresh attempt.
-        if (error as? CLError)?.code != .locationUnknown {
-            Task { @MainActor in
-                self.requestImmediateLocation()
-            }
-        }
+        // Required for requestLocation(). The system retries automatically on
+        // kCLErrorLocationUnknown; other errors mean the fix was permanently unavailable,
+        // and the heartbeat fallback will send lastSentLocation instead.
     }
 
     nonisolated func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -261,19 +261,9 @@ final class LocationSyncService: ObservableObject {
                 await pollAll()
             }
         }
-
-        // Heartbeat: Send location periodically if sharing.
-        // We use a 5-minute threshold for stationary updates, similar to Android.
-        if isSharingLocation {
-            let heartbeatInterval: TimeInterval = 300.0 // 5 minutes
-            if now.timeIntervalSince(lastSentTime) >= heartbeatInterval {
-                logger.info("tick: stationary heartbeat — sending best available location and requesting fresh fix")
-                if let loc = bestAvailableLocation {
-                    sendLocation(lat: loc.lat, lng: loc.lng, heading: loc.heading, force: true)
-                }
-                locationProvider.requestImmediateLocation()
-            }
-        }
+        // Heartbeat sends are handled inside pollAll() so they fire on every wakeup
+        // path (CLLocation callbacks, visit monitoring, background-app-refresh), not
+        // just on this 1-second timer tick.
     }
 
     @MainActor


### PR DESCRIPTION
- Android: always schedule a Doze alarm (not just on ≥5-min intervals) so the service wakes correctly when backgrounded during key exchange
- Android: remove 10f distance filter on primary location request so stationary devices still receive fused updates
- Android: apply 30s minimum send interval to movement-triggered sends (previously every fused callback was an unbounded network send)
- iOS: acquire background task synchronously in nonisolated delegate before dispatching to MainActor, closing the suspension gap
- iOS: retry requestImmediateLocation() on non-transient CLError
- iOS: consolidate heartbeat sends into pollAll() only; remove duplicate check from tick()