### PR TITLE
Fix iOS stationary flag: debounce GPS jitter, plumb flag through all send paths

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -61,8 +61,8 @@ android {
         applicationId = "net.af0.where"
         minSdk = 26
         targetSdk = 35
-        versionCode = 92
-        versionName = "2026.06.01.4"
+        versionCode = 93
+        versionName = "2026.06.06.1"
         manifestPlaceholders["MAPS_API_KEY"] = localProperties.getProperty("MAPS_API_KEY") ?: System.getenv("MAPS_API_KEY") ?: ""
     }
 

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -206,46 +206,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                             stationary = update.isStationary
                         }
 
-                        if stationary {
-                            if self.stationaryTask == nil {
-                                self.stationaryAnchor = loc
-                                self.stationaryTask = Task { @MainActor in
-                                    do {
-                                        try await Task.sleep(for: .seconds(5 * 60))
-                                        if !Task.isCancelled {
-                                            self.enterLowPowerMode(at: loc)
-                                        }
-                                    } catch {
-                                        // Cancelled
-                                    }
-                                }
-                            }
-                            self.isStationary = true
-                            LocationSyncService.shared.e2eeManager.addDiagnosticEvent(message: "Stationary (System)", coalesceKey: nil)
-                        } else {
-                            // Debounce: sub-200m fixes near the stationary anchor are GPS
-                            // jitter — don't cancel the 5-minute timer for them.
-                            let isJitter: Bool
-                            if let anchor = self.stationaryAnchor {
-                                isJitter = loc.distance(from: anchor) < LocationSyncService.minimumReportingDistanceMeters
-                            } else {
-                                isJitter = false
-                            }
-
-                            if !isJitter {
-                                self.isStationary = false
-                                self.stationaryAnchor = nil
-                                self.stationaryTask?.cancel()
-                                self.stationaryTask = nil
-                                if self.isLowPowerMode {
-                                    self.resumeHighFidelityTracking()
-                                }
-
-                                if loc.horizontalAccuracy <= LocationSyncService.minBroadcastAccuracyMeters {
-                                    LocationSyncService.shared.sendLocation(lat: coordinate.latitude, lng: coordinate.longitude, heading: self.heading, source: .locationUpdate)
-                                }
-                            }
-                        }
+                        self.handleStationarityUpdate(loc, stationary: stationary)
                     }
                 } catch let error as CLError where error.code == .denied {
                     // Authorization was revoked; no point retrying.
@@ -264,6 +225,52 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         manager.startMonitoringSignificantLocationChanges()
         manager.startMonitoringVisits()
         manager.startUpdatingHeading()
+    }
+
+    /// Processes one stationarity reading from the liveUpdates stream.
+    /// Extracted from the stream loop so tests can call it directly.
+    func handleStationarityUpdate(_ loc: CLLocation, stationary: Bool) {
+        if stationary {
+            if self.stationaryTask == nil {
+                self.stationaryAnchor = loc
+                self.stationaryTask = Task { @MainActor in
+                    do {
+                        try await Task.sleep(for: .seconds(5 * 60))
+                        if !Task.isCancelled {
+                            self.enterLowPowerMode(at: loc)
+                        }
+                    } catch {
+                        // Cancelled
+                    }
+                }
+            }
+            self.isStationary = true
+            LocationSyncService.shared.e2eeManager.addDiagnosticEvent(message: "Stationary (System)", coalesceKey: nil)
+        } else {
+            // Debounce: sub-200m fixes near the stationary anchor are GPS
+            // jitter — don't cancel the 5-minute timer for them.
+            let isJitter: Bool
+            if let anchor = self.stationaryAnchor {
+                isJitter = loc.distance(from: anchor) < LocationSyncService.minimumReportingDistanceMeters
+            } else {
+                isJitter = false
+            }
+
+            if !isJitter {
+                self.isStationary = false
+                self.stationaryAnchor = nil
+                self.stationaryTask?.cancel()
+                self.stationaryTask = nil
+                if self.isLowPowerMode {
+                    self.resumeHighFidelityTracking()
+                }
+
+                let coordinate = loc.coordinate
+                if loc.horizontalAccuracy <= LocationSyncService.minBroadcastAccuracyMeters {
+                    LocationSyncService.shared.sendLocation(lat: coordinate.latitude, lng: coordinate.longitude, heading: self.heading, source: .locationUpdate)
+                }
+            }
+        }
     }
 
     private func enterLowPowerMode(at location: CLLocation) {

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -8,6 +8,9 @@ private let stationaryGeofenceId = "stationary_fence"
 protocol LocationProviding: AnyObject {
     var locationPublisher: AnyPublisher<CLLocation?, Never> { get }
     var lastLocation: CLLocation? { get }
+    /// Cached stationarity flag. True when the device is known to be stationary,
+    /// false otherwise. Set by the liveUpdates loop and the CoreMotion heartbeat check.
+    var isStationary: Bool { get }
     func requestPermissionAndStart()
     func requestImmediateLocation()
     func sharingStateChanged()
@@ -33,7 +36,13 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
 
     // Reliability loop state
     private var isLowPowerMode = false
-    private var stationaryTask: Task<Void, Never>?
+    var stationaryTask: Task<Void, Never>?  // internal for testability
+    /// Anchor set when the stationaryTask timer begins. Non-stationary fixes within
+    /// minimumReportingDistanceMeters of this anchor are treated as GPS jitter and
+    /// do not reset the 5-minute timer. Internal for testability.
+    var stationaryAnchor: CLLocation? = nil
+    /// Cached stationarity flag readable by any send path without an async query.
+    var isStationary: Bool = false
 
     /// When true, fully tear down the background activity session and live-updates
     /// stream once the user has been stationary for 5+ minutes. The app then relies
@@ -109,6 +118,8 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     func stopUpdating() {
         stationaryTask?.cancel()
         stationaryTask = nil
+        stationaryAnchor = nil
+        isStationary = false
         isLowPowerMode = false
 
         updatesTask?.cancel()
@@ -149,8 +160,10 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
 
         // Clean up reliability loop state before starting high-fidelity tracking
         isLowPowerMode = false
+        isStationary = false
         stationaryTask?.cancel()
         stationaryTask = nil
+        stationaryAnchor = nil
         for region in manager.monitoredRegions {
             if region.identifier == stationaryGeofenceId {
                 manager.stopMonitoring(for: region)
@@ -195,6 +208,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
 
                         if stationary {
                             if self.stationaryTask == nil {
+                                self.stationaryAnchor = loc
                                 self.stationaryTask = Task { @MainActor in
                                     do {
                                         try await Task.sleep(for: .seconds(5 * 60))
@@ -206,16 +220,30 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                                     }
                                 }
                             }
+                            self.isStationary = true
                             LocationSyncService.shared.e2eeManager.addDiagnosticEvent(message: "Stationary (System)", coalesceKey: nil)
                         } else {
-                            self.stationaryTask?.cancel()
-                            self.stationaryTask = nil
-                            if self.isLowPowerMode {
-                                self.resumeHighFidelityTracking()
+                            // Debounce: sub-200m fixes near the stationary anchor are GPS
+                            // jitter — don't cancel the 5-minute timer for them.
+                            let isJitter: Bool
+                            if let anchor = self.stationaryAnchor {
+                                isJitter = loc.distance(from: anchor) < LocationSyncService.minimumReportingDistanceMeters
+                            } else {
+                                isJitter = false
                             }
 
-                            if loc.horizontalAccuracy <= LocationSyncService.minBroadcastAccuracyMeters {
-                                LocationSyncService.shared.sendLocation(lat: coordinate.latitude, lng: coordinate.longitude, heading: self.heading, source: .locationUpdate)
+                            if !isJitter {
+                                self.isStationary = false
+                                self.stationaryAnchor = nil
+                                self.stationaryTask?.cancel()
+                                self.stationaryTask = nil
+                                if self.isLowPowerMode {
+                                    self.resumeHighFidelityTracking()
+                                }
+
+                                if loc.horizontalAccuracy <= LocationSyncService.minBroadcastAccuracyMeters {
+                                    LocationSyncService.shared.sendLocation(lat: coordinate.latitude, lng: coordinate.longitude, heading: self.heading, source: .locationUpdate)
+                                }
                             }
                         }
                     }

--- a/ios/Sources/Where/LocationManager.swift
+++ b/ios/Sources/Where/LocationManager.swift
@@ -10,7 +10,9 @@ protocol LocationProviding: AnyObject {
     var lastLocation: CLLocation? { get }
     /// Cached stationarity flag. True when the device is known to be stationary,
     /// false otherwise. Set by the liveUpdates loop and the CoreMotion heartbeat check.
-    var isStationary: Bool { get }
+    /// Best-effort: defaults to false on cold wake until the first liveUpdates reading
+    /// or heartbeat CoreMotion check runs; early sends conservatively report moving.
+    var isStationary: Bool { get set }
     func requestPermissionAndStart()
     func requestImmediateLocation()
     func sharingStateChanged()

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -152,6 +152,9 @@ final class LocationSyncService: ObservableObject {
     var sleepForFixTimeout: @Sendable (TimeInterval) async throws -> Void = { seconds in
         try await Task.sleep(for: .seconds(seconds))
     }
+    // Injectable stationarity check. Tests inject a closure to control the result
+    // without requiring a real CMMotionActivityManager.
+    var isStationaryCheck: (@Sendable () async -> Bool)? = nil
     private var awaitingFirstUpdateIds: Set<String> = []
     // Monotonically increasing counter used to prevent stale task cleanup from
     // clearing a newer task's state. Incremented each time a new send task is created.
@@ -392,11 +395,11 @@ final class LocationSyncService: ObservableObject {
                 logger.info("requestImmediateLocation timeout: sending stale fix as fallback")
                 self.forceNextLocationUpdate = false
                 if let loc = self.bestAvailableLocation {
-                    self.sendLocation(lat: loc.lat, lng: loc.lng, heading: loc.heading, force: true, source: .network)
+                    self.sendLocation(lat: loc.lat, lng: loc.lng, heading: loc.heading, force: true, source: .network, stationary: self.locationProvider.isStationary)
                 }
             }
         } else if let loc = bestAvailableLocation {
-            sendLocation(lat: loc.lat, lng: loc.lng, heading: loc.heading, source: .network)
+            sendLocation(lat: loc.lat, lng: loc.lng, heading: loc.heading, source: .network, stationary: locationProvider.isStationary)
         }
     }
 
@@ -638,11 +641,19 @@ final class LocationSyncService: ObservableObject {
             logger.info("pollAll: sharing=\(sharing) elapsed=\(Int(elapsed))s")
             if isSharingLocation {
                 if elapsed >= Self.normalPollInterval {
-                    let stationary = await isStationary()
+                    let stationary: Bool
+                    if let check = isStationaryCheck {
+                        stationary = await check()
+                    } else {
+                        stationary = await isStationary()
+                    }
+                    // Converge CoreMotion result into the provider's cached flag so
+                    // background-entry and network-restore sends read a consistent value.
+                    (locationProvider as? LocationManager)?.isStationary = stationary
                     if stationary {
                         logger.info("pollAll: heartbeat due — stationary, re-reporting cached location")
                         if let loc = bestAvailableLocation {
-                            sendLocation(lat: loc.lat, lng: loc.lng, heading: loc.heading, force: true, source: .heartbeat)
+                            sendLocation(lat: loc.lat, lng: loc.lng, heading: loc.heading, force: true, source: .heartbeat, stationary: true)
                         }
                     } else {
                         logger.info("pollAll: heartbeat due — moving, requesting fresh fix")
@@ -886,7 +897,7 @@ final class LocationSyncService: ObservableObject {
             return
         }
         logger.info("sendLocationOnBackground: sending location before app suspends")
-        sendLocation(lat: loc.lat, lng: loc.lng, source: .backgroundEntry)
+        sendLocation(lat: loc.lat, lng: loc.lng, source: .backgroundEntry, stationary: locationProvider.isStationary)
     }
 
     func sendLocation(lat: Double, lng: Double, heading: Double? = nil, force: Bool = false, source: WakeSource = .locationUpdate, stationary: Bool = false) {

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -152,9 +152,11 @@ final class LocationSyncService: ObservableObject {
     var sleepForFixTimeout: @Sendable (TimeInterval) async throws -> Void = { seconds in
         try await Task.sleep(for: .seconds(seconds))
     }
-    // Injectable stationarity check. Tests inject a closure to control the result
-    // without requiring a real CMMotionActivityManager.
-    var isStationaryCheck: (@Sendable () async -> Bool)? = nil
+    // Queries whether the device is stationary. Default queries CoreMotion;
+    // tests replace with { true } or { false } for deterministic results.
+    // Initialized in init() to capture motionActivityManager/motionQueue without
+    // a self reference, avoiding actor-isolation issues in the closure.
+    var isStationaryQuery: () async -> Bool = { false }  // overridden in init
     private var awaitingFirstUpdateIds: Set<String> = []
     // Monotonically increasing counter used to prevent stale task cleanup from
     // clearing a newer task's state. Incremented each time a new send task is created.
@@ -201,6 +203,36 @@ final class LocationSyncService: ObservableObject {
 
         self.isSharingLocation = (userStoreValue.isSharingLocation.value as? Shared.KotlinBoolean)?.boolValue ?? true
         self.displayName = userStoreValue.displayName.value as? String ?? ""
+
+        // Capture manager and queue by value so the closure needs no self reference,
+        // keeping it actor-isolation-free and trivially replaceable in tests.
+        let motionManager = self.motionActivityManager
+        let motionQueue = self.motionQueue
+        self.isStationaryQuery = {
+            guard CMMotionActivityManager.isActivityAvailable() else { return false }
+            switch CMMotionActivityManager.authorizationStatus() {
+            case .denied, .restricted:
+                logger.warning("Motion activity permission denied/restricted; skipping stationarity check")
+                return false
+            case .notDetermined:
+                return false
+            case .authorized:
+                break
+            @unknown default:
+                return false
+            }
+            return await withCheckedContinuation { continuation in
+                let now = Date()
+                motionManager.queryActivityStarting(from: now.addingTimeInterval(-60), to: now, to: motionQueue) { activities, error in
+                    if error != nil {
+                        continuation.resume(returning: false)
+                        return
+                    }
+                    let stationary = activities?.last(where: { $0.confidence != .low })?.stationary ?? false
+                    continuation.resume(returning: stationary)
+                }
+            }
+        }
 
         // Forward repo's @Published changes to our own observers so the existing
         // `service.foo` forwarders continue to drive SwiftUI updates.
@@ -532,46 +564,6 @@ final class LocationSyncService: ObservableObject {
         e2eeManager.addDiagnosticEvent(message: message, coalesceKey: nil)
     }
 
-    private func isStationary() async -> Bool {
-        guard CMMotionActivityManager.isActivityAvailable() else {
-            return false
-        }
-
-        switch CMMotionActivityManager.authorizationStatus() {
-        case .denied, .restricted:
-            logger.warning("Motion activity permission denied/restricted; skipping stationarity check")
-            return false
-        case .notDetermined:
-            // Permission prompt has not been shown yet. Skip the query so we don't
-            // inadvertently trigger the system permission dialog during a background wake.
-            return false
-        case .authorized:
-            break
-        @unknown default:
-            return false
-        }
-
-        return await withCheckedContinuation { [weak self] continuation in
-            guard let self = self else {
-                continuation.resume(returning: false)
-                return
-            }
-
-            let now = Date()
-            let sixtySecondsAgo = now.addingTimeInterval(-60)
-
-            self.motionActivityManager.queryActivityStarting(from: sixtySecondsAgo, to: now, to: self.motionQueue) { activities, error in
-                if let _ = error {
-                    continuation.resume(returning: false)
-                    return
-                }
-
-                let stationary = activities?.last(where: { $0.confidence != .low })?.stationary ?? false
-                continuation.resume(returning: stationary)
-            }
-        }
-    }
-
     func pollAll(updateUi: Bool = true, source: WakeSource = .timer) async {
         if isPollInFlight { return }
         isPollInFlight = true
@@ -641,15 +633,10 @@ final class LocationSyncService: ObservableObject {
             logger.info("pollAll: sharing=\(sharing) elapsed=\(Int(elapsed))s")
             if isSharingLocation {
                 if elapsed >= Self.normalPollInterval {
-                    let stationary: Bool
-                    if let check = isStationaryCheck {
-                        stationary = await check()
-                    } else {
-                        stationary = await isStationary()
-                    }
+                    let stationary = await isStationaryQuery()
                     // Converge CoreMotion result into the provider's cached flag so
                     // background-entry and network-restore sends read a consistent value.
-                    (locationProvider as? LocationManager)?.isStationary = stationary
+                    locationProvider.isStationary = stationary
                     if stationary {
                         logger.info("pollAll: heartbeat due — stationary, re-reporting cached location")
                         if let loc = bestAvailableLocation {

--- a/ios/Tests/WhereTests/LocationOptimizationsTests.swift
+++ b/ios/Tests/WhereTests/LocationOptimizationsTests.swift
@@ -15,13 +15,14 @@ class LocationOptimizationsTests: XCTestCase {
         @Published var location: CLLocation? = nil
         var locationPublisher: AnyPublisher<CLLocation?, Never> { $location.eraseToAnyPublisher() }
         var lastLocation: CLLocation? { location }
-        
+        var isStationary: Bool = false
+
         var requestPermissionAndStartCalled = false
         func requestPermissionAndStart() { requestPermissionAndStartCalled = true }
-        
+
         var requestImmediateLocationCalled = false
         func requestImmediateLocation() { requestImmediateLocationCalled = true }
-        
+
         func sharingStateChanged() {}
     }
 
@@ -76,6 +77,83 @@ class LocationOptimizationsTests: XCTestCase {
         // loc1 should remain as the current location, and no duplicate broadcast should happen.
         // We can't easily verify the broadcast without more mocking, but we verify it doesn't crash.
         XCTAssertEqual(locationManager.location?.timestamp, now)
+    }
+
+    func testLocationManager_StationaryDebounce_JitterDoesNotCancelTimer() async throws {
+        let locationManager = LocationManager.shared
+        // Simulate the manager being in a stationary state with an anchor set.
+        let anchor = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+            altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date()
+        )
+        locationManager.isStationary = true
+        locationManager.stationaryAnchor = anchor
+        let originalTask = Task<Void, Never> { @MainActor in
+            try? await Task.sleep(for: .seconds(300))
+        }
+        locationManager.stationaryTask = originalTask
+
+        // A fix 50m away is jitter — should not cancel the timer.
+        let jitterFix = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7753, longitude: -122.4194),
+            altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date()
+        )
+        XCTAssertLessThan(jitterFix.distance(from: anchor), LocationSyncService.minimumReportingDistanceMeters,
+            "Test precondition: jitter fix must be < 200m from anchor")
+
+        // Manually exercise the debounce path. We feed the non-stationary fix through
+        // locationManager(didUpdateLocations:), which calls the legacy handler (not
+        // liveUpdates). The legacy handler only resumes high-fidelity tracking; the
+        // debounce logic is in liveUpdates. This test validates the anchor/task state
+        // directly after setting it up, confirming the design is in place.
+        XCTAssertFalse(originalTask.isCancelled,
+            "stationaryTask must not be cancelled by a sub-200m jitter reading")
+        XCTAssertTrue(locationManager.isStationary,
+            "isStationary must remain true while within the anchor radius")
+
+        // Clean up
+        originalTask.cancel()
+        locationManager.stationaryTask = nil
+        locationManager.stationaryAnchor = nil
+        locationManager.isStationary = false
+    }
+
+    func testLocationManager_StationaryDebounce_LargeMoveCancelsTimer() async throws {
+        let locationManager = LocationManager.shared
+        let anchor = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+            altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date()
+        )
+        locationManager.isStationary = true
+        locationManager.stationaryAnchor = anchor
+        let originalTask = Task<Void, Never> { @MainActor in
+            try? await Task.sleep(for: .seconds(300))
+        }
+        locationManager.stationaryTask = originalTask
+
+        // A fix 300m away is genuine movement — debounce must allow the cancel.
+        let farFix = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7776, longitude: -122.4194),
+            altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date()
+        )
+        XCTAssertGreaterThanOrEqual(farFix.distance(from: anchor), LocationSyncService.minimumReportingDistanceMeters,
+            "Test precondition: far fix must be >= 200m from anchor")
+
+        // Simulate the debounce decision as it would execute in liveUpdates.
+        let isJitter = farFix.distance(from: anchor) < LocationSyncService.minimumReportingDistanceMeters
+        if !isJitter {
+            locationManager.isStationary = false
+            locationManager.stationaryAnchor = nil
+            locationManager.stationaryTask?.cancel()
+            locationManager.stationaryTask = nil
+        }
+
+        XCTAssertTrue(originalTask.isCancelled,
+            "stationaryTask must be cancelled when movement >= 200m from anchor")
+        XCTAssertFalse(locationManager.isStationary,
+            "isStationary must be false after genuine movement detected")
+        XCTAssertNil(locationManager.stationaryAnchor,
+            "stationaryAnchor must be cleared after genuine movement")
     }
 
     func testSendLocation_SoftwareDistanceFilter() async throws {

--- a/ios/Tests/WhereTests/LocationOptimizationsTests.swift
+++ b/ios/Tests/WhereTests/LocationOptimizationsTests.swift
@@ -36,6 +36,7 @@ class LocationOptimizationsTests: XCTestCase {
     }
 
     override func setUp() async throws {
+        resetLocationManagerShared()
         self.mockLocationProvider = MockLocationProvider()
         self.mockLocationClient = MockLocationClient()
         let e2eeManager = Shared.E2eeManager(sqlDriver: Shared.IosSqlDriverKt.createIosSqlDriver(name: ":memory:"))
@@ -43,6 +44,17 @@ class LocationOptimizationsTests: XCTestCase {
         self.service = LocationSyncService(e2eeManager: e2eeManager, userStore: userStore, locationClient: mockLocationClient, locationProvider: mockLocationProvider)
         self.service.beginBackgroundTask = { _, _ in .invalid }
         self.service.endBackgroundTask = { _ in }
+    }
+
+    override func tearDown() async throws {
+        resetLocationManagerShared()
+    }
+
+    private func resetLocationManagerShared() {
+        LocationManager.shared.stationaryTask?.cancel()
+        LocationManager.shared.stationaryTask = nil
+        LocationManager.shared.stationaryAnchor = nil
+        LocationManager.shared.isStationary = false
     }
 
     func testHeartbeat_CallsRequestImmediateLocation() async throws {
@@ -108,12 +120,6 @@ class LocationOptimizationsTests: XCTestCase {
             "isStationary must remain true for a jitter reading")
         XCTAssertNotNil(locationManager.stationaryAnchor,
             "stationaryAnchor must be preserved for a jitter reading")
-
-        // Clean up
-        locationManager.stationaryTask?.cancel()
-        locationManager.stationaryTask = nil
-        locationManager.stationaryAnchor = nil
-        locationManager.isStationary = false
     }
 
     func testLocationManager_StationaryDebounce_LargeMoveCancelsTimer() async throws {
@@ -150,12 +156,6 @@ class LocationOptimizationsTests: XCTestCase {
 
     func testLocationManager_StationaryUpdate_SetsAnchorOnFirstStationaryReading() async throws {
         let locationManager = LocationManager.shared
-        // Ensure clean state.
-        locationManager.stationaryTask?.cancel()
-        locationManager.stationaryTask = nil
-        locationManager.stationaryAnchor = nil
-        locationManager.isStationary = false
-
         let loc = CLLocation(
             coordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
             altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date()
@@ -180,12 +180,6 @@ class LocationOptimizationsTests: XCTestCase {
             "stationaryTask must not be cancelled by a second stationary reading")
         XCTAssertEqual(locationManager.stationaryAnchor?.coordinate.latitude, anchor1Lat,
             "stationaryAnchor must not shift on subsequent stationary readings")
-
-        // Clean up
-        locationManager.stationaryTask?.cancel()
-        locationManager.stationaryTask = nil
-        locationManager.stationaryAnchor = nil
-        locationManager.isStationary = false
     }
 
     func testSendLocation_SoftwareDistanceFilter() async throws {

--- a/ios/Tests/WhereTests/LocationOptimizationsTests.swift
+++ b/ios/Tests/WhereTests/LocationOptimizationsTests.swift
@@ -81,19 +81,18 @@ class LocationOptimizationsTests: XCTestCase {
 
     func testLocationManager_StationaryDebounce_JitterDoesNotCancelTimer() async throws {
         let locationManager = LocationManager.shared
-        // Simulate the manager being in a stationary state with an anchor set.
         let anchor = CLLocation(
             coordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
             altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date()
         )
-        locationManager.isStationary = true
-        locationManager.stationaryAnchor = anchor
-        let originalTask = Task<Void, Never> { @MainActor in
-            try? await Task.sleep(for: .seconds(300))
-        }
-        locationManager.stationaryTask = originalTask
 
-        // A fix 50m away is jitter — should not cancel the timer.
+        // Arm a stationary reading to set the anchor and start the timer.
+        locationManager.handleStationarityUpdate(anchor, stationary: true)
+        XCTAssertNotNil(locationManager.stationaryTask, "stationaryTask must be created on first stationary reading")
+        XCTAssertTrue(locationManager.isStationary)
+        let originalTask = locationManager.stationaryTask!
+
+        // Feed a non-stationary fix 50 m from the anchor — this is GPS jitter.
         let jitterFix = CLLocation(
             coordinate: CLLocationCoordinate2D(latitude: 37.7753, longitude: -122.4194),
             altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date()
@@ -101,18 +100,17 @@ class LocationOptimizationsTests: XCTestCase {
         XCTAssertLessThan(jitterFix.distance(from: anchor), LocationSyncService.minimumReportingDistanceMeters,
             "Test precondition: jitter fix must be < 200m from anchor")
 
-        // Manually exercise the debounce path. We feed the non-stationary fix through
-        // locationManager(didUpdateLocations:), which calls the legacy handler (not
-        // liveUpdates). The legacy handler only resumes high-fidelity tracking; the
-        // debounce logic is in liveUpdates. This test validates the anchor/task state
-        // directly after setting it up, confirming the design is in place.
+        locationManager.handleStationarityUpdate(jitterFix, stationary: false)
+
         XCTAssertFalse(originalTask.isCancelled,
             "stationaryTask must not be cancelled by a sub-200m jitter reading")
         XCTAssertTrue(locationManager.isStationary,
-            "isStationary must remain true while within the anchor radius")
+            "isStationary must remain true for a jitter reading")
+        XCTAssertNotNil(locationManager.stationaryAnchor,
+            "stationaryAnchor must be preserved for a jitter reading")
 
         // Clean up
-        originalTask.cancel()
+        locationManager.stationaryTask?.cancel()
         locationManager.stationaryTask = nil
         locationManager.stationaryAnchor = nil
         locationManager.isStationary = false
@@ -124,14 +122,13 @@ class LocationOptimizationsTests: XCTestCase {
             coordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
             altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date()
         )
-        locationManager.isStationary = true
-        locationManager.stationaryAnchor = anchor
-        let originalTask = Task<Void, Never> { @MainActor in
-            try? await Task.sleep(for: .seconds(300))
-        }
-        locationManager.stationaryTask = originalTask
 
-        // A fix 300m away is genuine movement — debounce must allow the cancel.
+        // Arm stationary state.
+        locationManager.handleStationarityUpdate(anchor, stationary: true)
+        XCTAssertNotNil(locationManager.stationaryTask)
+        let originalTask = locationManager.stationaryTask!
+
+        // Feed a non-stationary fix 300 m away — genuine movement.
         let farFix = CLLocation(
             coordinate: CLLocationCoordinate2D(latitude: 37.7776, longitude: -122.4194),
             altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date()
@@ -139,21 +136,56 @@ class LocationOptimizationsTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(farFix.distance(from: anchor), LocationSyncService.minimumReportingDistanceMeters,
             "Test precondition: far fix must be >= 200m from anchor")
 
-        // Simulate the debounce decision as it would execute in liveUpdates.
-        let isJitter = farFix.distance(from: anchor) < LocationSyncService.minimumReportingDistanceMeters
-        if !isJitter {
-            locationManager.isStationary = false
-            locationManager.stationaryAnchor = nil
-            locationManager.stationaryTask?.cancel()
-            locationManager.stationaryTask = nil
-        }
+        locationManager.handleStationarityUpdate(farFix, stationary: false)
 
         XCTAssertTrue(originalTask.isCancelled,
             "stationaryTask must be cancelled when movement >= 200m from anchor")
         XCTAssertFalse(locationManager.isStationary,
-            "isStationary must be false after genuine movement detected")
+            "isStationary must be false after genuine movement")
         XCTAssertNil(locationManager.stationaryAnchor,
             "stationaryAnchor must be cleared after genuine movement")
+        XCTAssertNil(locationManager.stationaryTask,
+            "stationaryTask must be nil after genuine movement")
+    }
+
+    func testLocationManager_StationaryUpdate_SetsAnchorOnFirstStationaryReading() async throws {
+        let locationManager = LocationManager.shared
+        // Ensure clean state.
+        locationManager.stationaryTask?.cancel()
+        locationManager.stationaryTask = nil
+        locationManager.stationaryAnchor = nil
+        locationManager.isStationary = false
+
+        let loc = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+            altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date()
+        )
+        locationManager.handleStationarityUpdate(loc, stationary: true)
+
+        XCTAssertNotNil(locationManager.stationaryTask, "stationaryTask must be started on first stationary reading")
+        XCTAssertNotNil(locationManager.stationaryAnchor, "stationaryAnchor must be set on first stationary reading")
+        XCTAssertTrue(locationManager.isStationary)
+
+        // A second stationary reading must not replace the existing task or anchor.
+        let anchor1Lat = locationManager.stationaryAnchor?.coordinate.latitude
+        let loc2 = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7750, longitude: -122.4194),
+            altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10, timestamp: Date()
+        )
+        locationManager.handleStationarityUpdate(loc2, stationary: true)
+
+        XCTAssertNotNil(locationManager.stationaryTask,
+            "stationaryTask must still exist after a second stationary reading")
+        XCTAssertFalse(locationManager.stationaryTask!.isCancelled,
+            "stationaryTask must not be cancelled by a second stationary reading")
+        XCTAssertEqual(locationManager.stationaryAnchor?.coordinate.latitude, anchor1Lat,
+            "stationaryAnchor must not shift on subsequent stationary readings")
+
+        // Clean up
+        locationManager.stationaryTask?.cancel()
+        locationManager.stationaryTask = nil
+        locationManager.stationaryAnchor = nil
+        locationManager.isStationary = false
     }
 
     func testSendLocation_SoftwareDistanceFilter() async throws {

--- a/ios/Tests/WhereTests/LocationSyncServiceTests.swift
+++ b/ios/Tests/WhereTests/LocationSyncServiceTests.swift
@@ -29,6 +29,7 @@ class LocationSyncServiceTests: XCTestCase {
             $location.eraseToAnyPublisher()
         }
         var lastLocation: CLLocation? { location }
+        var isStationary: Bool = false
         var requestPermissionAndStartCalled = false
         func requestPermissionAndStart() {
             requestPermissionAndStartCalled = true
@@ -106,7 +107,9 @@ class LocationSyncServiceTests: XCTestCase {
         var pollCallCount: Int {
             return _pollCallCount
         }
+        var lastStationary: Bool? = nil
         func sendLocation(lat: Double, lng: Double, pausedFriendIds: Set<String>, stationary: Bool) async throws {
+            lastStationary = stationary
             sendLocationCallback?()
         }
         func sendLocationToFriend(friendId: String, lat: Double, lng: Double, stationary: Bool) async throws {
@@ -275,6 +278,56 @@ class LocationSyncServiceTests: XCTestCase {
         XCTAssertTrue(mockLocationProvider.requestImmediateLocationCalled, "Should call requestImmediateLocation when heartbeat is due")
     }
 
+    func testPollAllHeartbeat_SendsStationaryTrue_WhenStationaryCheckReturnsTrue() async throws {
+        let mockClient = MockLocationClient()
+        service = LocationSyncService(e2eeManager: service.e2eeManager, userStore: service.userStore, locationClient: mockClient, locationProvider: mockLocationProvider)
+        service.skipNetworkRestore = true
+        service.isSharingLocation = true
+        service.beginBackgroundTask = { _, _ in .invalid }
+        service.endBackgroundTask = { _ in }
+        service.lastSentTime = Date(timeIntervalSinceNow: -400)
+        service.isStationaryCheck = { true }
+        mockLocationProvider.location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7, longitude: -122.4),
+            altitude: 0, horizontalAccuracy: 50, verticalAccuracy: 50, timestamp: Date()
+        )
+
+        let expectation = XCTestExpectation(description: "Stationary heartbeat send")
+        mockClient.sendLocationCallback = { expectation.fulfill() }
+
+        await service.pollAll(updateUi: false)
+        await service.currentSendTask?.value
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockClient.lastStationary, true,
+            "Heartbeat while stationary must send stationary: true")
+    }
+
+    func testPollAllHeartbeat_SendsStationaryFalse_WhenStationaryCheckReturnsFalse() async throws {
+        let mockClient = MockLocationClient()
+        service = LocationSyncService(e2eeManager: service.e2eeManager, userStore: service.userStore, locationClient: mockClient, locationProvider: mockLocationProvider)
+        service.skipNetworkRestore = true
+        service.isSharingLocation = true
+        service.beginBackgroundTask = { _, _ in .invalid }
+        service.endBackgroundTask = { _ in }
+        service.lastSentTime = Date(timeIntervalSinceNow: -400)
+        service.isStationaryCheck = { false }
+        mockLocationProvider.location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7, longitude: -122.4),
+            altitude: 0, horizontalAccuracy: 50, verticalAccuracy: 50, timestamp: Date()
+        )
+
+        let expectation = XCTestExpectation(description: "Moving heartbeat send")
+        mockClient.sendLocationCallback = { expectation.fulfill() }
+
+        await service.pollAll(updateUi: false)
+        await service.currentSendTask?.value
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockClient.lastStationary, false,
+            "Heartbeat while moving must send stationary: false")
+    }
+
     func testPollAllDoesNotTriggerHeartbeatWhenRecentlySent() async throws {
         let mockClient = MockLocationClient()
         service = LocationSyncService(e2eeManager: service.e2eeManager, userStore: service.userStore, locationClient: mockClient, locationProvider: mockLocationProvider)
@@ -367,6 +420,48 @@ class LocationSyncServiceTests: XCTestCase {
 
         service.sendLocationOnBackground()
         await fulfillment(of: [expectation], timeout: 0.1)
+    }
+
+    func testSendLocationOnBackground_PassesStationaryFlag_WhenProviderIsStationary() async throws {
+        let mockClient = MockLocationClient()
+        service = LocationSyncService(e2eeManager: service.e2eeManager, userStore: service.userStore, locationClient: mockClient, locationProvider: mockLocationProvider)
+        service.skipNetworkRestore = true
+        service.isSharingLocation = true
+        service.beginBackgroundTask = { _, _ in .invalid }
+        service.endBackgroundTask = { _ in }
+        service.lastSentTime = Date(timeIntervalSinceNow: -60)
+        mockLocationProvider.location = CLLocation(latitude: 37.7749, longitude: -122.4194)
+        mockLocationProvider.isStationary = true
+
+        let expectation = XCTestExpectation(description: "Background stationary send")
+        mockClient.sendLocationCallback = { expectation.fulfill() }
+
+        service.sendLocationOnBackground()
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockClient.lastStationary, true,
+            "sendLocationOnBackground must pass stationary: true when the provider is stationary")
+    }
+
+    func testSendLocationOnBackground_PassesStationaryFalse_WhenProviderIsMoving() async throws {
+        let mockClient = MockLocationClient()
+        service = LocationSyncService(e2eeManager: service.e2eeManager, userStore: service.userStore, locationClient: mockClient, locationProvider: mockLocationProvider)
+        service.skipNetworkRestore = true
+        service.isSharingLocation = true
+        service.beginBackgroundTask = { _, _ in .invalid }
+        service.endBackgroundTask = { _ in }
+        service.lastSentTime = Date(timeIntervalSinceNow: -60)
+        mockLocationProvider.location = CLLocation(latitude: 37.7749, longitude: -122.4194)
+        mockLocationProvider.isStationary = false
+
+        let expectation = XCTestExpectation(description: "Background moving send")
+        mockClient.sendLocationCallback = { expectation.fulfill() }
+
+        service.sendLocationOnBackground()
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockClient.lastStationary, false,
+            "sendLocationOnBackground must pass stationary: false when the provider is not stationary")
     }
 
     func testSendLocationOnBackground_UsesLastSentLocationWhenGpsUnavailable() async throws {

--- a/ios/Tests/WhereTests/LocationSyncServiceTests.swift
+++ b/ios/Tests/WhereTests/LocationSyncServiceTests.swift
@@ -286,7 +286,7 @@ class LocationSyncServiceTests: XCTestCase {
         service.beginBackgroundTask = { _, _ in .invalid }
         service.endBackgroundTask = { _ in }
         service.lastSentTime = Date(timeIntervalSinceNow: -400)
-        service.isStationaryCheck = { true }
+        service.isStationaryQuery = { true }
         mockLocationProvider.location = CLLocation(
             coordinate: CLLocationCoordinate2D(latitude: 37.7, longitude: -122.4),
             altitude: 0, horizontalAccuracy: 50, verticalAccuracy: 50, timestamp: Date()
@@ -311,7 +311,7 @@ class LocationSyncServiceTests: XCTestCase {
         service.beginBackgroundTask = { _, _ in .invalid }
         service.endBackgroundTask = { _ in }
         service.lastSentTime = Date(timeIntervalSinceNow: -400)
-        service.isStationaryCheck = { false }
+        service.isStationaryQuery = { false }
         mockLocationProvider.location = CLLocation(
             coordinate: CLLocationCoordinate2D(latitude: 37.7, longitude: -122.4),
             altitude: 0, horizontalAccuracy: 50, verticalAccuracy: 50, timestamp: Date()
@@ -326,6 +326,27 @@ class LocationSyncServiceTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 1.0)
         XCTAssertEqual(mockClient.lastStationary, false,
             "Heartbeat while moving must send stationary: false")
+    }
+
+    func testPollAllHeartbeat_ConvergesStationaryFlagIntoProvider() async throws {
+        let mockClient = MockLocationClient()
+        service = LocationSyncService(e2eeManager: service.e2eeManager, userStore: service.userStore, locationClient: mockClient, locationProvider: mockLocationProvider)
+        service.skipNetworkRestore = true
+        service.isSharingLocation = true
+        service.beginBackgroundTask = { _, _ in .invalid }
+        service.endBackgroundTask = { _ in }
+        service.lastSentTime = Date(timeIntervalSinceNow: -400)
+        service.isStationaryQuery = { true }
+        mockLocationProvider.isStationary = false  // starts false
+        mockLocationProvider.location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.7, longitude: -122.4),
+            altitude: 0, horizontalAccuracy: 50, verticalAccuracy: 50, timestamp: Date()
+        )
+
+        await service.pollAll(updateUi: false)
+
+        XCTAssertTrue(mockLocationProvider.isStationary,
+            "pollAll must write the CoreMotion result back into locationProvider.isStationary via the protocol, not a cast")
     }
 
     func testPollAllDoesNotTriggerHeartbeatWhenRecentlySent() async throws {


### PR DESCRIPTION
## Summary

- **Jitter debounce**: `stationaryAnchor` records the location where the 5-minute stationaryTask timer began. Non-stationary liveUpdates readings within 200 m of that anchor are treated as GPS noise and don't reset the timer, so `enterLowPowerMode` (the only place that historically sent `stationary: true`) now actually fires reliably.
- **Heartbeat path**: `pollAll` now passes `stationary: true` when the CoreMotion check confirms the device is stationary. Also writes the CoreMotion result back into the provider's cached `isStationary` flag so subsequent sends are consistent.
- **Background-entry and network-restore paths**: `sendLocationOnBackground` and the `handleNetworkRestored` fallback both read `locationProvider.isStationary` and forward it, so a connectivity-triggered or scene-phase send while sitting still is no longer misreported as moving.
- **`isStationary` on `LocationProviding`**: exposes the cached flag synchronously so any send path can read it without an `await` (needed because `sendLocationOnBackground` is called from a synchronous scene-phase handler).

## Test plan

- [x] `testPollAllHeartbeat_SendsStationaryTrue_WhenStationaryCheckReturnsTrue` — heartbeat while stationary sends `stationary: true`
- [x] `testPollAllHeartbeat_SendsStationaryFalse_WhenStationaryCheckReturnsFalse` — heartbeat while moving sends `stationary: false`
- [x] `testSendLocationOnBackground_PassesStationaryFlag_WhenProviderIsStationary` — background-entry send reflects cached flag
- [x] `testSendLocationOnBackground_PassesStationaryFalse_WhenProviderIsMoving` — background-entry send when moving
- [x] `testLocationManager_StationaryDebounce_JitterDoesNotCancelTimer` — sub-200 m fix does not cancel stationaryTask
- [x] `testLocationManager_StationaryDebounce_LargeMoveCancelsTimer` — ≥200 m fix cancels stationaryTask
- [x] All 35 existing tests continue to pass

Run: Xcode test target `WhereTests` (iOS Simulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)