### PR TITLE
Add constant-time comparisons and cap skipped key limit

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
@@ -132,8 +132,12 @@ object KeyExchange {
 
             // VERIFY TOKEN (#168): Alice MUST verify that Bob computed the same initial routing token.
             // Alice is the initiator, so her SEND token (Alice->Bob) uses (AliceFp, BobFp).
+            // Constant-time comparison (matching verifyKeyConfirmation) to prevent timing oracle.
             val expectedToken = deriveRoutingToken(sk, aliceFp, bobFp)
-            if (!expectedToken.contentEquals(msg.token)) {
+            var tokenDiff = expectedToken.size xor msg.token.size
+            val tokenLen = minOf(expectedToken.size, msg.token.size)
+            for (i in 0 until tokenLen) tokenDiff = tokenDiff or (expectedToken[i].toInt() xor msg.token[i].toInt())
+            if (tokenDiff != 0) {
                 val expectedHex = expectedToken.toHex()
                 val providedHex = msg.token.toHex()
                 throw AuthenticationException(

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -208,7 +208,8 @@ object Session {
 
         val pnGaps =
             if (isNewDhEpoch && header.pn > cleanState.recvSeq) {
-                (header.pn - cleanState.recvSeq).toInt()
+                val diff = header.pn - cleanState.recvSeq
+                if (diff > MAX_SKIPPED_KEYS) MAX_SKIPPED_KEYS else diff.toInt()
             } else {
                 0
             }


### PR DESCRIPTION
## Summary
This PR hardens the E2EE implementation against timing oracle attacks and adds a safety limit on skipped message keys during Double Ratchet epoch transitions.

## Key changes

- **Constant-time token comparison in KeyExchange** (`KeyExchange.kt`):
  - Replace `contentEquals()` check for routing token verification with a constant-time comparison loop
  - Prevents timing oracle attacks that could leak information about token mismatches
  - Matches the existing constant-time pattern used in `verifyKeyConfirmation()`
  - First compares sizes using XOR, then iterates through all bytes regardless of early mismatch

- **Cap skipped keys limit in Session** (`Session.kt`):
  - Add `MAX_SKIPPED_KEYS` bound when calculating packet number gaps during new DH epoch transitions
  - Prevents unbounded memory growth from processing messages with extremely large packet number jumps
  - Maintains backward compatibility by only capping when the gap exceeds the limit

## Implementation details

The constant-time comparison uses bitwise XOR accumulation to avoid early returns that could leak timing information. The skipped keys cap is applied only when `isNewDhEpoch` and the gap would exceed the configured maximum, ensuring legitimate out-of-order messages are still handled correctly.

https://claude.ai/code/session_01SvssntyMVkqMnQFtChjrHY