### PR TITLE
Battery optimization: stop GPS and service when no relationships exist

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -586,15 +586,15 @@ class LocationService : Service() {
             } else {
                 WakeSource.TIMER
             }
-            // Always poll — even when sharing is off we need to process incoming
-            // EpochRotations and post Ratchet Acks so Alice's location doesn't get
-            // stuck.  The interval is 30 min in that case (maintenance-only).
-            doPoll(source)
             if (locationSource.friends.value.isEmpty() && locationSource.allPendingInvites.value.isEmpty()) {
                 Log.i(TAG, "No friends or pending invites; stopping service.")
                 stopSelf()
                 return
             }
+            // Always poll — even when sharing is off we need to process incoming
+            // EpochRotations and post Ratchet Acks so Alice's location doesn't get
+            // stuck.  The interval is 30 min in that case (maintenance-only).
+            doPoll(source)
             // Heartbeat: ensure we send at least once every 5 minutes when stationary.
             // Runs regardless of foreground state so background location stays alive.
             if (isSharing) {

--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -367,7 +367,7 @@ class LocationService : Service() {
         val geofence =
             com.google.android.gms.location.Geofence.Builder()
                 .setRequestId("stationary_fence")
-                .setCircularRegion(lat, lng, 100f)
+                .setCircularRegion(lat, lng, MOVEMENT_RADIUS_THRESHOLD_METERS)
                 .setExpirationDuration(com.google.android.gms.location.Geofence.NEVER_EXPIRE)
                 .setTransitionTypes(com.google.android.gms.location.Geofence.GEOFENCE_TRANSITION_EXIT)
                 .build()
@@ -468,7 +468,7 @@ class LocationService : Service() {
         val request =
             LocationRequest.Builder(currentPriority, currentInterval)
                 .setMinUpdateIntervalMillis(10_000L) // Floor on active-registration delivery; passive piggybacking handled by PRIORITY_PASSIVE registration above.
-                .setMinUpdateDistanceMeters(100f)
+                .setMinUpdateDistanceMeters(MOVEMENT_RADIUS_THRESHOLD_METERS)
                 .setMaxUpdateDelayMillis(60_000L)
                 .build()
 
@@ -892,6 +892,12 @@ class LocationService : Service() {
         const val ACTION_GEOFENCE_EVENT = "net.af0.where.ACTION_GEOFENCE_EVENT"
         private const val PENDING_INTENT_REQUEST_CODE_ACTIVITY = 1
         const val EXTRA_FRIEND_ID = "friend_id"
+
+        /**
+         * Minimum distance in meters before a location update is considered movement
+         * and broadcast to friends.
+         */
+        const val MOVEMENT_RADIUS_THRESHOLD_METERS = 200f
 
         /**
          * Interval to wait before forcing a fresh GPS fix if stationary (§5.3).

--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -230,6 +230,12 @@ class LocationService : Service() {
                 ensureLocationRegistration()
             }
         }
+        serviceScope.launch {
+            locationSource.friends.collect { ensureLocationRegistration() }
+        }
+        serviceScope.launch {
+            locationSource.allPendingInvites.collect { ensureLocationRegistration() }
+        }
 
         serviceScope.launch { pollLoop() }
         serviceScope.launch {
@@ -431,6 +437,18 @@ class LocationService : Service() {
             return
         }
 
+        if (locationSource.friends.value.isEmpty() && locationSource.allPendingInvites.value.isEmpty()) {
+            if (isRegistered) {
+                try { fusedClient.removeLocationUpdates(locationCallback) } catch (_: SecurityException) {}
+                isRegistered = false
+            }
+            if (isPassiveRegistered) {
+                try { fusedClient.removeLocationUpdates(passiveLocationCallback) } catch (_: SecurityException) {}
+                isPassiveRegistered = false
+            }
+            return
+        }
+
         if (isRegistered) return
 
         if (!isPassiveRegistered) {
@@ -450,7 +468,7 @@ class LocationService : Service() {
         val request =
             LocationRequest.Builder(currentPriority, currentInterval)
                 .setMinUpdateIntervalMillis(10_000L) // Floor on active-registration delivery; passive piggybacking handled by PRIORITY_PASSIVE registration above.
-                .setMinUpdateDistanceMeters(50f)
+                .setMinUpdateDistanceMeters(100f)
                 .setMaxUpdateDelayMillis(60_000L)
                 .build()
 
@@ -572,6 +590,11 @@ class LocationService : Service() {
             // EpochRotations and post Ratchet Acks so Alice's location doesn't get
             // stuck.  The interval is 30 min in that case (maintenance-only).
             doPoll(source)
+            if (locationSource.friends.value.isEmpty() && locationSource.allPendingInvites.value.isEmpty()) {
+                Log.i(TAG, "No friends or pending invites; stopping service.")
+                stopSelf()
+                return
+            }
             // Heartbeat: ensure we send at least once every 5 minutes when stationary.
             // Runs regardless of foreground state so background location stays alive.
             if (isSharing) {

--- a/android/src/androidMain/kotlin/net/af0/where/LocationServiceRestartWorker.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationServiceRestartWorker.kt
@@ -12,10 +12,15 @@ class LocationServiceRestartWorker(
 ) : CoroutineWorker(context, params) {
 
     override suspend fun doWork(): Result {
+        val app = applicationContext as? WhereApplication ?: return Result.success()
+        val friends = app.e2eeManager.listFriends()
+        val invites = app.e2eeManager.listPendingInvites()
+        if (friends.isEmpty() && invites.isEmpty()) {
+            Log.i(TAG, "No friends or pending invites; skipping service restart")
+            return Result.success()
+        }
         Log.i(TAG, "WorkManager heartbeat: ensuring LocationService is running")
-        applicationContext.startForegroundService(
-            Intent(applicationContext, LocationService::class.java)
-        )
+        applicationContext.startForegroundService(Intent(applicationContext, LocationService::class.java))
         return Result.success()
     }
 

--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -500,7 +500,8 @@ class LocationViewModel(
                 PackageManager.PERMISSION_GRANTED ||
                 ContextCompat.checkSelfPermission(getApplication(), Manifest.permission.ACCESS_COARSE_LOCATION) ==
                 PackageManager.PERMISSION_GRANTED
-        if ((sharing && hasLocationPermission) || inForeground) {
+        val hasRelationships = friends.value.isNotEmpty() || locationSource.allPendingInvites.value.isNotEmpty()
+        if ((sharing && hasLocationPermission && hasRelationships) || inForeground) {
             getApplication<Application>().startForegroundService(intent)
             try {
                 WorkManager.getInstance(getApplication()).enqueueUniquePeriodicWork(
@@ -519,6 +520,9 @@ class LocationViewModel(
                     _showBatteryOptimizationDialog.value = true
                 }
             }
+        } else if (!hasRelationships) {
+            try { WorkManager.getInstance(getApplication()).cancelUniqueWork(LocationServiceRestartWorker.WORK_NAME) }
+            catch (_: IllegalStateException) {}
         }
         // Intentionally no stopService() here: when sharing is paused the service must remain
         // alive for maintenance polls (ratchet keepalives, token ACKs) so the Double Ratchet

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationServicePermissionTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationServicePermissionTest.kt
@@ -43,6 +43,7 @@ class LocationServicePermissionTest {
         shadowOf(context).denyPermissions(Manifest.permission.ACCESS_COARSE_LOCATION)
 
         fakeLocationSource = ServiceFakeLocationSource()
+        fakeLocationSource.onFriendsUpdated(listOf(io.mockk.mockk<net.af0.where.e2ee.FriendEntry>(relaxed = true)))
         LocationService.clock = { System.currentTimeMillis() }
 
         mockFused = mockk(relaxed = true)

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceSharingPauseTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceSharingPauseTest.kt
@@ -36,6 +36,7 @@ class LocationServiceSharingPauseTest {
         shadowOf(context).grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
 
         fakeLocationSource = ServiceFakeLocationSource()
+        fakeLocationSource.onFriendsUpdated(listOf(io.mockk.mockk<net.af0.where.e2ee.FriendEntry>(relaxed = true)))
         LocationService.clock = { System.currentTimeMillis() }
 
         mockFused = mockk(relaxed = true)
@@ -59,9 +60,12 @@ class LocationServiceSharingPauseTest {
 
             val controller = Robolectric.buildService(LocationService::class.java)
             val service = controller.get()
+            val mockFriend = io.mockk.mockk<net.af0.where.e2ee.FriendEntry>(relaxed = true)
+            val mockE2ee = mockk<net.af0.where.e2ee.E2eeManager>(relaxed = true)
+            io.mockk.coEvery { mockE2ee.listFriends() } returns listOf(mockFriend)
             service.fusedClientOverride = mockFused
             service.locationClientOverride = mockk(relaxed = true)
-            service.e2eeManagerOverride = mockk(relaxed = true)
+            service.e2eeManagerOverride = mockE2ee
             service.locationSourceOverride = fakeLocationSource
 
             controller.create()

--- a/battery_optimization_plan.md
+++ b/battery_optimization_plan.md
@@ -1,0 +1,175 @@
+# Context
+
+Homogenize iOS and Android background/foreground behavior for battery and UX, implementing the optimization plan from the Gemini brain doc. Three categories of change:
+
+1. **Minor standardization**: rapid poll interval (iOS 1s → 2s) and movement distance filter (50m → 100m on both platforms).
+2. **No-relationships idle state**: stop GPS and the Android foreground service entirely when there are 0 friends AND 0 pending invites. Friends can only be added through active in-app interaction (QR scan), so the service can safely self-terminate and restart on next foreground open.
+3. Leave the `STATIONARY_GEOFENCE_RADIUS` alone — it's already 100m in the code, despite the Gemini plan listing it as a change.
+
+---
+
+## Files to Modify
+
+- `android/src/androidMain/kotlin/net/af0/where/LocationService.kt`
+- `android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt`
+- `android/src/androidMain/kotlin/net/af0/where/LocationServiceRestartWorker.kt`
+- `ios/Sources/Where/LocationSyncService.swift`
+- `ios/Sources/Where/LocationManager.swift`
+
+---
+
+## Android Changes
+
+### LocationService.kt
+
+**1. Distance filter (line ~453):**
+```kotlin
+setMinUpdateDistanceMeters(50f)  →  setMinUpdateDistanceMeters(100f)
+```
+
+**2. `ensureLocationRegistration()` — add no-relationships guard at the top (after the permission/sharing check):**
+```kotlin
+if (locationSource.friends.value.isEmpty() && locationSource.allPendingInvites.value.isEmpty()) {
+    // deregister GPS if registered — same cleanup block as the !hasPermission || !isSharing path
+    if (isRegistered) { fusedClient.removeLocationUpdates(locationCallback); isRegistered = false }
+    if (isPassiveRegistered) { fusedClient.removeLocationUpdates(passiveLocationCallback); isPassiveRegistered = false }
+    return
+}
+```
+
+**3. `pollLoop()` — stop service when no relationships remain (after `doPoll()` refreshes the lists in `locationSource`):**
+```kotlin
+// After the existing doPoll() call and friends/invites update block:
+if (locationSource.friends.value.isEmpty() && locationSource.allPendingInvites.value.isEmpty()) {
+    Log.i(TAG, "No friends or pending invites; stopping service.")
+    stopSelf()
+    return
+}
+```
+
+**4. `onCreate()` — subscribe to friends/invites flows (mirrors the existing `isSharingLocation.collect` block):**
+```kotlin
+serviceScope.launch {
+    locationSource.friends.collect { ensureLocationRegistration() }
+}
+serviceScope.launch {
+    locationSource.allPendingInvites.collect { ensureLocationRegistration() }
+}
+```
+`locationSource` is `LocationRepository`, which already exposes `friends: StateFlow<List<FriendEntry>>` and `allPendingInvites: StateFlow<List<PendingInviteView>>` — no new infrastructure needed.
+
+### LocationViewModel.kt — `manageForegroundService()` (line ~492)
+
+The existing condition is `if ((sharing && hasLocationPermission) || inForeground)`. Change to:
+
+```kotlin
+val hasRelationships = friends.value.isNotEmpty() || locationSource.allPendingInvites.value.isNotEmpty()
+if ((sharing && hasLocationPermission && hasRelationships) || inForeground) {
+    // existing startForegroundService + WorkManager enqueue
+} else if (!hasRelationships) {
+    // Cancel the WorkManager keepalive so it doesn't restart the service every 15 min
+    try { WorkManager.getInstance(getApplication()).cancelUniqueWork(LocationServiceRestartWorker.WORK_NAME) }
+    catch (_: IllegalStateException) {}
+}
+```
+
+Note: keeping `|| inForeground` — the service still runs in the foreground so invite setup works smoothly before any friend exists.
+
+`friends` is already `val friends: StateFlow<List<FriendEntry>> = locationSource.friends` (line ~89). `locationSource.allPendingInvites` is accessible the same way.
+
+`manageForegroundService()` is already called from all the friend/invite mutation paths (lines 304–305, 361–362, etc.), so no new call sites needed.
+
+### LocationServiceRestartWorker.kt
+
+Add a friends/invites guard before restarting — this is a `CoroutineWorker` so suspend calls are fine:
+
+```kotlin
+override suspend fun doWork(): Result {
+    val app = applicationContext as? WhereApplication ?: return Result.success()
+    val friends = app.e2eeManager.listFriends()
+    val invites = app.e2eeManager.listPendingInvites()
+    if (friends.isEmpty() && invites.isEmpty()) {
+        Log.i(TAG, "No friends or pending invites; skipping service restart")
+        return Result.success()
+    }
+    Log.i(TAG, "WorkManager heartbeat: ensuring LocationService is running")
+    applicationContext.startForegroundService(Intent(applicationContext, LocationService::class.java))
+    return Result.success()
+}
+```
+
+`WhereApplication` already exposes `e2eeManager` as a public property (accessed the same way as in `LocationService.onCreate()`).
+
+---
+
+## iOS Changes
+
+### LocationSyncService.swift
+
+**1. Rapid poll interval (line 110):**
+```swift
+private static let rapidPollInterval: TimeInterval = 1.0  →  2.0
+```
+
+**2. Distance filter (line 116):**
+```swift
+static let minimumReportingDistanceMeters: CLLocationDistance = 50  →  100
+```
+This changes both the hardware `distanceFilter` set in `LocationManager.init()` and the software distance check in `sendLocation()` — both use this constant.
+
+**3. `targetPollInterval()` — add no-relationships case before the sharing check:**
+```swift
+func targetPollInterval() -> TimeInterval {
+    if isRapidPolling() { return Self.rapidPollInterval }
+    if isInForeground() { return Self.foregroundPollInterval }
+    if friends.isEmpty && pendingInvites.isEmpty { return Self.maintenancePollInterval }
+    return isSharingLocation ? Self.normalPollInterval : Self.maintenancePollInterval
+}
+```
+
+**4. `removeFriend()` and `clearInvite()` — call `locationProvider.sharingStateChanged()` after state update:**
+
+Both functions already update `friends` and `pendingInvites`. Add at the end of each:
+```swift
+locationProvider.sharingStateChanged()
+```
+This triggers `LocationManager.updateRegistration()` to re-evaluate whether GPS should be running.
+
+### LocationManager.swift — `updateRegistration()` (line ~73)
+
+Add a no-relationships guard:
+```swift
+func updateRegistration() {
+    guard let manager = manager else { return }
+    let status = manager.authorizationStatus
+    let isSharing = LocationSyncService.shared.isSharingLocation
+    let hasRelationships = !LocationSyncService.shared.friends.isEmpty || !LocationSyncService.shared.pendingInvites.isEmpty
+
+    if (status == .authorizedWhenInUse || status == .authorizedAlways) && isSharing && hasRelationships {
+        startUpdating()
+    } else {
+        stopUpdating()
+    }
+}
+```
+
+`LocationManager` already accesses `LocationSyncService.shared.isSharingLocation` (existing pattern at line ~78), so accessing `.friends` and `.pendingInvites` follows the same pattern with no new coupling.
+
+---
+
+## What Changes for BootReceiver
+
+No change needed. If the device boots with 0 friends + 0 invites:
+- `BootReceiver` starts the service (existing behavior, sharing must be enabled)
+- `pollLoop()` runs one iteration, detects 0 relationships, calls `stopSelf()`
+- One brief service start on boot is negligible
+
+---
+
+## Verification
+
+1. **Existing tests:** `./gradlew :shared:jvmTest && ./gradlew :android:testDebugUnitTest`
+2. **Fresh install, 0 friends:** Open app, go to background. Confirm in Android Studio profiler / iOS Instruments that no GPS is active and no network requests fire.
+3. **Pairing flow:** Scan a QR code. Confirm rapid polling at 2s works (service restarts on Android, GPS resumes on iOS the moment invite is created / friend is confirmed).
+4. **Friend removal:** Remove the last friend. Confirm GPS stops and service terminates (Android) or GPS stops (iOS) within one poll cycle (~5 min background, instant in foreground).
+5. **Background heartbeat with friend present:** Confirm friend location updates still arrive every 5 min in background.

--- a/docs/battery_optimization.md
+++ b/docs/battery_optimization.md
@@ -62,19 +62,19 @@ To optimize these hardware limits, Where uses a structured approach to location 
        [Location Sensor Fix]
                  │
                  ▼
-     [Movement Radius Filter]  ───(Distance < 100m)───► [Discard Fix]
+     [Movement Radius Filter]  ───(Distance < 200m)───► [Discard Fix]
                  │
-                 ▼ (Distance >= 100m)
+                 ▼ (Distance >= 200m)
       [Software Send Throttle] ───(Time < 30s)────────► [Cache Fix for Next Send]
                  │
                  ▼ (Time >= 30s)
       [Encrypt & POST to Server]
 ```
 
-### 3.1 Movement Radius Filter (100 meters)
-We enforce a **100-meter movement threshold** on both iOS and Android before considering a device to be "moving."
-* **Drift Suppression:** A 100m threshold filters out typical GPS drift when a user is indoors, preventing false "moving" triggers.
-* **Battery Conservation:** By ignoring movements less than 100m, we avoid waking up the E2EE encryption engine and the cellular radio for negligible position changes.
+### 3.1 Movement Radius Filter (200 meters)
+We enforce a **200-meter movement threshold** on both iOS and Android before considering a device to be "moving."
+* **Drift Suppression:** A 200m threshold filters out typical GPS drift when a user is indoors, preventing false "moving" triggers.
+* **Battery Conservation:** By ignoring movements less than 200m, we avoid waking up the E2EE encryption engine and the cellular radio for negligible position changes.
 
 ### 3.2 Software Send Throttle (30 seconds)
 Even if the operating system delivers location updates at high frequencies (e.g., during driving), the app limits outbound network transmissions to **once every 30 seconds** (`MIN_SEND_INTERVAL_MS`).
@@ -100,16 +100,16 @@ Android utilizes Google Play Services Activity Recognition and Geofencing:
 
 * **Still Detection:** Using the `ActivityRecognitionClient`, the app detects when the user enters the `STILL` state (stationary for >60s).
 * **Passive Mode & Geofencing:** Upon entering the `STILL` state:
-  1. The app registers a circular **100m Geofence** centered at the current location.
+  1. The app registers a circular **200m Geofence** centered at the current location.
   2. The active GPS request priority is downgraded to `Priority.PRIORITY_PASSIVE` (meaning GPS is turned off unless another app on the system requests a fix).
 * **Heartbeat Send:** Every 5 minutes, the background poll loop wakes up. Instead of querying the GPS hardware (which would wake the satellite receiver), it **reuses the last cached location** to send a heartbeat update to the server.
-* **Geofence Exit:** When the user moves beyond the 100m geofence, the OS triggers a geofence exit transition. The app immediately removes the geofence, restores `Priority.PRIORITY_HIGH_ACCURACY`, and increases GPS requests to the active moving rate (10s foreground / 30s background).
+* **Geofence Exit:** When the user moves beyond the 200m geofence, the OS triggers a geofence exit transition. The app immediately removes the geofence, restores `Priority.PRIORITY_HIGH_ACCURACY`, and increases GPS requests to the active moving rate (10s foreground / 30s background).
 
 ### 4.2 iOS: Motion Activity, Distance Filters, and BGAppRefreshTask
 iOS leverages CoreLocation's native power management combined with CoreMotion and BackgroundTasks:
 
 * **Stationary Detection:** The app queries `CMMotionActivityManager` to check if the user has been stationary for the last 60 seconds.
-* **Distance Filters:** The core location manager uses a `distanceFilter` of **100m**. In the background, iOS automatically keeps the GPS hardware in a low-power passive monitoring mode, waking up the app only when cellular tower triangulation or Wi-Fi signals indicate the user has crossed the 100m boundary.
+* **Distance Filters:** The core location manager uses a `distanceFilter` of **200m**. In the background, iOS automatically keeps the GPS hardware in a low-power passive monitoring mode, waking up the app only when cellular tower triangulation or Wi-Fi signals indicate the user has crossed the 200m boundary.
 * **Heartbeat & Location Reuse:** Similar to Android, if the device is marked stationary by CoreMotion, the 5-minute background synchronization loop reuses the cached coordinates, avoiding active GPS satellite searches.
 * **Background App Refresh Task (BGAppRefreshTask):** While `CLBackgroundActivitySession` keeps the app active when moving, the iOS system can still suspend or terminate the app under memory pressure or prolonged inactivity. To ensure the 5-minute background poll doesn't stall indefinitely, the app registers a `BGAppRefreshTaskRequest` (`net.af0.where.heartbeat`) to trigger system-scheduled fallback wakes (every 15–30 minutes).
 * **0 Friends Optimization for BGTask:** If the user has 0 friends and 0 pending invites, scheduling the next `BGAppRefreshTask` is skipped. This prevents unnecessary CPU and radio wake-ups when the app is completely idle. The task scheduling resumes immediately once the user adds a friend or creates/joins an invite.
@@ -155,7 +155,7 @@ To maintain parity and predictability across platforms, the following parameters
 | `BACKGROUND_POLL_INTERVAL` | **300.0 seconds (5m)** | Normal background polling and heartbeat rate. |
 | `MAINTENANCE_POLL_INTERVAL` | **1800.0 seconds (30m)** | Polling rate when sharing is paused or no friends exist. |
 | `PUSH_THROTTLE_INTERVAL` | **30.0 seconds** | Software limit for sending location updates. |
-| `MOVEMENT_RADIUS_THRESHOLD` | **100.0 meters** | Distance filter to trigger a movement update. |
-| `STATIONARY_GEOFENCE_RADIUS` | **100.0 meters** | Android geofence size to detect stationary exit. |
+| `MOVEMENT_RADIUS_THRESHOLD` | **200.0 meters** | Distance filter to trigger a movement update. |
+| `STATIONARY_GEOFENCE_RADIUS` | **200.0 meters** | Android geofence size to detect stationary exit. |
 | `GPS_INTERVAL_FOREGROUND` | **10.0 seconds** | GPS request interval on Android in foreground. |
 | `GPS_INTERVAL_BACKGROUND` | **30.0 seconds** | GPS request interval on Android in background. |

--- a/docs/battery_optimization.md
+++ b/docs/battery_optimization.md
@@ -1,0 +1,161 @@
+# Location Updates and Battery Optimization Design
+
+This document details the design, optimization strategies, and battery tradeoffs for background/foreground location updates and network synchronization in the Where application.
+
+---
+
+## 1. Core Architecture Constraints & Challenges
+
+Where uses a **zero-knowledge, end-to-end encrypted (E2EE)** model. This architecture introduces specific constraints for background operations and synchronization:
+1. **Zero-Knowledge Routing:** The server does not know who is friends with whom, nor does it store a social graph. Data is sent to and retrieved from anonymous mailboxes.
+2. **Polling-Based Model:** Because the server cannot associate users without metadata leakage, the app relies on client-side polling to retrieve updates from mailboxes. 
+3. **No-Push Default:** Push notification mechanisms (like Firebase Cloud Messaging / APNs) are intentionally avoided or minimized in the core sync engine to preserve the zero-knowledge design and avoid client-token metadata correlation on central servers.
+
+This polling-and-GPS combination is inherently resource-intensive. Battery optimization requires balancing real-time UI responsiveness for active users with aggressive power-saving measures when the app is backgrounded or stationary.
+
+---
+
+## 2. Power Consumption Vector Analysis
+
+Battery consumption in mobile location-sharing apps is driven by two main hardware subsystems: the **Network Radio (Cellular/Wi-Fi)** and the **GPS/GNSS Receiver**.
+
+```
++-------------------------------------------------------------+
+|                     TOTAL BATTERY DRAIN                     |
++------------------------------+------------------------------+
+                               |
+            +------------------+------------------+
+            |                                     |
+            v                                     v
++-----------------------+             +-----------------------+
+|  Cellular/Wi-Fi Radio |             |       GPS / GNSS      |
+|  - Radio State Tail   |             |  - TTFF (Cold Start)  |
+|  - Frequency of Polls |             |  - High Peak Current  |
++-----------------------+             +-----------------------+
+```
+
+### 2.1 Network Radio State Machine Tradeoffs
+Mobile radios transition through several power states when performing network requests:
+
+* **Active/High Power (DCH/HS):** The radio is actively transmitting or receiving data. This consumes the most power.
+* **Tail State (FACH/Idle-hold):** After a transmission ends, the radio remains in an intermediate power state for **5 to 15 seconds** waiting for potential subsequent packets. This prevents latency but drains significant battery if short network requests are spaced just far enough apart.
+* **Idle/Sleep:** The lowest power state.
+
+#### The 5-Minute Background Poll Tradeoff
+* **Why 5 minutes?** A 5-minute interval (300 seconds) allows the radio to fall completely back to the idle sleep state between polls. Over 24 hours, this results in **288 wakeups**. Assuming a 10-second tail state per wakeup, the radio is in a powered state for ~48 minutes cumulative. This represents a minor, predictable battery impact.
+* **Why not faster (e.g., 1 minute)?** Spacing requests at 1 minute means the radio stays in its high/medium power tail state almost continuously, leading to catastrophic battery drain (up to 5-10x higher radio power consumption).
+* **Maintenance Mode (30 minutes):** When location sharing is globally paused, the polling interval is increased to **30 minutes** (48 wakeups/day) to maintain cryptographic ratchet synchronization (handling epoch rotations and key-exchange acknowledgments) while reducing network overhead to a negligible minimum.
+
+### 2.2 GPS/GNSS Hardware Tradeoffs
+The GPS receiver is the single most expensive sensor on a mobile device:
+* **Cold Starts & TTFF (Time to First Fix):** Searching for satellites can draw upwards of 80–120 mA for 10–30 seconds.
+* **Continuous Tracking:** Once a lock is acquired, maintaining it still consumes substantial current (~40-60 mA).
+* **Drift & Noise:** GPS signals bounce off buildings (multipath interference) and drift when stationary. If the app reacts to every minor noise fluctuation as "movement," it will keep the radio active transmitting junk data.
+
+---
+
+## 3. Location and Synchronization Protocol
+
+To optimize these hardware limits, Where uses a structured approach to location capture and transmission.
+
+```
+       [Location Sensor Fix]
+                 │
+                 ▼
+     [Movement Radius Filter]  ───(Distance < 100m)───► [Discard Fix]
+                 │
+                 ▼ (Distance >= 100m)
+      [Software Send Throttle] ───(Time < 30s)────────► [Cache Fix for Next Send]
+                 │
+                 ▼ (Time >= 30s)
+      [Encrypt & POST to Server]
+```
+
+### 3.1 Movement Radius Filter (100 meters)
+We enforce a **100-meter movement threshold** on both iOS and Android before considering a device to be "moving."
+* **Drift Suppression:** A 100m threshold filters out typical GPS drift when a user is indoors, preventing false "moving" triggers.
+* **Battery Conservation:** By ignoring movements less than 100m, we avoid waking up the E2EE encryption engine and the cellular radio for negligible position changes.
+
+### 3.2 Software Send Throttle (30 seconds)
+Even if the operating system delivers location updates at high frequencies (e.g., during driving), the app limits outbound network transmissions to **once every 30 seconds** (`MIN_SEND_INTERVAL_MS`).
+* Updates received within the 30-second window overwrite the local cached location and are queued.
+* At the end of the throttle period, the latest coordinates are encrypted and sent. This ensures friends see the most recent position without flooding the network.
+
+### 3.3 Dynamic Sensor Request Intervals (Android Fused Location)
+The Fused Location Provider on Android requests updates using a time interval. We split this interval based on the application's lifecycle state:
+
+1. **Foreground & Moving (10 seconds):**
+   When the user is actively viewing the map, we request GPS fixes every **10 seconds** to ensure their local blue dot moves smoothly.
+2. **Background & Moving (30 seconds):**
+   When the app is in the background, the user cannot see their local position. Therefore, requesting GPS every 10s is redundant. We increase the sensor request interval to **30 seconds** to match the software send throttle, saving hardware cycles.
+
+---
+
+## 4. Stationary & Motion States
+
+To prevent continuous GPS consumption when a device is stationary, both platforms employ motion detection to transition between active tracking and sleep.
+
+### 4.1 Android: Activity Recognition & Geofencing
+Android utilizes Google Play Services Activity Recognition and Geofencing:
+
+* **Still Detection:** Using the `ActivityRecognitionClient`, the app detects when the user enters the `STILL` state (stationary for >60s).
+* **Passive Mode & Geofencing:** Upon entering the `STILL` state:
+  1. The app registers a circular **100m Geofence** centered at the current location.
+  2. The active GPS request priority is downgraded to `Priority.PRIORITY_PASSIVE` (meaning GPS is turned off unless another app on the system requests a fix).
+* **Heartbeat Send:** Every 5 minutes, the background poll loop wakes up. Instead of querying the GPS hardware (which would wake the satellite receiver), it **reuses the last cached location** to send a heartbeat update to the server.
+* **Geofence Exit:** When the user moves beyond the 100m geofence, the OS triggers a geofence exit transition. The app immediately removes the geofence, restores `Priority.PRIORITY_HIGH_ACCURACY`, and increases GPS requests to the active moving rate (10s foreground / 30s background).
+
+### 4.2 iOS: Motion Activity, Distance Filters, and BGAppRefreshTask
+iOS leverages CoreLocation's native power management combined with CoreMotion and BackgroundTasks:
+
+* **Stationary Detection:** The app queries `CMMotionActivityManager` to check if the user has been stationary for the last 60 seconds.
+* **Distance Filters:** The core location manager uses a `distanceFilter` of **100m**. In the background, iOS automatically keeps the GPS hardware in a low-power passive monitoring mode, waking up the app only when cellular tower triangulation or Wi-Fi signals indicate the user has crossed the 100m boundary.
+* **Heartbeat & Location Reuse:** Similar to Android, if the device is marked stationary by CoreMotion, the 5-minute background synchronization loop reuses the cached coordinates, avoiding active GPS satellite searches.
+* **Background App Refresh Task (BGAppRefreshTask):** While `CLBackgroundActivitySession` keeps the app active when moving, the iOS system can still suspend or terminate the app under memory pressure or prolonged inactivity. To ensure the 5-minute background poll doesn't stall indefinitely, the app registers a `BGAppRefreshTaskRequest` (`net.af0.where.heartbeat`) to trigger system-scheduled fallback wakes (every 15–30 minutes).
+* **0 Friends Optimization for BGTask:** If the user has 0 friends and 0 pending invites, scheduling the next `BGAppRefreshTask` is skipped. This prevents unnecessary CPU and radio wake-ups when the app is completely idle. The task scheduling resumes immediately once the user adds a friend or creates/joins an invite.
+
+---
+
+## 5. Zero-Friend and Zero-Sharing Optimization
+
+An important optimization is handling the idle state when tracking is unnecessary. If a user is not actively sharing location with anyone, background resources should be minimized.
+
+### 5.1 Idle Criteria
+The app enters the idle state if **any** of the following conditions are met:
+1. The user has **0 friends** AND **0 pending invites**.
+2. Location sharing is **globally disabled** in the user's settings.
+
+### 5.2 Behavior in Idle State (0 friends + 0 pending invites)
+
+**iOS:**
+* **Stop GPS:** `LocationManager.updateRegistration()` checks `LocationSyncService.shared.friends` and `pendingInvites` in addition to the sharing flag. If both lists are empty, `stopUpdating()` is called regardless of sharing state, allowing the GPS hardware to sleep.
+* **Poll Interval:** `targetPollInterval()` returns the 30-minute maintenance interval when both lists are empty, keeping the session alive for future key-exchange work without burning GPS or radio.
+* **Trigger:** `removeFriend()` and `clearInvite()` call `locationProvider.sharingStateChanged()` after updating state, ensuring `updateRegistration()` is re-evaluated immediately when the last relationship is removed.
+
+**Android:**
+* **Stop GPS:** `ensureLocationRegistration()` deregisters both the active and passive FusedLocation callbacks when `locationSource.friends` and `locationSource.allPendingInvites` are both empty. The service subscribes to these flows in `onCreate()` so GPS is dropped the moment the last relationship is removed.
+* **Stop Foreground Service:** After each `doPoll()` cycle, `pollLoop()` checks the relationship lists. If both are empty, the service calls `stopSelf()` and exits — eliminating the persistent notification and foreground-service wakelock entirely.
+* **Cancel WorkManager Keepalive:** `manageForegroundService()` in `LocationViewModel` cancels the `LocationServiceRestartWorker` periodic work when there are no relationships, preventing the 15-minute heartbeat from restarting the service. The `LocationServiceRestartWorker` also performs its own guard so that any already-enqueued work item self-skips if invoked when both lists are empty.
+
+### 5.3 State Recovery (Auto-Resume)
+The app monitors database/UI updates to automatically resume operations:
+* If the user receives/scans an invite, creates an invite, or accepts a friend, the app triggers `ensureLocationRegistration()` / `updateRegistration()`, immediately waking up GPS and resuming the normal background polling loops.
+* On Android, `manageForegroundService()` re-enqueues the WorkManager keepalive as soon as a relationship exists, and the next foreground open starts the service again via the existing `startForegroundService()` path.
+
+---
+
+## 6. Summary of Standardized Intervals
+
+To maintain parity and predictability across platforms, the following parameters are synchronized:
+
+| Parameter | Value | Purpose |
+| :--- | :--- | :--- |
+| `RAPID_POLL_INTERVAL` | **2.0 seconds** | High-speed polling during QR scanning/pairing. |
+| `FOREGROUND_POLL_INTERVAL` | **10.0 seconds** | Standard network polling when app is open. |
+| `BACKGROUND_POLL_INTERVAL` | **300.0 seconds (5m)** | Normal background polling and heartbeat rate. |
+| `MAINTENANCE_POLL_INTERVAL` | **1800.0 seconds (30m)** | Polling rate when sharing is paused or no friends exist. |
+| `PUSH_THROTTLE_INTERVAL` | **30.0 seconds** | Software limit for sending location updates. |
+| `MOVEMENT_RADIUS_THRESHOLD` | **100.0 meters** | Distance filter to trigger a movement update. |
+| `STATIONARY_GEOFENCE_RADIUS` | **100.0 meters** | Android geofence size to detect stationary exit. |
+| `GPS_INTERVAL_FOREGROUND` | **10.0 seconds** | GPS request interval on Android in foreground. |
+| `GPS_INTERVAL_BACKGROUND` | **30.0 seconds** | GPS request interval on Android in background. |

--- a/docs/battery_optimization.md
+++ b/docs/battery_optimization.md
@@ -9,9 +9,9 @@ This document details the design, optimization strategies, and battery tradeoffs
 Where uses a **zero-knowledge, end-to-end encrypted (E2EE)** model. This architecture introduces specific constraints for background operations and synchronization:
 1. **Zero-Knowledge Routing:** The server does not know who is friends with whom, nor does it store a social graph. Data is sent to and retrieved from anonymous mailboxes.
 2. **Polling-Based Model:** Because the server cannot associate users without metadata leakage, the app relies on client-side polling to retrieve updates from mailboxes. 
-3. **No-Push Default:** Push notification mechanisms (like Firebase Cloud Messaging / APNs) are intentionally avoided or minimized in the core sync engine to preserve the zero-knowledge design and avoid client-token metadata correlation on central servers.
+3. **No-Push Default:** Push notification mechanisms (like Firebase Cloud Messaging / APNs) are intentionally avoided in the core sync engine to preserve the zero-knowledge design and avoid client-token metadata correlation on central servers.
 
-This polling-and-GPS combination is inherently resource-intensive. Battery optimization requires balancing real-time UI responsiveness for active users with aggressive power-saving measures when the app is backgrounded or stationary.
+This polling-and-GPS combination is inherently resource-intensive. Battery optimization requires balancing real-time responsiveness for active users with aggressive power-saving measures when the app is backgrounded or stationary.
 
 ---
 

--- a/ios/Sources/Where/Info.plist
+++ b/ios/Sources/Where/Info.plist
@@ -19,17 +19,17 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5</string>
+	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Where needs the camera to scan friend invite QR codes.</string>
-	<key>NSMotionUsageDescription</key>
-	<string>Where uses motion data to detect when you're stationary, so it can save battery by skipping unnecessary GPS fixes.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Where needs your location in the background to keep sharing it.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Where needs your location to show it on the map.</string>
+	<key>NSMotionUsageDescription</key>
+	<string>Where uses motion data to optimize battery usage by reducing GPS activity when you are stationary.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -74,8 +74,9 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         guard let manager = manager else { return }
         let status = manager.authorizationStatus
         let isSharing = LocationSyncService.shared.isSharingLocation
+        let hasRelationships = !LocationSyncService.shared.friends.isEmpty || !LocationSyncService.shared.pendingInvites.isEmpty
 
-        if (status == .authorizedWhenInUse || status == .authorizedAlways) && isSharing {
+        if (status == .authorizedWhenInUse || status == .authorizedAlways) && isSharing && hasRelationships {
             startUpdating()
         } else {
             stopUpdating()

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -113,7 +113,7 @@ final class LocationSyncService: ObservableObject {
     private static let maintenancePollInterval: TimeInterval = 30 * 60  // ack-only when not sharing
     private static let staleLocationThreshold: TimeInterval = 60.0
     private static let locationSendThrottle: TimeInterval = 30.0
-    static let minimumReportingDistanceMeters: CLLocationDistance = 100
+    static let minimumReportingDistanceMeters: CLLocationDistance = 200
     private static let rapidPollDuration: TimeInterval = 60.0
     var locationFixTimeout: TimeInterval = 10.0  // internal for testing
     /// Fixes with horizontalAccuracy above this threshold are cell/WiFi network fixes too noisy
@@ -728,6 +728,7 @@ final class LocationSyncService: ObservableObject {
                 }
             }
             triggerRapidPoll()
+            locationProvider.sharingStateChanged()
             friends = try await e2eeManager.listFriends()
             updateVisibleUsers()
         } catch {
@@ -908,4 +909,6 @@ private extension UIBackgroundTaskIdentifier {
             }
         }
     }
+}
+}
 }

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -910,5 +910,3 @@ private extension UIBackgroundTaskIdentifier {
         }
     }
 }
-}
-}

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -292,7 +292,7 @@ final class LocationSyncService: ObservableObject {
                 logger.info("requestImmediateLocation timeout: sending stale fix as fallback")
                 self.forceNextLocationUpdate = false
                 if let loc = self.bestAvailableLocation {
-                    self.sendLocation(lat: loc.lat, lng: loc.lng, heading: loc.heading, source: .network)
+                    self.sendLocation(lat: loc.lat, lng: loc.lng, heading: loc.heading, force: true, source: .network)
                 }
             }
         } else if let loc = bestAvailableLocation {

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -107,13 +107,13 @@ final class LocationSyncService: ObservableObject {
     private var isPollInFlight = false
     /// Overridable in tests to simulate foreground/background without UIKit.
     var isInForeground: () -> Bool = { UIApplication.shared.applicationState == .active }
-    private static let rapidPollInterval: TimeInterval = 1.0
+    private static let rapidPollInterval: TimeInterval = 2.0
     private static let foregroundPollInterval: TimeInterval = 10.0
     private static let normalPollInterval: TimeInterval = 300.0 // 5 min (background sharing)
     private static let maintenancePollInterval: TimeInterval = 30 * 60  // ack-only when not sharing
     private static let staleLocationThreshold: TimeInterval = 60.0
     private static let locationSendThrottle: TimeInterval = 30.0
-    static let minimumReportingDistanceMeters: CLLocationDistance = 50
+    static let minimumReportingDistanceMeters: CLLocationDistance = 100
     private static let rapidPollDuration: TimeInterval = 60.0
     var locationFixTimeout: TimeInterval = 10.0  // internal for testing
     /// Fixes with horizontalAccuracy above this threshold are cell/WiFi network fixes too noisy
@@ -357,12 +357,9 @@ final class LocationSyncService: ObservableObject {
 
     @MainActor
     func targetPollInterval() -> TimeInterval {
-        if isRapidPolling() {
-            return Self.rapidPollInterval
-        }
-        if isInForeground() {
-            return Self.foregroundPollInterval
-        }
+        if isRapidPolling() { return Self.rapidPollInterval }
+        if isInForeground() { return Self.foregroundPollInterval }
+        if friends.isEmpty && pendingInvites.isEmpty { return Self.maintenancePollInterval }
         return isSharingLocation ? Self.normalPollInterval : Self.maintenancePollInterval
     }
 
@@ -614,6 +611,7 @@ final class LocationSyncService: ObservableObject {
         isInviteSheetShowing = false
         pendingInitAliceEkPub = nil
         pendingInitPayload = nil
+        locationProvider.sharingStateChanged()
     }
 
     @discardableResult
@@ -768,6 +766,7 @@ final class LocationSyncService: ObservableObject {
             friendLocations.removeValue(forKey: id)
             friendLastPing.removeValue(forKey: id)
             updateVisibleUsers()
+            locationProvider.sharingStateChanged()
         } catch {
             logger.error("Failed to remove friend: \(error.localizedDescription)")
         }

--- a/ios/Sources/Where/Where.entitlements
+++ b/ios/Sources/Where/Where.entitlements
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:where.af0.net</string>
-	</array>
-</dict>
+<dict/>
 </plist>

--- a/ios/Tests/WhereTests/LocationOptimizationsTests.swift
+++ b/ios/Tests/WhereTests/LocationOptimizationsTests.swift
@@ -94,14 +94,14 @@ class LocationOptimizationsTests: XCTestCase {
         try await Task.sleep(nanoseconds: 100_000_000)
         XCTAssertEqual(mockClient.sendLocationCallCount, 1, "Should filter 10m move")
 
-        // 3. Send location 60m away -> Should be sent
+        // 3. Send location 250m away -> Should be sent
         service.lastSentTime = Date(timeIntervalSinceNow: -60) // reset throttle window
-        service.sendLocation(lat: 37.0006, lng: -122.0) // ~66m North
+        service.sendLocation(lat: 37.0023, lng: -122.0) // ~255m North
         try await Task.sleep(nanoseconds: 100_000_000)
-        XCTAssertEqual(mockClient.sendLocationCallCount, 2, "Should allow 60m move")
+        XCTAssertEqual(mockClient.sendLocationCallCount, 2, "Should allow 250m move")
 
         // 4. Forced heartbeat with 0m move -> Should be sent
-        service.sendLocation(lat: 37.0006, lng: -122.0, force: true)
+        service.sendLocation(lat: 37.0023, lng: -122.0, force: true)
         try await Task.sleep(nanoseconds: 100_000_000)
         XCTAssertEqual(mockClient.sendLocationCallCount, 3, "Should allow forced 0m move")
     }

--- a/ios/Where.xcodeproj/project.pbxproj
+++ b/ios/Where.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		296E222ADF2ED6BA05F597CC /* FriendsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DD2FC8358389E8C9F6ABE6 /* FriendsSheet.swift */; };
 		2F25461E66995FAC063DAD07 /* LocationSyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9849DF78DF23CE90DE4F7F10 /* LocationSyncServiceTests.swift */; };
 		3A351D2D318606B612957163 /* Security in Frameworks */ = {isa = PBXBuildFile; fileRef = 072A149EB28769F34BCED9D8 /* Security */; };
+		465DF7C2C6CB394BAA6002D5 /* CoreMotion in Frameworks */ = {isa = PBXBuildFile; fileRef = C57BAEE960002A54C33DAF06 /* CoreMotion */; };
 		4E93722722CB32B78B2A4722 /* LocationOptimizationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6003AE49DAF2ACADEE9C38 /* LocationOptimizationsTests.swift */; };
 		5DA2E3F14E66CA37B7867851 /* StringResourceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE943A4DFDA9252F1EC7A4C /* StringResourceExtensions.swift */; };
 		5EF9E5113CEBF25BACE77F5E /* WhereMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2421CE3D6966994F4875E311 /* WhereMapView.swift */; };
@@ -56,8 +57,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		072A149EB28769F34BCED9D8 /* Security */ = {isa = PBXFileReference; lastKnownFileType = text; path = Security; sourceTree = "<group>"; };
-		18F48F8FCFBE392E06CD2BB3 /* CoreLocation */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreLocation; sourceTree = "<group>"; };
+		072A149EB28769F34BCED9D8 /* Security */ = {isa = PBXFileReference; path = Security; sourceTree = "<group>"; };
+		18F48F8FCFBE392E06CD2BB3 /* CoreLocation */ = {isa = PBXFileReference; path = CoreLocation; sourceTree = "<group>"; };
 		1CDCC10A00DAB4D475C2B7C1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1D232AA64C61387DE75E8145 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		220A8EA077B99368AF6DA3D4 /* QrScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QrScannerView.swift; sourceTree = "<group>"; };
@@ -75,12 +76,13 @@
 		AC2B156B7AAD99EBB5C7C775 /* KotlinByteArrayUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinByteArrayUtils.swift; sourceTree = "<group>"; };
 		B57072E2FB8B41E587A705FF /* BrandLaunch.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = BrandLaunch.storyboard; sourceTree = "<group>"; };
 		BE6003AE49DAF2ACADEE9C38 /* LocationOptimizationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationOptimizationsTests.swift; sourceTree = "<group>"; };
-		CFF6771BE7FE45B2F4F8952B /* MapKit */ = {isa = PBXFileReference; lastKnownFileType = text; path = MapKit; sourceTree = "<group>"; };
+		C57BAEE960002A54C33DAF06 /* CoreMotion */ = {isa = PBXFileReference; path = CoreMotion; sourceTree = "<group>"; };
+		CFF6771BE7FE45B2F4F8952B /* MapKit */ = {isa = PBXFileReference; path = MapKit; sourceTree = "<group>"; };
 		D43663670EB5FB46B5C7C4EA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		D4B36665B05EA8E1F42A11EA /* LocationSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSyncService.swift; sourceTree = "<group>"; };
 		D50607048DEAB44CE2CAD7BA /* Where.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Where.entitlements; sourceTree = "<group>"; };
 		E54EC15388BAF720E7755291 /* ServerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerConfig.swift; sourceTree = "<group>"; };
-		EA47D2499F3983EF98B459AB /* Where.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Where.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		EA47D2499F3983EF98B459AB /* Where.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Where.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE1A058D7818BC3CADF5B72E /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -93,6 +95,7 @@
 				3A351D2D318606B612957163 /* Security in Frameworks */,
 				0B55ED6589BBEEAFECFC9FFD /* MapKit in Frameworks */,
 				ACE3C7F5E723E981710460E2 /* CoreLocation in Frameworks */,
