### PR TITLE
Fix network-restore on iOS clearing stationary flag when device is stationary

### DIFF
--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -409,7 +409,14 @@ final class LocationSyncService: ObservableObject {
         guard isSharingLocation else { return }
 
         let locationIsStale = (locationProvider.lastLocation?.timestamp.timeIntervalSinceNow ?? -.infinity) < -Self.staleLocationThreshold
-        if locationIsStale {
+        if locationIsStale && locationProvider.isStationary {
+            // Don't request a fresh fix when stationary: the position hasn't changed, and
+            // requestImmediateLocation() → didUpdateLocations → resumeHighFidelityTracking()
+            // would reset isStationary=false and send stationary:false to friends.
+            if let loc = bestAvailableLocation {
+                sendLocation(lat: loc.lat, lng: loc.lng, heading: loc.heading, force: true, source: .network, stationary: true)
+            }
+        } else if locationIsStale {
             forceNextLocationUpdate = true
             locationProvider.requestImmediateLocation()
             // Cancel any previous fallback timeout before starting a new one.

--- a/ios/Tests/WhereTests/LocationSyncServiceTests.swift
+++ b/ios/Tests/WhereTests/LocationSyncServiceTests.swift
@@ -908,6 +908,37 @@ class LocationSyncServiceTests: XCTestCase {
         XCTAssertFalse(service.forceNextLocationUpdate, "forceNextLocationUpdate should be cleared after fallback send")
     }
 
+    func testNetworkRestore_StaleLocation_Stationary_SendsStationaryWithoutRequestingFix() async throws {
+        let mockClient = MockLocationClient()
+        service = LocationSyncService(e2eeManager: service.e2eeManager, userStore: service.userStore, locationClient: mockClient, locationProvider: mockLocationProvider)
+        service.skipNetworkRestore = true
+        service.beginBackgroundTask = { _, _ in .invalid }
+        service.endBackgroundTask = { _ in }
+        service.isSharingLocation = true
+        service.lastSentTime = Date(timeIntervalSince1970: 0)
+
+        // Stale location (90s old) but device is stationary
+        let staleLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            altitude: 0, horizontalAccuracy: 10, verticalAccuracy: 10,
+            timestamp: Date(timeIntervalSinceNow: -90)
+        )
+        mockLocationProvider.location = staleLocation
+        mockLocationProvider.isStationary = true
+
+        let expectation = XCTestExpectation(description: "Should send stationary:true immediately")
+        mockClient.sendLocationCallback = { expectation.fulfill() }
+
+        await service.handleNetworkRestored()
+        await service.currentSendTask?.value
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertTrue(mockClient.lastStationary == true, "Network restore while stationary must send stationary:true")
+        XCTAssertFalse(mockLocationProvider.requestImmediateLocationCalled,
+            "Must not request a fresh fix when stationary — that resets isStationary to false")
+        XCTAssertFalse(service.forceNextLocationUpdate, "forceNextLocationUpdate must not be set when stationary")
+    }
+
     func testNetworkRestore_RapidFlap_OnlyOneSend() async throws {
         let mockClient = MockLocationClient()
         service = LocationSyncService(e2eeManager: service.e2eeManager, userStore: service.userStore, locationClient: mockClient, locationProvider: mockLocationProvider)


### PR DESCRIPTION
When network restores while in low-power stationary mode, handleNetworkRestored() was calling requestImmediateLocation() for stale locations, which triggered didUpdateLocations → resumeHighFidelityTracking() → startUpdating(), resetting isStationary=false and sending stationary:false to friends. If the process was then killed, the stationary flag was never re-sent, leaving friends with a stale "moving" state.

Now skips the fresh-fix request when isStationary is already true, sending the cached location with stationary:true directly instead. Movement is still correctly detected via the existing 200m geofence exit.