### PR TITLE
e2ee: confine E2eeStore SQLite I/O to Dispatchers.IO

### DIFF
--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import net.af0.where.db.WhereDatabase
@@ -245,7 +246,7 @@ class LocationViewModelTest {
     fun testInviteLifecycle_AliceSide() =
         runTest {
             val fakeLocationSource = TestFakeLocationSource()
-            val store = E2eeManager(createTestSqlDriver())
+            val store = E2eeManager(createTestSqlDriver(), UnconfinedTestDispatcher())
             val client = LocationClient("http://localhost", store)
             // Disable automatic polling loop to prevent hangs
             viewModel =
@@ -301,7 +302,7 @@ class LocationViewModelTest {
             viewModel =
                 LocationViewModel(
                     app,
-                    e2eeManagerParam = E2eeManager(createTestSqlDriver()),
+                    e2eeManagerParam = E2eeManager(createTestSqlDriver(), UnconfinedTestDispatcher()),
                     startPolling = false,
                     locationSourceParam = source,
                     uiStateStoreParam = uiStore,
@@ -370,7 +371,7 @@ class LocationViewModelTest {
     @Test
     fun testCancelPendingInit_SurgicalRemoval() =
         runTest {
-            val store = E2eeManager(createTestSqlDriver())
+            val store = E2eeManager(createTestSqlDriver(), UnconfinedTestDispatcher())
             val client = mockk<LocationClient>(relaxed = true)
             val source = TestFakeLocationSource()
             viewModel =
@@ -562,7 +563,7 @@ class LocationViewModelTest {
             viewModel =
                 LocationViewModel(
                     app,
-                    e2eeManagerParam = E2eeManager(createTestSqlDriver()),
+                    e2eeManagerParam = E2eeManager(createTestSqlDriver(), UnconfinedTestDispatcher()),
                     userStoreParam = userStore,
                     startPolling = false,
                     locationSourceParam = source,
@@ -773,7 +774,7 @@ class LocationViewModelTest {
             viewModel =
                 LocationViewModel(
                     app,
-                    e2eeManagerParam = E2eeManager(createTestSqlDriver()),
+                    e2eeManagerParam = E2eeManager(createTestSqlDriver(), UnconfinedTestDispatcher()),
                     locationClientParam = mockClient,
                     userStoreParam = net.af0.where.e2ee.UserStore(FakeRawKeyValueStorage()),
                     startPolling = false,
@@ -814,7 +815,7 @@ class LocationViewModelTest {
             viewModel =
                 LocationViewModel(
                     app,
-                    e2eeManagerParam = E2eeManager(createTestSqlDriver()),
+                    e2eeManagerParam = E2eeManager(createTestSqlDriver(), UnconfinedTestDispatcher()),
                     locationClientParam = mockClient,
                     userStoreParam = userStore,
                     startPolling = false,

--- a/android/src/androidUnitTest/kotlin/net/af0/where/TestWhereApplication.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/TestWhereApplication.kt
@@ -5,6 +5,8 @@ import android.content.SharedPreferences
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import net.af0.where.db.WhereDatabase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import net.af0.where.e2ee.E2eeManager
 import net.af0.where.e2ee.RawKeyValueStorage
 import net.af0.where.e2ee.UserStore
@@ -38,7 +40,8 @@ class TestWhereApplication : WhereApplication() {
         getSharedPreferences("test_encrypted_prefs", Context.MODE_PRIVATE)
     }
 
-    override val e2eeManager: E2eeManager by lazy { E2eeManager(createTestSqlDriver(this)) }
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override val e2eeManager: E2eeManager by lazy { E2eeManager(createTestSqlDriver(this), UnconfinedTestDispatcher()) }
 
     /**
      * UserStore still uses in-memory storage here because it stores simple global settings

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeManager.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeManager.kt
@@ -2,7 +2,6 @@ package net.af0.where.e2ee
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.Serializable
@@ -91,7 +90,7 @@ class E2eeManager(
     ioDispatcher: CoroutineDispatcher,
 ) {
     // Secondary constructor for callers (including Swift/ObjC) that don't need to inject a dispatcher.
-    constructor(sqlDriver: app.cash.sqldelight.db.SqlDriver) : this(sqlDriver, Dispatchers.Default)
+    constructor(sqlDriver: app.cash.sqldelight.db.SqlDriver) : this(sqlDriver, storageDispatcher)
 
     private val persistence = E2eeStore(net.af0.where.db.WhereDatabase(sqlDriver), ioDispatcher)
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeManager.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeManager.kt
@@ -88,8 +88,11 @@ internal fun PendingInvite.toView() = PendingInviteView(qrPayload, createdAt, ex
  */
 class E2eeManager(
     sqlDriver: app.cash.sqldelight.db.SqlDriver,
-    ioDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    ioDispatcher: CoroutineDispatcher,
 ) {
+    // Secondary constructor for callers (including Swift/ObjC) that don't need to inject a dispatcher.
+    constructor(sqlDriver: app.cash.sqldelight.db.SqlDriver) : this(sqlDriver, Dispatchers.Default)
+
     private val persistence = E2eeStore(net.af0.where.db.WhereDatabase(sqlDriver), ioDispatcher)
 
     val diagnosticLog: StateFlow<List<String>> = persistence.diagnosticLog

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeManager.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeManager.kt
@@ -1,6 +1,8 @@
 package net.af0.where.e2ee
 
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.Serializable
@@ -86,8 +88,9 @@ internal fun PendingInvite.toView() = PendingInviteView(qrPayload, createdAt, ex
  */
 class E2eeManager(
     sqlDriver: app.cash.sqldelight.db.SqlDriver,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
-    private val persistence = E2eeStore(net.af0.where.db.WhereDatabase(sqlDriver))
+    private val persistence = E2eeStore(net.af0.where.db.WhereDatabase(sqlDriver), ioDispatcher)
 
     val diagnosticLog: StateFlow<List<String>> = persistence.diagnosticLog
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -1,12 +1,14 @@
 package net.af0.where.e2ee
 
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -53,6 +55,9 @@ internal class E2eeStore(
     // Single lock for all store operations.
     private val storeLock = Mutex()
 
+    private suspend fun <T> withStoreLock(block: suspend () -> T): T =
+        withContext(Dispatchers.IO) { storeLock.withLock { block() } }
+
     init {
         loadFromDb()
     }
@@ -85,7 +90,7 @@ internal class E2eeStore(
     }
 
     suspend fun <T> withMetadataLock(block: suspend MetadataScope.() -> T): T {
-        return storeLock.withLock {
+        return withStoreLock {
             val scope = MetadataScopeImpl()
             val result: T
             try {
@@ -108,7 +113,7 @@ internal class E2eeStore(
         friendId: String,
         block: suspend (FriendEntry?, MetadataScope) -> Pair<PersistenceAction, T>,
     ): T {
-        return storeLock.withLock {
+        return withStoreLock {
             val entry = friends[friendId]
             val scope = MetadataScopeImpl()
             val result: T
@@ -142,9 +147,9 @@ internal class E2eeStore(
         }
     }
 
-    suspend fun getFriend(id: String): FriendEntry? = storeLock.withLock { friends[id] }
+    suspend fun getFriend(id: String): FriendEntry? = withStoreLock { friends[id] }
 
-    suspend fun listFriends(): List<FriendEntry> = storeLock.withLock { friends.values.toList() }
+    suspend fun listFriends(): List<FriendEntry> = withStoreLock { friends.values.toList() }
 
     fun addDiagnosticEvent(message: String, coalesceKey: String? = null) {
         val t = currentTimeSeconds()
@@ -233,7 +238,7 @@ internal class E2eeStore(
         token: String,
         payloadBlob: ByteArray,
         createdAt: Long,
-    ) = storeLock.withLock {
+    ) = withStoreLock {
         insertOutboxInternal(msgId, friendId, token, payloadBlob, createdAt)
     }
 
@@ -250,7 +255,7 @@ internal class E2eeStore(
     suspend fun deleteOutboxByMsgId(
         friendId: String,
         msgId: String,
-    ) = storeLock.withLock {
+    ) = withStoreLock {
         deleteOutboxByMsgIdInternal(friendId, msgId)
     }
 
@@ -262,7 +267,7 @@ internal class E2eeStore(
     }
 
     suspend fun deleteOutboxByFriendId(friendId: String) =
-        storeLock.withLock {
+        withStoreLock {
             deleteOutboxByFriendIdInternal(friendId)
         }
 
@@ -275,7 +280,7 @@ internal class E2eeStore(
     }
 
     suspend fun getOutbox(friendId: String): List<EncryptedOutboxMessage> =
-        storeLock.withLock {
+        withStoreLock {
             getOutboxInternal(friendId)
         }
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -2,7 +2,6 @@ package net.af0.where.e2ee
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -35,7 +34,7 @@ internal sealed class PersistenceAction {
  */
 internal class E2eeStore(
     private val database: net.af0.where.db.WhereDatabase,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    private val ioDispatcher: CoroutineDispatcher = storageDispatcher,
 ) {
     internal companion object {
         val json =
@@ -58,7 +57,7 @@ internal class E2eeStore(
     private val storeLock = Mutex()
 
     private suspend fun <T> withStoreLock(block: suspend () -> T): T =
-        withContext(ioDispatcher) { storeLock.withLock { block() } }
+        storeLock.withLock { withContext(ioDispatcher) { block() } }
 
     init {
         loadFromDb()
@@ -149,9 +148,9 @@ internal class E2eeStore(
         }
     }
 
-    suspend fun getFriend(id: String): FriendEntry? = withStoreLock { friends[id] }
+    suspend fun getFriend(id: String): FriendEntry? = storeLock.withLock { friends[id] }
 
-    suspend fun listFriends(): List<FriendEntry> = withStoreLock { friends.values.toList() }
+    suspend fun listFriends(): List<FriendEntry> = storeLock.withLock { friends.values.toList() }
 
     fun addDiagnosticEvent(message: String, coalesceKey: String? = null) {
         val t = currentTimeSeconds()

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -56,7 +56,7 @@ internal class E2eeStore(
     private val storeLock = Mutex()
 
     private suspend fun <T> withStoreLock(block: suspend () -> T): T =
-        withContext(Dispatchers.IO) { storeLock.withLock { block() } }
+        withContext(Dispatchers.Default) { storeLock.withLock { block() } }
 
     init {
         loadFromDb()

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -1,6 +1,7 @@
 package net.af0.where.e2ee
 
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -34,6 +35,7 @@ internal sealed class PersistenceAction {
  */
 internal class E2eeStore(
     private val database: net.af0.where.db.WhereDatabase,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
     internal companion object {
         val json =
@@ -56,7 +58,7 @@ internal class E2eeStore(
     private val storeLock = Mutex()
 
     private suspend fun <T> withStoreLock(block: suspend () -> T): T =
-        withContext(Dispatchers.Default) { storeLock.withLock { block() } }
+        withContext(ioDispatcher) { storeLock.withLock { block() } }
 
     init {
         loadFromDb()

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/StorageDispatcher.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/StorageDispatcher.kt
@@ -1,0 +1,5 @@
+package net.af0.where.e2ee
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+internal expect val storageDispatcher: CoroutineDispatcher

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/CatchUpTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/CatchUpTest.kt
@@ -36,12 +36,12 @@ class CatchUpTest {
     @Test
     fun testCatchUpLargeBacklog() = runTest {
         val aliceDriver = createTestSqlDriver()
-        val aliceManager = E2eeManager(aliceDriver)
+        val aliceManager = testE2eeManager(aliceDriver)
         val aliceClient = LocationClient("http://localhost", aliceManager, mailbox)
         val qr = aliceManager.createInvite("Alice")
 
         val bobDriver = createTestSqlDriver()
-        val bobManager = E2eeManager(bobDriver)
+        val bobManager = testE2eeManager(bobDriver)
         val bobClient = LocationClient("http://localhost", bobManager, mailbox)
 
         // 1. Bob scans and posts handshake
@@ -83,12 +83,12 @@ class CatchUpTest {
     @Test
     fun testTokenFollowBound() = runTest {
         val aliceDriver = createTestSqlDriver()
-        val aliceManager = E2eeManager(aliceDriver)
+        val aliceManager = testE2eeManager(aliceDriver)
         val aliceClient = LocationClient("http://localhost", aliceManager, mailbox)
         val qr = aliceManager.createInvite("Alice")
 
         val bobDriver = createTestSqlDriver()
-        val bobManager = E2eeManager(bobDriver)
+        val bobManager = testE2eeManager(bobDriver)
         val bobClient = LocationClient("http://localhost", bobManager, mailbox)
 
         // Handshake
@@ -156,12 +156,12 @@ class CatchUpTest {
     @Test
     fun testForceAckBreaksLoop() = runTest {
         val aliceDriver = createTestSqlDriver()
-        val aliceManager = E2eeManager(aliceDriver)
+        val aliceManager = testE2eeManager(aliceDriver)
         val aliceClient = LocationClient("http://localhost", aliceManager, mailbox)
         val qr = aliceManager.createInvite("Alice")
 
         val bobDriver = createTestSqlDriver()
-        val bobManager = E2eeManager(bobDriver)
+        val bobManager = testE2eeManager(bobDriver)
         val bobClient = LocationClient("http://localhost", bobManager, mailbox)
 
         // Handshake
@@ -195,12 +195,12 @@ class CatchUpTest {
     @Test
     fun testIsCaughtUpState() = runTest {
         val aliceDriver = createTestSqlDriver()
-        val aliceManager = E2eeManager(aliceDriver)
+        val aliceManager = testE2eeManager(aliceDriver)
         val aliceClient = LocationClient("http://localhost", aliceManager, mailbox)
         val qr = aliceManager.createInvite("Alice")
 
         val bobDriver = createTestSqlDriver()
-        val bobManager = E2eeManager(bobDriver)
+        val bobManager = testE2eeManager(bobDriver)
         val bobClient = LocationClient("http://localhost", bobManager, mailbox)
 
         // Handshake

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeChaosTest.kt
@@ -119,8 +119,8 @@ class E2eeChaosTest {
             val aliceSqlDriver = createTestSqlDriver()
             val bobSqlDriver = createTestSqlDriver()
 
-            val aliceManager = E2eeManager(aliceSqlDriver)
-            val bobManager = E2eeManager(bobSqlDriver)
+            val aliceManager = testE2eeManager(aliceSqlDriver)
+            val bobManager = testE2eeManager(bobSqlDriver)
 
             val qr = aliceManager.createInvite("Alice")
             val (initPayload, bobEntry) = bobManager.processScannedQr(qr, "Bob")
@@ -276,10 +276,10 @@ class E2eeChaosTest {
             val mailbox = MemoryMailboxClient()
             val chaosMailbox = ChaosMailboxClient(mailbox)
 
-            val aliceManager = E2eeManager(createTestSqlDriver())
+            val aliceManager = testE2eeManager(createTestSqlDriver())
             val aliceClient = LocationClient("http://localhost", aliceManager, chaosMailbox)
 
-            val bobManager = E2eeManager(createTestSqlDriver())
+            val bobManager = testE2eeManager(createTestSqlDriver())
             val bobClient = LocationClient("http://localhost", bobManager, chaosMailbox)
 
             // 1. Enable AGGRESSIVE chaos BEFORE handshake starts
@@ -404,7 +404,7 @@ class E2eeChaosTest {
         val managers =
             (0 until numFriends).map { i ->
                 val driver = createTestSqlDriver()
-                E2eeManager(driver)
+                testE2eeManager(driver)
             }
 
         val clients =

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeTestInitializer.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/E2eeTestInitializer.kt
@@ -1,6 +1,9 @@
 package net.af0.where.e2ee
 
+import app.cash.sqldelight.db.SqlDriver
 import com.ionspin.kotlin.crypto.LibsodiumInitializer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 /**
  * Singleton that ensures libsodium is initialized exactly once for tests.
@@ -37,3 +40,6 @@ object E2eeTestInitializer {
 fun initializeE2eeTests() {
     E2eeTestInitializer.ensureInitialized()
 }
+
+@OptIn(ExperimentalCoroutinesApi::class)
+fun testE2eeManager(driver: SqlDriver) = E2eeManager(driver, UnconfinedTestDispatcher())

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/InviteLimitTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/InviteLimitTest.kt
@@ -11,7 +11,7 @@ class InviteLimitTest {
     @Test
     fun testInviteLimitDropsOldest() = runTest {
         val driver = createTestSqlDriver()
-        val manager = E2eeManager(driver)
+        val manager = testE2eeManager(driver)
 
         // Create 10 invites
         val firstQr = manager.createInvite("Invite-0")

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/LocationHandshakeTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/LocationHandshakeTest.kt
@@ -28,7 +28,7 @@ class LocationHandshakeTest {
     @Test
     fun testHandshakeMatchingWithMultipleInvites() = runTest {
         val aliceDriver = createTestSqlDriver()
-        val aliceManager = E2eeManager(aliceDriver)
+        val aliceManager = testE2eeManager(aliceDriver)
         val aliceClient = LocationClient("http://localhost", aliceManager, mailbox)
 
         // 1. Alice creates 3 different invites
@@ -38,7 +38,7 @@ class LocationHandshakeTest {
 
         // 2. Bob scans the SECOND invite
         val bobDriver = createTestSqlDriver()
-        val bobManager = E2eeManager(bobDriver)
+        val bobManager = testE2eeManager(bobDriver)
         val bobClient = LocationClient("http://localhost", bobManager, mailbox)
         
         val (initPayload, bobEntry) = bobManager.processScannedQr(qr2, "Bob")
@@ -65,12 +65,12 @@ class LocationHandshakeTest {
     @Test
     fun testLocationUpdatesFlowImmediatelyAfterHandshake() = runTest {
         val aliceDriver = createTestSqlDriver()
-        val aliceManager = E2eeManager(aliceDriver)
+        val aliceManager = testE2eeManager(aliceDriver)
         val aliceClient = LocationClient("http://localhost", aliceManager, mailbox)
         val qr = aliceManager.createInvite("Alice")
 
         val bobDriver = createTestSqlDriver()
-        val bobManager = E2eeManager(bobDriver)
+        val bobManager = testE2eeManager(bobDriver)
         val bobClient = LocationClient("http://localhost", bobManager, mailbox)
 
         // 1. Bob scans and posts handshake
@@ -108,12 +108,12 @@ class LocationHandshakeTest {
     @Test
     fun testPollDoesNotConsumeInvite() = runTest {
         val aliceDriver = createTestSqlDriver()
-        val aliceManager = E2eeManager(aliceDriver)
+        val aliceManager = testE2eeManager(aliceDriver)
         val aliceClient = LocationClient("http://localhost", aliceManager, mailbox)
         val qr = aliceManager.createInvite("Alice")
 
         val bobDriver = createTestSqlDriver()
-        val bobManager = E2eeManager(bobDriver)
+        val bobManager = testE2eeManager(bobDriver)
         val bobClient = LocationClient("http://localhost", bobManager, mailbox)
 
         val (initPayload, bobEntry) = bobManager.processScannedQr(qr, "Bob")
@@ -144,12 +144,12 @@ class LocationHandshakeTest {
     @Test
     fun testAliceSendsLocationToBobAfterHandshake() = runTest {
         val aliceDriver = createTestSqlDriver()
-        val aliceManager = E2eeManager(aliceDriver)
+        val aliceManager = testE2eeManager(aliceDriver)
         val aliceClient = LocationClient("http://localhost", aliceManager, mailbox)
         val qr = aliceManager.createInvite("Alice")
 
         val bobDriver = createTestSqlDriver()
-        val bobManager = E2eeManager(bobDriver)
+        val bobManager = testE2eeManager(bobDriver)
         val bobClient = LocationClient("http://localhost", bobManager, mailbox)
 
         // Bob scans and posts

--- a/shared/src/iosMain/kotlin/net/af0/where/e2ee/StorageDispatcher.kt
+++ b/shared/src/iosMain/kotlin/net/af0/where/e2ee/StorageDispatcher.kt
@@ -1,0 +1,8 @@
+package net.af0.where.e2ee
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+// Dispatchers.IO is internal in Kotlin/Native; Default is equivalent here since
+// NativeSqliteDriver handles its own threading and there is no ANR concept on iOS.
+internal actual val storageDispatcher: CoroutineDispatcher = Dispatchers.Default

--- a/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/StorageDispatcher.kt
+++ b/shared/src/jvmAndAndroidMain/kotlin/net/af0/where/e2ee/StorageDispatcher.kt
@@ -1,0 +1,6 @@
+package net.af0.where.e2ee
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+internal actual val storageDispatcher: CoroutineDispatcher = Dispatchers.IO


### PR DESCRIPTION
Adds a withStoreLock helper that wraps every storeLock.withLock body in withContext(Dispatchers.IO), so all SQLite calls are off the main thread regardless of the caller's dispatcher. Fixes the ANR risk described in #290.