### PR TITLE
Remove plaintext token field from KeyExchangeInit (Stage 1: stop verifying)

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -61,8 +61,8 @@ android {
         applicationId = "net.af0.where"
         minSdk = 26
         targetSdk = 35
-        versionCode = 94
-        versionName = "2026.06.08.1"
+        versionCode = 95
+        versionName = "2026.06.10.1"
         manifestPlaceholders["MAPS_API_KEY"] = localProperties.getProperty("MAPS_API_KEY") ?: System.getenv("MAPS_API_KEY") ?: ""
     }
 

--- a/docs/e2ee-location-sync.md
+++ b/docs/e2ee-location-sync.md
@@ -303,7 +303,6 @@ Bob transmits:
 {
   "v": 1,
   "type":             "KeyExchangeInit",
-  "token":            "<hex, T_AB_0>",
   "ek_pub":           "<base64, Bob's X25519 ephemeral public key>",
   "encrypted_name":   "<base64, 12-byte nonce || ChaCha20-Poly1305 ciphertext>",
   "key_confirmation": "<base64, key_confirmation>"
@@ -322,8 +321,7 @@ Alice receives the `KeyExchangeInit` and:
 4. Derives `K_name = HKDF-SHA-256(ikm=SK, salt=null, info="Where-v1-SuggestedName", length=32)`.
 5. Decrypts `encrypted_name` using `ChaCha20-Poly1305-Decrypt` with key `K_name`, nonce `name_nonce` (the first 12 bytes), ciphertext `name_ct` (the remaining bytes), and AAD `EK_A.pub || EK_B.pub`. If decryption fails, Alice **MUST abort and discard** the session.
 6. Derives `alice_fp`, `bob_fp`, `T_AB_0`, `T_BA_0` using the same formulas above.
-7. **Alice MUST verify** that the `token` in `KeyExchangeInit` matches her independently derived `T_AB_0`. If they do not match, she MUST abort and discard the session.
-8. **Deletes `EK_A.priv` immediately.**
+7. **Deletes `EK_A.priv` immediately.**
 9. Prompts user to name Bob (pre-filled with the decrypted `suggested_name` from `KeyExchangeInit`).
 10. **Eager Ratchet (Deadlock Breaker):** To prevent the session from being stuck in the initial symmetric chain (Epoch 0), Alice immediately generates a new DH keypair (`A1`) and performs one DH ratchet step using `EK_B.pub` before returning the session. This ensures her very first location message is sent in Epoch 1. When Bob receives this message, he will observe the new `A1` and perform his own DH ratchet step, completing the transition to a fully ratcheted state. This eager approach is a deliberate deadlock breaker; while a Keepalive mechanism (§5.3) provides an alternative path for rotation, the implementation chooses this eager transition to ensure post-compromise security from the first message.
 11. Stores the session.
@@ -806,7 +804,6 @@ The server returns a JSON array of `MailboxPayload` objects, or an empty array `
 {
   "v": 1,
   "type": "KeyExchangeInit",
-  "token":            "<hex, T_AB_0>",
   "ek_pub":           "<base64, Bob's X25519 ephemeral public key>",
   "encrypted_name":   "<base64, 12-byte nonce || ChaCha20-Poly1305 ciphertext>",
   "key_confirmation": "<base64, key_confirmation>"

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeManager.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeManager.kt
@@ -126,11 +126,10 @@ class E2eeManager(
             }
         if (pending == null || aliceEkPubBytes == null) return null
 
-        val tokenBytes = payload.token.hexToByteArray()
         val msg =
             KeyExchangeInitMessage(
                 protocolVersion = payload.v,
-                token = tokenBytes,
+                token = payload.token?.hexToByteArray() ?: ByteArray(0),
                 ekPub = payload.ekPub,
                 keyConfirmation = payload.keyConfirmation,
                 encryptedName = payload.encryptedName,

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
@@ -130,20 +130,11 @@ object KeyExchange {
             val aliceFp = fingerprint(aliceEkPub)
             val bobFp = fingerprint(msg.ekPub)
 
-            // VERIFY TOKEN (#168): Alice MUST verify that Bob computed the same initial routing token.
-            // Alice is the initiator, so her SEND token (Alice->Bob) uses (AliceFp, BobFp).
-            // Constant-time comparison (matching verifyKeyConfirmation) to prevent timing oracle.
-            val expectedToken = deriveRoutingToken(sk, aliceFp, bobFp)
-            var tokenDiff = expectedToken.size xor msg.token.size
-            val tokenLen = minOf(expectedToken.size, msg.token.size)
-            for (i in 0 until tokenLen) tokenDiff = tokenDiff or (expectedToken[i].toInt() xor msg.token[i].toInt())
-            if (tokenDiff != 0) {
-                val expectedHex = expectedToken.toHex()
-                val providedHex = msg.token.toHex()
-                throw AuthenticationException(
-                    "KeyExchangeInit token mismatch (expected=$expectedHex, provided=$providedHex) — possible tampering or protocol error",
-                )
-            }
+            // NOTE: The `token` field in KeyExchangeInit is deprecated and ignored.
+            // It was redundant with `key_confirmation` (both are derived from SK), and
+            // including it in plaintext let the server link the discovery mailbox to the
+            // session routing token, defeating the purpose of `discovery_secret`. Alice
+            // derives T_AB_0 independently; no wire value is needed or trusted.
 
             val session =
                 initSession(

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/MailboxMessage.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/MailboxMessage.kt
@@ -67,6 +67,9 @@ data class EncryptedMessagePayload(
  *
  * @property v               Protocol version.
  * @property token           Hex-encoded T_AB_0 (16 bytes) — the pairwise routing token Bob computed.
+ *                           **Deprecated:** Alice derives T_AB_0 independently and the check is
+ *                           redundant with `key_confirmation`. This field is optional and ignored
+ *                           by Alice; it will be removed in a future protocol version.
  * @property ekPub           Bob's X25519 ephemeral public key (32 bytes).
  * @property keyConfirmation HMAC-SHA-256(SK, "Where-v1-Confirm" || EK_A.pub || EK_B.pub).
  * @property encryptedName   Bob's suggested display name for Alice, encrypted under K_name.
@@ -77,7 +80,7 @@ data class EncryptedMessagePayload(
 @SerialName("KeyExchangeInit")
 data class KeyExchangeInitPayload(
     override val v: Int = PROTOCOL_VERSION,
-    val token: String,
+    val token: String? = null,
     @SerialName("ek_pub")
     @Serializable(with = ByteArrayBase64Serializer::class) val ekPub: ByteArray,
     @SerialName("key_confirmation")
@@ -96,7 +99,7 @@ data class KeyExchangeInitPayload(
     }
 
     override fun hashCode(): Int {
-        var h = token.hashCode()
+        var h = token?.hashCode() ?: 0
         h = 31 * h + encryptedName.contentHashCode()
         h = 31 * h + suggestedName.hashCode()
         return h

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
@@ -156,19 +156,15 @@ class KeyExchangeTest {
     }
 
     @Test
-    fun `aliceProcessInit rejects tampered token`() {
+    fun `aliceProcessInit ignores token field`() {
+        // token is deprecated and ignored by Alice — a wrong or absent value must not
+        // cause rejection; key_confirmation is the authoritative check.
         val (qr, aliceEkPriv) = KeyExchange.aliceCreateQrPayload("Alice")
         val (msg, _) = KeyExchange.bobProcessQr(qr, "Bob")
-        val badMsg = msg.copy(token = ByteArray(16) { 0x42.toByte() })
-
-        val threw =
-            try {
-                KeyExchange.aliceProcessInit(badMsg, aliceEkPriv, qr.ekPub)
-                false
-            } catch (_: AuthenticationException) {
-                true
-            }
-        assertTrue(threw, "Expected AuthenticationException for tampered token")
+        val badTokenMsg = msg.copy(token = ByteArray(16) { 0x42.toByte() })
+        // Should succeed despite the wrong token value.
+        val session = KeyExchange.aliceProcessInit(badTokenMsg, aliceEkPriv, qr.ekPub)
+        assertNotNull(session)
     }
 
     @Test
@@ -441,7 +437,7 @@ class KeyExchangeTest {
 
         // Attacker constructs a tampered KeyExchangeInitMessage with EK_M.pub and a keyConfirmation
         // correctly computed over (SK_AM, EK_A.pub, EK_M.pub) using KeyExchange.buildKeyConfirmation.
-        // Attacker must also compute the "correct" tampered token to pass verification.
+        // token is deprecated/ignored, so the attacker does not need to forge it.
         val aliceFp = fingerprint(qr.ekPub)
         val attackerFp = fingerprint(ekM.pub)
 


### PR DESCRIPTION
## Summary

- `KeyExchangeInitPayload.token` changed from `String` to `String? = null` — field is now optional on the wire
- Token verification block removed from `aliceProcessInit`; `key_confirmation` is the sole cryptographic check
- Spec updated: `token` removed from §4.4 step 7 and §9.3 wire schema
- Test updated to confirm a wrong token value is ignored, not rejected

## Why

The plaintext `T_AB_0` in `KeyExchangeInit` lets the server link the discovery mailbox to the session's first-epoch routing token, defeating the privacy purpose of `discovery_secret`. The check was also security-redundant: `T_AB_0` and `key_confirmation` both derive from the same `SK`, so an attacker who can forge one can forge the other.

Stage 2 (stop sending the field from Bob's side) is tracked in #309 and can follow once this lands.

Closes #308.

## Test plan

- [ ] `./gradlew :shared:jvmTest` passes
- [ ] Pairing flow works end-to-end (both sides running this build)
- [ ] Pairing flow works with one side on an older build that still sends `token` (backward-compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)