### PR TITLE
Drop legacy bypass for empty encryptedName in key exchange

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
@@ -244,8 +244,6 @@ object KeyExchange {
         ekBPub: ByteArray,
         encryptedName: ByteArray,
     ): String {
-        // TODO: remove allowing empty encrypted_name once some time has passed and legacy clients are updated.
-        if (encryptedName.isEmpty()) return ""
         if (encryptedName.size < 28) { // 12-byte nonce + 16-byte tag
             throw AuthenticationException("encryptedName payload is too short")
         }

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
@@ -172,13 +172,13 @@ class KeyExchangeTest {
     }
 
     @Test
-    fun `decryptSuggestedName handles empty name for legacy compatibility`() {
+    fun `decryptSuggestedName rejects empty encryptedName`() {
         val sk = randomBytes(32)
         val ekA = randomBytes(32)
         val ekB = randomBytes(32)
-        
-        val decrypted = KeyExchange.decryptSuggestedName(sk, ekA, ekB, byteArrayOf())
-        assertEquals("", decrypted)
+        assertFailsWith<AuthenticationException> {
+            KeyExchange.decryptSuggestedName(sk, ekA, ekB, byteArrayOf())
+        }
         sk.zeroize()
     }
 

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
@@ -172,6 +172,28 @@ class KeyExchangeTest {
     }
 
     @Test
+    fun `decryptSuggestedName round-trips the name Bob encrypted`() {
+        val (qr, aliceEkPriv) = KeyExchange.aliceCreateQrPayload("Alice")
+        val (msg, _) = KeyExchange.bobProcessQr(qr, "Bob")
+        val sk = x25519(aliceEkPriv, msg.ekPub)
+        val name = KeyExchange.decryptSuggestedName(sk, qr.ekPub, msg.ekPub, msg.encryptedName)
+        assertEquals("Bob", name)
+        sk.zeroize()
+    }
+
+    @Test
+    fun `decryptSuggestedName rejects wrong session key`() {
+        val (qr, aliceEkPriv) = KeyExchange.aliceCreateQrPayload("Alice")
+        val (msg, _) = KeyExchange.bobProcessQr(qr, "Bob")
+        val wrongSk = randomBytes(32)
+        assertFailsWith<AuthenticationException> {
+            KeyExchange.decryptSuggestedName(wrongSk, qr.ekPub, msg.ekPub, msg.encryptedName)
+        }
+        aliceEkPriv.zeroize()
+        wrongSk.zeroize()
+    }
+
+    @Test
     fun `decryptSuggestedName rejects empty encryptedName`() {
         val sk = randomBytes(32)
         val ekA = randomBytes(32)


### PR DESCRIPTION
## Summary

- Removes the two-line legacy bypass in `decryptSuggestedName` that silently accepted an empty `encryptedName` during key exchange
- All current clients send a properly AEAD-encrypted `suggestedName`; the bypass was a temporary compatibility shim while old builds cycled out
- With the bypass gone, every pairing attempt must now supply a well-formed ciphertext (≥28 bytes) that passes ChaCha20-Poly1305 authentication

## Security impact

The `encryptedName` AEAD check is a secondary binding on top of the existing `keyConfirmation` HMAC — removing the bypass does not weaken the key exchange, but it does close the gap where a legacy (or malformed) message could skip that authentication step.

## Test plan

- [ ] Pair two up-to-date clients (iOS ↔ Android) and confirm pairing succeeds
- [ ] Confirm that a synthesized `KeyExchangeInit` with `encryptedName = []` is now rejected with `AuthenticationException`

https://claude.ai/code/session_01SvssntyMVkqMnQFtChjrHY

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvssntyMVkqMnQFtChjrHY)_