### PR TITLE
Ios background location improvements

### DIFF
--- a/ios/Sources/Where/Info.plist
+++ b/ios/Sources/Where/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2</string>
+	<string>1.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSCameraUsageDescription</key>

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -26,6 +26,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     internal var manager: CLLocationManager?
     private var stationaryStart: Date?
     private var geofenceRegion: CLCircularRegion?
+    private var preGeofenceAccuracy: CLLocationAccuracy = kCLLocationAccuracyHundredMeters
 
     private static let lastLatKey = "location_last_lat"
     private static let lastLngKey = "location_last_lng"
@@ -179,6 +180,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         region.notifyOnEntry = false
         manager.startMonitoring(for: region)
         self.geofenceRegion = region
+        preGeofenceAccuracy = manager.desiredAccuracy
 
         // Switch to lowest-power accuracy instead of stopping GPS entirely.
         // Stopping startUpdatingLocation() would exit background-location mode and
@@ -195,7 +197,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         manager.stopMonitoring(for: region)
         self.geofenceRegion = nil
         self.stationaryStart = nil
-        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        manager.desiredAccuracy = preGeofenceAccuracy
         LocationSyncService.shared.e2eeManager.addDiagnosticEvent(message: "Moving: Geofence removed, GPS restored")
     }
 

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -165,7 +165,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
             // Skip sends from low-accuracy network fixes (e.g. while geofence is active and
             // GPS is throttled to kCLLocationAccuracyThreeKilometers). These fixes keep the
             // RunLoop alive but their coordinates are too noisy to broadcast to friends.
-            if loc.horizontalAccuracy <= 200 {
+            if loc.horizontalAccuracy <= LocationSyncService.minBroadcastAccuracyMeters {
                 LocationSyncService.shared.sendLocation(lat: coordinate.latitude, lng: coordinate.longitude, heading: self.heading, source: .locationUpdate)
             }
             // Don't call pollAll here — tick() fires within 1s and will poll if the

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -175,11 +175,14 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         manager.startMonitoring(for: region)
         self.geofenceRegion = region
 
-        // HYBRID HEARTBEAT (§3.3): Stop continuous GPS. The 5-minute timer in
-        // LocationSyncService will continue to call requestLocation() to
-        // provide heartbeats while stationary.
-        manager.stopUpdatingLocation()
-        LocationSyncService.shared.e2eeManager.addDiagnosticEvent(message: "Stationary: Geofence set, GPS throttled")
+        // Switch to lowest-power accuracy instead of stopping GPS entirely.
+        // Stopping startUpdatingLocation() would exit background-location mode and
+        // suspend the RunLoop, causing the 1-second pollTimer to stop firing and
+        // breaking heartbeat delivery until BGAppRefreshTask fires (iOS may delay
+        // this by 30+ min). kCLLocationAccuracyThreeKilometers uses cell/WiFi
+        // positioning at negligible battery cost and keeps the RunLoop alive.
+        manager.desiredAccuracy = kCLLocationAccuracyThreeKilometers
+        LocationSyncService.shared.e2eeManager.addDiagnosticEvent(message: "Stationary: Geofence set, GPS throttled to 3km accuracy")
     }
 
     private func removeGeofence() {
@@ -187,7 +190,8 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         manager.stopMonitoring(for: region)
         self.geofenceRegion = nil
         self.stationaryStart = nil
-        LocationSyncService.shared.e2eeManager.addDiagnosticEvent(message: "Moving: Geofence removed")
+        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        LocationSyncService.shared.e2eeManager.addDiagnosticEvent(message: "Moving: Geofence removed, GPS restored")
     }
 
     nonisolated func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -161,7 +161,12 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                 }
             }
 