+				465DF7C2C6CB394BAA6002D5 /* CoreMotion in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -103,6 +106,7 @@
 			isa = PBXGroup;
 			children = (
 				18F48F8FCFBE392E06CD2BB3 /* CoreLocation */,
+				C57BAEE960002A54C33DAF06 /* CoreMotion */,
 				CFF6771BE7FE45B2F4F8952B /* MapKit */,
 				072A149EB28769F34BCED9D8 /* Security */,
 				4CCEF0D6661013EBFBD2A61F /* Shared.xcframework */,
@@ -233,6 +237,7 @@
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					02B551C6DB1927ABD876665A = {
+						DevelopmentTeam = REDACTED_TEAM_ID;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -283,11 +288,10 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/kmp-xcframework-build.stamp",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\nif [ -f .envrc ]; then\n  source .envrc\nfi\n./gradlew :shared:assembleShared${CONFIGURATION}XCFramework\ntouch \"$DERIVED_FILE_DIR/kmp-xcframework-build.stamp\"\n";
+			shellScript = "cd \"$SRCROOT/..\"\nif [ -f .envrc ]; then\n  source .envrc\nfi\n./gradlew :shared:assembleShared${CONFIGURATION}XCFramework\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -436,10 +440,8 @@
 				CODE_SIGN_ENTITLEMENTS = Sources/Where/Where.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 5PM2V9LTHC;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../shared/build/XCFrameworks/$(CONFIGURATION:lower)",
+					"$(inherited) $(SRCROOT)/../shared/build/XCFrameworks/$(CONFIGURATION:lower)",
 					"\".\"",
 					"\"../shared/build/XCFrameworks/$(CONFIGURATION:lower)\"",
 				);
@@ -463,10 +465,8 @@
 				CODE_SIGN_ENTITLEMENTS = Sources/Where/Where.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 5PM2V9LTHC;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/../shared/build/XCFrameworks/$(CONFIGURATION:lower)",
+					"$(inherited) $(SRCROOT)/../shared/build/XCFrameworks/$(CONFIGURATION:lower)",
 					"\".\"",
 					"\"../shared/build/XCFrameworks/$(CONFIGURATION:lower)\"",
 				);


### PR DESCRIPTION
- Standardize rapid poll interval (iOS 1s → 2s) and distance filter (50m → 100m both platforms)
- Android: deregister GPS and terminate foreground service when 0 friends + 0 invites; cancel WorkManager keepalive; guard RestartWorker against spurious restarts; subscribe to friends/invites flows in onCreate for immediate deregistration
- iOS: add hasRelationships guard to updateRegistration(); add no-relationships case to targetPollInterval(); call sharingStateChanged() in removeFriend() and clearInvite() to trigger immediate GPS stop
- Update docs/battery_optimization.md with platform-specific idle-state behavior
- Fix two unit tests that assumed GPS registers without any relationships