-            LocationSyncService.shared.sendLocation(lat: coordinate.latitude, lng: coordinate.longitude, heading: self.heading, source: .locationUpdate)
+            // Skip sends from low-accuracy network fixes (e.g. while geofence is active and
+            // GPS is throttled to kCLLocationAccuracyThreeKilometers). These fixes keep the
+            // RunLoop alive but their coordinates are too noisy to broadcast to friends.
+            if loc.horizontalAccuracy <= 200 {
+                LocationSyncService.shared.sendLocation(lat: coordinate.latitude, lng: coordinate.longitude, heading: self.heading, source: .locationUpdate)
+            }
             // Don't call pollAll here — tick() fires within 1s and will poll if the
             // interval has elapsed, without over-polling on every position jitter.
         }

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -258,6 +258,8 @@ final class LocationSyncService: ObservableObject {
         // interval check and — if a poll is stuck in-flight — triggers the 90s reset path.
         lastPollTime = .distantPast
         // Proactively send own location so friends see us immediately (subject to 30s throttle).
+        // sendLocation() updates lastSentTime synchronously, so pollAll()'s heartbeat guard
+        // (elapsed >= 300s) will not fire a second send even if a heartbeat was overdue.
         if isSharingLocation, let loc = bestAvailableLocation {
             sendLocation(lat: loc.lat, lng: loc.lng, heading: loc.heading, source: .manual)
         }

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -110,9 +110,11 @@ final class LocationSyncService: ObservableObject {
 
     private var lastSentLocation: (lat: Double, lng: Double)? = nil
 
-    /// Best available location for heartbeat sends: live GPS first, then last sent.
+    /// Best available location for heartbeat sends: accurate GPS fix first, then last sent.
+    /// Low-accuracy network fixes (e.g. from stationary cell-tower positioning) are skipped
+    /// so a 3km drift doesn't overwrite a precise known location in friends' maps.
     private var bestAvailableLocation: (lat: Double, lng: Double, heading: Double?)? {
-        if let loc = locationProvider.lastLocation {
+        if let loc = locationProvider.lastLocation, loc.horizontalAccuracy >= 0, loc.horizontalAccuracy <= 200 {
             return (lat: loc.coordinate.latitude, lng: loc.coordinate.longitude, heading: (locationProvider as? LocationManager)?.heading)
         }
         if let last = lastSentLocation {

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -104,6 +104,9 @@ final class LocationSyncService: ObservableObject {
     private static let foregroundPollInterval: TimeInterval = 10.0
     private static let normalPollInterval: TimeInterval = 300.0 // 5 min (background sharing)
     private static let maintenancePollInterval: TimeInterval = 30 * 60  // ack-only when not sharing
+    /// Fixes with horizontalAccuracy above this threshold are cell/WiFi network fixes too noisy
+    /// to broadcast; only sub-200m GPS fixes are sent to friends or used for heartbeats.
+    static let minBroadcastAccuracyMeters: CLLocationAccuracy = 200
     private var visibleUsersCancellables = Set<AnyCancellable>()
     private let pathMonitor = NWPathMonitor()
     private let monitorQueue = DispatchQueue(label: "NWPathMonitorQueue")
@@ -114,7 +117,7 @@ final class LocationSyncService: ObservableObject {
     /// Low-accuracy network fixes (e.g. from stationary cell-tower positioning) are skipped
     /// so a 3km drift doesn't overwrite a precise known location in friends' maps.
     private var bestAvailableLocation: (lat: Double, lng: Double, heading: Double?)? {
-        if let loc = locationProvider.lastLocation, loc.horizontalAccuracy >= 0, loc.horizontalAccuracy <= 200 {
+        if let loc = locationProvider.lastLocation, loc.horizontalAccuracy >= 0, loc.horizontalAccuracy <= Self.minBroadcastAccuracyMeters {
             return (lat: loc.coordinate.latitude, lng: loc.coordinate.longitude, heading: (locationProvider as? LocationManager)?.heading)
         }
         if let last = lastSentLocation {

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -251,6 +251,22 @@ final class LocationSyncService: ObservableObject {
         pollTimer?.fire()
     }
 
+    func onForegroundEntry() {
+        // Reset lastPollTime to .distantPast so the next pollAll() call bypasses the
+        // interval check and — if a poll is stuck in-flight — triggers the 90s reset path.
+        lastPollTime = .distantPast
+        // Proactively send own location so friends see us immediately (subject to 30s throttle).
+        if isSharingLocation, let loc = bestAvailableLocation {
+            sendLocation(lat: loc.lat, lng: loc.lng, heading: loc.heading, source: .manual)
+        }
+        // Request a fresh high-accuracy fix; result arrives via didUpdateLocations.
+        locationProvider.requestImmediateLocation()
+        // Fire a poll directly rather than through the timer to minimize foreground latency.
+        Task { @MainActor in
+            await pollAll(updateUi: true, source: .manual)
+        }
+    }
+
     func startPolling() {
         pollTimer?.invalidate()
         pollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in

--- a/ios/Sources/Where/WhereApp.swift
+++ b/ios/Sources/Where/WhereApp.swift
@@ -34,7 +34,7 @@ struct WhereApp: App {
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {
-                LocationSyncService.shared.wakePoll()
+                LocationSyncService.shared.onForegroundEntry()
             } else if newPhase == .background {
                 scheduleHeartbeatTask()
             }

--- a/ios/Tests/WhereTests/LocationSyncServiceTests.swift
+++ b/ios/Tests/WhereTests/LocationSyncServiceTests.swift
@@ -366,6 +366,58 @@ class LocationSyncServiceTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 1.0)
     }
 
+    // MARK: - onForegroundEntry
+
+    func testOnForegroundEntry_RequestsImmediateLocation() async throws {
+        service.onForegroundEntry()
+        XCTAssertTrue(mockLocationProvider.requestImmediateLocationCalled,
+            "onForegroundEntry must request an immediate GPS fix")
+    }
+
+    func testOnForegroundEntry_SendsLocationWhenSharingAndAvailable() async throws {
+        let mockClient = MockLocationClient()
+        service = LocationSyncService(e2eeManager: service.e2eeManager, userStore: service.userStore, locationClient: mockClient, locationProvider: mockLocationProvider)
+        service.beginBackgroundTask = { _, _ in .invalid }
+        service.endBackgroundTask = { _ in }
+        service.isSharingLocation = true
+        service.lastSentTime = Date(timeIntervalSinceNow: -60)
+        mockLocationProvider.location = CLLocation(latitude: 37.7, longitude: -122.4)
+
+        let expectation = XCTestExpectation(description: "Location sent on foreground entry")
+        mockClient.sendLocationCallback = { expectation.fulfill() }
+
+        service.onForegroundEntry()
+        await fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    func testOnForegroundEntry_FiresImmediatePollBypassingInterval() async throws {
+        let mockClient = MockLocationClient()
+        service = LocationSyncService(e2eeManager: service.e2eeManager, userStore: service.userStore, locationClient: mockClient, locationProvider: mockLocationProvider)
+        service.beginBackgroundTask = { _, _ in .invalid }
+        service.endBackgroundTask = { _ in }
+        service.isInForeground = { true }
+        // Set lastPollTime to 5s ago — normally foreground interval (10s) would block a poll.
+        service.lastPollTime = Date(timeIntervalSinceNow: -5)
+        let before = mockClient.pollCallCount
+
+        service.onForegroundEntry()
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertGreaterThan(mockClient.pollCallCount, before,
+            "onForegroundEntry must poll immediately even if the foreground interval hasn't elapsed")
+    }
+
+    func testOnForegroundEntry_ResetsLastPollTimeToDistantPast() async throws {
+        // lastPollTime = .distantPast is what causes the 90s stuck-poll guard to trigger
+        // and lets a new poll proceed even if isPollInFlight was true.
+        service.lastPollTime = Date()
+
+        service.onForegroundEntry()
+
+        XCTAssertEqual(service.lastPollTime.timeIntervalSince1970, Date.distantPast.timeIntervalSince1970, accuracy: 1.0,
+            "onForegroundEntry must reset lastPollTime so the stuck-poll guard fires immediately")
+    }
+
     func testIsRapidPolling() async throws {
         service.lastRapidPollTrigger = Date(timeIntervalSinceNow: -10)
         let isRapid1 = await service.isRapidPolling()

--- a/ios/Tests/WhereTests/LocationSyncServiceTests.swift
+++ b/ios/Tests/WhereTests/LocationSyncServiceTests.swift
@@ -381,13 +381,41 @@ class LocationSyncServiceTests: XCTestCase {
         service.endBackgroundTask = { _ in }
         service.isSharingLocation = true
         service.lastSentTime = Date(timeIntervalSinceNow: -60)
-        mockLocationProvider.location = CLLocation(latitude: 37.7, longitude: -122.4)
+        // Specify horizontalAccuracy explicitly: CLLocation(latitude:longitude:) gives
+        // horizontalAccuracy = -1 (invalid), which bestAvailableLocation would reject.
+        mockLocationProvider.location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7, longitude: -122.4),
+            altitude: 0, horizontalAccuracy: 50, verticalAccuracy: 50, timestamp: Date()
+        )
 
         let expectation = XCTestExpectation(description: "Location sent on foreground entry")
         mockClient.sendLocationCallback = { expectation.fulfill() }
 
         service.onForegroundEntry()
         await fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    func testOnForegroundEntry_NodoubleSendWhenHeartbeatAlsoDue() async throws {
+        let mockClient = MockLocationClient()
+        service = LocationSyncService(e2eeManager: service.e2eeManager, userStore: service.userStore, locationClient: mockClient, locationProvider: mockLocationProvider)
+        service.beginBackgroundTask = { _, _ in .invalid }
+        service.endBackgroundTask = { _ in }
+        service.isSharingLocation = true
+        // lastSentTime > 300s ago so the pollAll heartbeat would also try to send.
+        service.lastSentTime = Date(timeIntervalSinceNow: -400)
+        mockLocationProvider.location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7, longitude: -122.4),
+            altitude: 0, horizontalAccuracy: 50, verticalAccuracy: 50, timestamp: Date()
+        )
+
+        let sendCount = SendCountBox()
+        mockClient.sendLocationCallback = { sendCount.increment() }
+
+        service.onForegroundEntry()
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        XCTAssertEqual(sendCount.getCount(), 1,
+            "sendLocation() updates lastSentTime synchronously, so pollAll's heartbeat must not fire a second send")
     }
 
     func testOnForegroundEntry_FiresImmediatePollBypassingInterval() async throws {

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -120,11 +120,7 @@ internal class E2eeStore(
 
     fun addDiagnosticEvent(message: String) {
         val t = currentTimeSeconds()
-        val s = (t % 86400).toInt()
-        val entry = "${(s / 3600).toString().padStart(
-            2,
-            '0',
-        )}:${((s % 3600) / 60).toString().padStart(2, '0')}:${(s % 60).toString().padStart(2, '0')} $message"
+        val entry = "${TimeSource.formatLocalTime(t)} $message"
         _diagnosticLog.value = (listOf(entry) + _diagnosticLog.value).take(MAX_DIAGNOSTIC_EVENTS)
     }
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/TimeProvider.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/TimeProvider.kt
@@ -17,20 +17,29 @@ object TimeSource {
     fun currentTimeSeconds(): Long = provider.currentTimeSeconds()
 
     fun currentTimeMillis(): Long = provider.currentTimeMillis()
+
+    /** Formats a Unix timestamp (seconds) into a local time string (HH:mm:ss). */
+    fun formatLocalTime(seconds: Long): String = provider.formatLocalTime(seconds)
 }
 
 interface TimeProvider {
     fun currentTimeSeconds(): Long
 
     fun currentTimeMillis(): Long
+
+    fun formatLocalTime(seconds: Long): String
 }
 
 internal object DefaultTimeProvider : TimeProvider {
     override fun currentTimeSeconds(): Long = platformCurrentTimeSeconds()
 
     override fun currentTimeMillis(): Long = platformCurrentTimeMillis()
+
+    override fun formatLocalTime(seconds: Long): String = platformFormatLocalTime(seconds)
 }
 
 internal expect fun platformCurrentTimeSeconds(): Long
 
 internal expect fun platformCurrentTimeMillis(): Long
+
+internal expect fun platformFormatLocalTime(seconds: Long): String

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/ChaosInfrastructure.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/ChaosInfrastructure.kt
@@ -18,6 +18,8 @@ class ChaosTimeProvider(private var offsetMillis: Long = 0) : TimeProvider {
     override fun currentTimeMillis(): Long = platformCurrentTimeMillis() + offsetMillis
 
     override fun currentTimeSeconds(): Long = (platformCurrentTimeMillis() + offsetMillis) / 1000
+
+    override fun formatLocalTime(seconds: Long): String = platformFormatLocalTime(seconds)
 }
 
 class ChaosStorage(private val storage: RawKeyValueStorage) : RawKeyValueStorage {

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
@@ -110,10 +110,7 @@ class E2eeChaosTest {
 
                     override fun currentTimeSeconds() = (baseTimeMs + testScheduler.currentTime) / 1000
 
-                    override fun formatLocalTime(seconds: Long): String {
-                        val s = (seconds % 86400).toInt()
-                        return "${(s / 3600).toString().padStart(2, '0')}:${((s % 3600) / 60).toString().padStart(2, '0')}:${(s % 60).toString().padStart(2, '0')}"
-                    }
+                    override fun formatLocalTime(seconds: Long): String = platformFormatLocalTime(seconds)
                 },
             )
             val mailbox = MemoryMailboxClient()
@@ -272,10 +269,7 @@ class E2eeChaosTest {
 
                     override fun currentTimeSeconds() = testScheduler.currentTime / 1000
 
-                    override fun formatLocalTime(seconds: Long): String {
-                        val s = (seconds % 86400).toInt()
-                        return "${(s / 3600).toString().padStart(2, '0')}:${((s % 3600) / 60).toString().padStart(2, '0')}:${(s % 60).toString().padStart(2, '0')}"
-                    }
+                    override fun formatLocalTime(seconds: Long): String = platformFormatLocalTime(seconds)
                 },
             )
 

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
@@ -109,6 +109,11 @@ class E2eeChaosTest {
                     override fun currentTimeMillis() = baseTimeMs + testScheduler.currentTime
 
                     override fun currentTimeSeconds() = (baseTimeMs + testScheduler.currentTime) / 1000
+
+                    override fun formatLocalTime(seconds: Long): String {
+                        val s = (seconds % 86400).toInt()
+                        return "${(s / 3600).toString().padStart(2, '0')}:${((s % 3600) / 60).toString().padStart(2, '0')}:${(s % 60).toString().padStart(2, '0')}"
+                    }
                 },
             )
             val mailbox = MemoryMailboxClient()
@@ -266,6 +271,11 @@ class E2eeChaosTest {
                     override fun currentTimeMillis() = testScheduler.currentTime
 
                     override fun currentTimeSeconds() = testScheduler.currentTime / 1000
+
+                    override fun formatLocalTime(seconds: Long): String {
+                        val s = (seconds % 86400).toInt()
+                        return "${(s / 3600).toString().padStart(2, '0')}:${((s % 3600) / 60).toString().padStart(2, '0')}:${(s % 60).toString().padStart(2, '0')}"
+                    }
                 },
             )
 
@@ -382,6 +392,11 @@ class E2eeChaosTest {
                 override fun currentTimeMillis() = baseTimeMs + testScheduler.currentTime
 
                 override fun currentTimeSeconds() = (baseTimeMs + testScheduler.currentTime) / 1000
+
+                override fun formatLocalTime(seconds: Long): String {
+                    val s = (seconds % 86400).toInt()
+                    return "${(s / 3600).toString().padStart(2, '0')}:${((s % 3600) / 60).toString().padStart(2, '0')}:${(s % 60).toString().padStart(2, '0')}"
+                }
             },
         )
         val mailbox = MemoryMailboxClient()

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/MockTimeProvider.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/MockTimeProvider.kt
@@ -7,6 +7,11 @@ class MockTimeProvider(
 
     override fun currentTimeMillis(): Long = nowMs
 
+    override fun formatLocalTime(seconds: Long): String {
+        val s = (seconds % 86400).toInt()
+        return "${(s / 3600).toString().padStart(2, '0')}:${((s % 3600) / 60).toString().padStart(2, '0')}:${(s % 60).toString().padStart(2, '0')}"
+    }
+
     fun advanceSeconds(seconds: Long) {
         nowMs += seconds * 1000
     }

--- a/shared/src/iosMain/kotlin/net/af0/where/e2ee/TimeProviderImpl.kt
+++ b/shared/src/iosMain/kotlin/net/af0/where/e2ee/TimeProviderImpl.kt
@@ -13,13 +13,13 @@ actual fun platformCurrentTimeSeconds(): Long = (CFAbsoluteTimeGetCurrent() + CF
 
 actual fun platformCurrentTimeMillis(): Long = ((CFAbsoluteTimeGetCurrent() + CF_TO_UNIX_OFFSET) * 1000).toLong()
 
-private val formatter =
-    NSDateFormatter().apply {
-        dateFormat = "HH:mm:ss"
-        timeZone = NSTimeZone.localTimeZone
-    }
-
 actual fun platformFormatLocalTime(seconds: Long): String {
+    // NSDateFormatter is not thread-safe; create a new instance per call.
+    val formatter =
+        NSDateFormatter().apply {
+            dateFormat = "HH:mm:ss"
+            timeZone = NSTimeZone.localTimeZone
+        }
     val date = NSDate(timeIntervalSinceReferenceDate = seconds.toDouble() - CF_TO_UNIX_OFFSET)
     return formatter.stringFromDate(date)
 }

--- a/shared/src/iosMain/kotlin/net/af0/where/e2ee/TimeProviderImpl.kt
+++ b/shared/src/iosMain/kotlin/net/af0/where/e2ee/TimeProviderImpl.kt
@@ -1,6 +1,10 @@
 package net.af0.where.e2ee
 
 import platform.CoreFoundation.CFAbsoluteTimeGetCurrent
+import platform.Foundation.NSDate
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSTimeZone
+import platform.Foundation.localTimeZone
 
 // CFAbsoluteTime is seconds since 2001-01-01; add the Unix offset to get Unix seconds.
 private const val CF_TO_UNIX_OFFSET = 978307200L
@@ -8,3 +12,14 @@ private const val CF_TO_UNIX_OFFSET = 978307200L
 actual fun platformCurrentTimeSeconds(): Long = (CFAbsoluteTimeGetCurrent() + CF_TO_UNIX_OFFSET).toLong()
 
 actual fun platformCurrentTimeMillis(): Long = ((CFAbsoluteTimeGetCurrent() + CF_TO_UNIX_OFFSET) * 1000).toLong()
+
+private val formatter =
+    NSDateFormatter().apply {
+        dateFormat = "HH:mm:ss"
+        timeZone = NSTimeZone.localTimeZone
+    }
+
+actual fun platformFormatLocalTime(seconds: Long): String {
+    val date = NSDate(timeIntervalSinceReferenceDate = seconds.toDouble() - CF_TO_UNIX_OFFSET)
+    return formatter.stringFromDate(date)
+}

--- a/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/TimeProviderImpl.kt
+++ b/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/TimeProviderImpl.kt
@@ -1,15 +1,15 @@
 package net.af0.where.e2ee
 
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 actual fun platformCurrentTimeSeconds(): Long = System.currentTimeMillis() / 1000L
 
 actual fun platformCurrentTimeMillis(): Long = System.currentTimeMillis()
 
-private val formatter = SimpleDateFormat("HH:mm:ss", Locale.getDefault())
+// DateTimeFormatter is immutable and thread-safe; safe to share as a top-level val.
+private val formatter = DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault())
 
-actual fun platformFormatLocalTime(seconds: Long): String {
-    return formatter.format(Date(seconds * 1000L))
-}
+actual fun platformFormatLocalTime(seconds: Long): String =
+    formatter.format(Instant.ofEpochSecond(seconds))

--- a/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/TimeProviderImpl.kt
+++ b/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/TimeProviderImpl.kt
@@ -1,5 +1,15 @@
 package net.af0.where.e2ee
 
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
 actual fun platformCurrentTimeSeconds(): Long = System.currentTimeMillis() / 1000L
 
 actual fun platformCurrentTimeMillis(): Long = System.currentTimeMillis()
+
+private val formatter = SimpleDateFormat("HH:mm:ss", Locale.getDefault())
+
+actual fun platformFormatLocalTime(seconds: Long): String {
+    return formatter.format(Date(seconds * 1000L))
+}


### PR DESCRIPTION
    When the stationary geofence is active, CoreLocation delivers cell/WiFi
    fixes at kCLLocationAccuracyThreeKilometers to keep the RunLoop alive.
    These fixes can drift 3km+ and must not be broadcast to friends.

    - didUpdateLocations: skip sendLocation() when horizontalAccuracy > 200m
    - bestAvailableLocation: fall back to lastSentLocation (last real GPS fix)
      rather than returning a noisy network fix for heartbeat sends