### PR TITLE
Fix/invite privacy

### DIFF
--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
@@ -271,7 +271,7 @@ class LocationViewModelTest {
             val initPayload =
                 KeyExchangeInitPayload(
                     v = PROTOCOL_VERSION,
-                    token = "token",
+
                     ekPub = byteArrayOf(1, 2, 3),
                     keyConfirmation = byteArrayOf(4, 5, 6),
                     suggestedName = "Bob",
@@ -314,7 +314,7 @@ class LocationViewModelTest {
                     protocolVersion = PROTOCOL_VERSION,
                     ekPub = byteArrayOf(1, 2, 3),
                     suggestedName = "Alice",
-                    fingerprint = "fp",
+
                     discoverySecret = ByteArray(32),
                 )
 
@@ -348,7 +348,7 @@ class LocationViewModelTest {
             val initPayload =
                 KeyExchangeInitPayload(
                     v = PROTOCOL_VERSION,
-                    token = "token",
+
                     ekPub = byteArrayOf(1, 2, 3),
                     keyConfirmation = byteArrayOf(4, 5, 6),
                     suggestedName = "Bob",
@@ -400,7 +400,7 @@ class LocationViewModelTest {
             val initPayload =
                 KeyExchangeInitPayload(
                     v = PROTOCOL_VERSION,
-                    token = "token",
+
                     ekPub = byteArrayOf(1, 2, 3),
                     keyConfirmation = byteArrayOf(4, 5, 6),
                     suggestedName = "Bob",
@@ -441,7 +441,7 @@ class LocationViewModelTest {
             val initPayload =
                 KeyExchangeInitPayload(
                     v = PROTOCOL_VERSION,
-                    token = "token",
+
                     ekPub = byteArrayOf(1, 2, 3),
                     keyConfirmation = byteArrayOf(4, 5, 6),
                     suggestedName = "Bob",
@@ -485,7 +485,7 @@ class LocationViewModelTest {
                     protocolVersion = PROTOCOL_VERSION,
                     ekPub = byteArrayOf(1, 2, 3),
                     suggestedName = "Alice",
-                    fingerprint = "alice_fp",
+
                     discoverySecret = ByteArray(32),
                 )
 
@@ -532,7 +532,7 @@ class LocationViewModelTest {
                     protocolVersion = PROTOCOL_VERSION,
                     ekPub = byteArrayOf(1, 2, 3),
                     suggestedName = "Alice",
-                    fingerprint = "fp",
+
                     discoverySecret = ByteArray(32),
                 )
 
@@ -612,7 +612,7 @@ class LocationViewModelTest {
                     protocolVersion = PROTOCOL_VERSION,
                     ekPub = byteArrayOf(1, 2, 3),
                     suggestedName = "Alice",
-                    fingerprint = "fp",
+
                     discoverySecret = ByteArray(32),
                 )
 
@@ -660,7 +660,7 @@ class LocationViewModelTest {
                     protocolVersion = PROTOCOL_VERSION,
                     ekPub = byteArrayOf(1, 2, 3),
                     suggestedName = "Alice",
-                    fingerprint = "fp",
+
                     discoverySecret = ByteArray(32),
                 )
 
@@ -736,7 +736,7 @@ class LocationViewModelTest {
             val initPayload =
                 KeyExchangeInitPayload(
                     v = PROTOCOL_VERSION,
-                    token = "token",
+
                     ekPub = byteArrayOf(1, 2, 3),
                     keyConfirmation = byteArrayOf(4, 5, 6),
                     suggestedName = "Alice",

--- a/ios/Sources/Where/Info.plist
+++ b/ios/Sources/Where/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>12</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Where needs the camera to scan friend invite QR codes.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -745,10 +745,9 @@ final class LocationSyncService: ObservableObject {
         repo.inviteState = Shared.InviteState.None()
         isInviteSheetShowing = false
 
-        let qrWithName = Shared.QrPayload(protocolVersion: Shared.ProtocolConstantsKt.PROTOCOL_VERSION, 
+        let qrWithName = Shared.QrPayload(protocolVersion: Shared.ProtocolConstantsKt.PROTOCOL_VERSION,
             ekPub: qr.ekPub,
             suggestedName: friendName,
-            fingerprint: qr.fingerprint,
             discoverySecret: qr.discoverySecret
         )
         debugLog { "Scanning QR: discovery=\(qrWithName.discoveryToken().toHex()), friendName=\(friendName)" }

--- a/ios/Tests/WhereTests/LocationSyncServiceTests.swift
+++ b/ios/Tests/WhereTests/LocationSyncServiceTests.swift
@@ -244,7 +244,7 @@ class LocationSyncServiceTests: XCTestCase {
         let update1 = Shared.UserLocation(userId: existingFriendId, lat: 1.0, lng: 2.0, timestamp: 123)
         mockClient.pollResult = [update1]
 
-        await service.confirmPendingInit(payload: Shared.KeyExchangeInitPayload(v: 1, token: "t", ekPub: kotlinByteArray(from: Data([1])), keyConfirmation: kotlinByteArray(from: Data([2])), encryptedName: kotlinByteArray(from: Data(repeating: 0, count: 31)), suggestedName: "n", msgId: "m1"), name: "n")
+        await service.confirmPendingInit(payload: Shared.KeyExchangeInitPayload(v: 1, ekPub: kotlinByteArray(from: Data([1])), keyConfirmation: kotlinByteArray(from: Data([2])), encryptedName: kotlinByteArray(from: Data(repeating: 0, count: 31)), suggestedName: "n", msgId: "m1"), name: "n")
 
         await service.pollAll(updateUi: true)
 
@@ -679,7 +679,6 @@ class LocationSyncServiceTests: XCTestCase {
         //    The payload fields don't need to be cryptographically valid for this UI test.
         let fakePayload = Shared.KeyExchangeInitPayload(
             v: Shared.ProtocolConstantsKt.PROTOCOL_VERSION,
-            token: "deadbeef",
             ekPub: kotlinByteArray(from: Data([1, 2, 3])),
             keyConfirmation: kotlinByteArray(from: Data([4, 5, 6])),
             encryptedName: kotlinByteArray(from: Data(repeating: 0, count: 31)),
@@ -736,7 +735,6 @@ class LocationSyncServiceTests: XCTestCase {
 
         let fakePayload = Shared.KeyExchangeInitPayload(
             v: Shared.ProtocolConstantsKt.PROTOCOL_VERSION,
-            token: "deadbeef",
             ekPub: kotlinByteArray(from: Data([1, 2, 3])),
             keyConfirmation: kotlinByteArray(from: Data([4, 5, 6])),
             encryptedName: kotlinByteArray(from: Data(repeating: 0, count: 31)),

--- a/ios/Where.xcodeproj/project.pbxproj
+++ b/ios/Where.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 				CODE_SIGN_ENTITLEMENTS = Sources/Where/Where.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = 5PM2V9LTHC;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited) $(SRCROOT)/../shared/build/XCFrameworks/$(CONFIGURATION:lower)",
@@ -457,7 +457,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.15;
+				MARKETING_VERSION = 1.16;
 				PRODUCT_BUNDLE_IDENTIFIER = net.af0.WhereApp;
 				PROVISIONING_PROFILE_SPECIFIER = "Where AppStore";
 				SDKROOT = iphoneos;
@@ -473,7 +473,7 @@
 				CODE_SIGN_ENTITLEMENTS = Sources/Where/Where.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited) $(SRCROOT)/../shared/build/XCFrameworks/$(CONFIGURATION:lower)",
 					"\".\"",
@@ -485,7 +485,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.15;
+				MARKETING_VERSION = 1.16;
 				PRODUCT_BUNDLE_IDENTIFIER = net.af0.WhereApp;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeManager.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeManager.kt
@@ -129,7 +129,6 @@ class E2eeManager(
         val msg =
             KeyExchangeInitMessage(
                 protocolVersion = payload.v,
-                token = payload.token?.hexToByteArray() ?: ByteArray(0),
                 ekPub = payload.ekPub,
                 keyConfirmation = payload.keyConfirmation,
                 encryptedName = payload.encryptedName,
@@ -334,7 +333,6 @@ class E2eeManager(
         val payload =
             KeyExchangeInitPayload(
                 v = initMsg.protocolVersion,
-                token = initMsg.token.toHex(),
                 ekPub = initMsg.ekPub,
                 keyConfirmation = initMsg.keyConfirmation,
                 encryptedName = initMsg.encryptedName,

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeStore.kt
@@ -321,7 +321,6 @@ internal class E2eeStore(
                 QrPayload(
                     suggestedName = suggestedName,
                     ekPub = ekPub,
-                    fingerprint = fingerprint,
                     discoverySecret = discoverySecret,
                 ),
             aliceEkPriv = privKeyBlob,
@@ -409,7 +408,7 @@ internal class E2eeStore(
                         database.invitesQueries.insertPendingInvite(
                             ekPub = invite.qrPayload.ekPub,
                             suggestedName = invite.qrPayload.suggestedName,
-                            fingerprint = invite.qrPayload.fingerprint ?: "",
+                            fingerprint = "",
                             discoverySecret = invite.qrPayload.discoverySecret,
                             privKeyBlob = invite.aliceEkPriv,
                             createdAt = invite.createdAt,

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Fingerprint.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Fingerprint.kt
@@ -8,12 +8,6 @@ package net.af0.where.e2ee
 internal fun fingerprint(ekPub: ByteArray): ByteArray = sha256(ekPub)
 
 /**
- * QR fingerprint: hex(SHA-256(EK.pub)[0:20]). 40 hex characters (160 bits).
- * Truncated version used for visual verification in QR codes and out-of-band links.
- */
-internal fun qrFingerprint(ekPub: ByteArray): String = sha256(ekPub).copyOfRange(0, 20).toHex()
-
-/**
  * Safety number for out-of-band verification.
  * Returns the full 60-byte HKDF-SHA-256(ikm=SHA-256(lower_EK.pub || higher_EK.pub), info="Where-v1-SafetyNumber"),
  * where "lower/higher" is lexicographic order of the two bootstrap EK.pub values.

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
@@ -66,10 +66,6 @@ object KeyExchange {
 
         val keyConfirmation = buildKeyConfirmation(sk, qr.ekPub, ekB.pub)
 
-        // Initial token Bob sends to Alice for discovery is T_AB_0 (Alice -> Bob).
-        // Bob is the scanner, so this token uses (AliceFp, BobFp).
-        val tokenAliceToBob = deriveRoutingToken(sk, aliceFp, bobFp)
-
         val encryptedName = encryptSuggestedName(sk, qr.ekPub, ekB.pub, suggestedName)
 
         // MEMORY HYGIENE NOTE (§5.5): Bob's initial ephemeral key (ekB.priv) is copied into
@@ -81,7 +77,6 @@ object KeyExchange {
 
         val msg =
             KeyExchangeInitMessage(
-                token = tokenAliceToBob,
                 ekPub = ekB.pub.copyOf(),
                 keyConfirmation = keyConfirmation,
                 encryptedName = encryptedName,

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/KeyExchange.kt
@@ -21,12 +21,10 @@ object KeyExchange {
      */
     fun aliceCreateQrPayload(suggestedName: String): Pair<QrPayload, ByteArray> {
         val ek = generateX25519KeyPair()
-        val fp = qrFingerprint(ek.pub)
         val payload =
             QrPayload(
                 ekPub = ek.pub.copyOf(),
                 suggestedName = suggestedName,
-                fingerprint = fp,
                 discoverySecret = randomBytes(32),
             )
         return payload to ek.priv
@@ -103,8 +101,7 @@ object KeyExchange {
         try {
             // Verify key confirmation before proceeding.
             if (!verifyKeyConfirmation(sk, aliceEkPub, msg.ekPub, msg.keyConfirmation)) {
-                val actualFp = qrFingerprint(aliceEkPub)
-                throw AuthenticationException("KeyExchangeInit key_confirmation failed (expectedAliceFp=$actualFp) — aborting key exchange")
+                throw AuthenticationException("KeyExchangeInit key_confirmation failed — aborting key exchange")
             }
 
             // Decrypt/verify the suggested name to bind it cryptographically

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/MailboxMessage.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/MailboxMessage.kt
@@ -66,10 +66,6 @@ data class EncryptedMessagePayload(
  * Bob's KeyExchangeInit posted to the discovery token address (§4.2).
  *
  * @property v               Protocol version.
- * @property token           Hex-encoded T_AB_0 (16 bytes) — the pairwise routing token Bob computed.
- *                           **Deprecated:** Alice derives T_AB_0 independently and the check is
- *                           redundant with `key_confirmation`. This field is optional and ignored
- *                           by Alice; it will be removed in a future protocol version.
  * @property ekPub           Bob's X25519 ephemeral public key (32 bytes).
  * @property keyConfirmation HMAC-SHA-256(SK, "Where-v1-Confirm" || EK_A.pub || EK_B.pub).
  * @property encryptedName   Bob's suggested display name for Alice, encrypted under K_name.
@@ -80,7 +76,6 @@ data class EncryptedMessagePayload(
 @SerialName("KeyExchangeInit")
 data class KeyExchangeInitPayload(
     override val v: Int = PROTOCOL_VERSION,
-    val token: String? = null,
     @SerialName("ek_pub")
     @Serializable(with = ByteArrayBase64Serializer::class) val ekPub: ByteArray,
     @SerialName("key_confirmation")
@@ -92,14 +87,14 @@ data class KeyExchangeInitPayload(
 ) : MailboxPayload() {
     override fun equals(other: Any?): Boolean {
         if (other !is KeyExchangeInitPayload) return false
-        return token == other.token && ekPub.contentEquals(other.ekPub) &&
+        return ekPub.contentEquals(other.ekPub) &&
             keyConfirmation.contentEquals(other.keyConfirmation) &&
             encryptedName.contentEquals(other.encryptedName) &&
             suggestedName == other.suggestedName
     }
 
     override fun hashCode(): Int {
-        var h = token?.hashCode() ?: 0
+        var h = ekPub.contentHashCode()
         h = 31 * h + encryptedName.contentHashCode()
         h = 31 * h + suggestedName.hashCode()
         return h

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
@@ -216,9 +216,6 @@ data class QrPayload(
     @Serializable(with = ByteArrayBase64Serializer::class) val ekPub: ByteArray,
     @SerialName("suggested_name")
     val suggestedName: String,
-    // hex(SHA-256(ekPub)[0:20]); optional — ignored by receiver (Stage 1 of §4.2 removal)
-    @SerialName("fingerprint")
-    val fingerprint: String? = null,
     // Fresh random 32-byte secret; HKDF IKM for the discovery token (§4.2).
     @SerialName("discovery_secret")
     @Serializable(with = ByteArrayBase64Serializer::class) val discoverySecret: ByteArray,
@@ -226,14 +223,13 @@ data class QrPayload(
     override fun equals(other: Any?): Boolean {
         if (other !is QrPayload) return false
         return protocolVersion == other.protocolVersion && ekPub.contentEquals(other.ekPub) && suggestedName == other.suggestedName &&
-            fingerprint == other.fingerprint && discoverySecret.contentEquals(other.discoverySecret)
+            discoverySecret.contentEquals(other.discoverySecret)
     }
 
     override fun hashCode(): Int {
         var h = protocolVersion
         h = 31 * h + ekPub.contentHashCode()
         h = 31 * h + suggestedName.hashCode()
-        h = 31 * h + fingerprint.hashCode()
         h = 31 * h + discoverySecret.contentHashCode()
         return h
     }

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Types.kt
@@ -273,8 +273,6 @@ data class QrPayload(
 /** Bob's KeyExchangeInit message sent to the mailbox. */
 data class KeyExchangeInitMessage(
     val protocolVersion: Int = PROTOCOL_VERSION,
-    // T_AB_0 (16 bytes) — mailbox address
-    @Serializable(with = ByteArrayBase64Serializer::class) val token: ByteArray,
     // Bob's ephemeral X25519 public key
     @Serializable(with = ByteArrayBase64Serializer::class) val ekPub: ByteArray,
     // HMAC-SHA-256(SK, "Where-v1-Confirm" || EK_A.pub || EK_B.pub)
@@ -283,13 +281,13 @@ data class KeyExchangeInitMessage(
 ) {
     override fun equals(other: Any?): Boolean {
         if (other !is KeyExchangeInitMessage) return false
-        return protocolVersion == other.protocolVersion && token.contentEquals(other.token) && ekPub.contentEquals(other.ekPub) &&
+        return protocolVersion == other.protocolVersion && ekPub.contentEquals(other.ekPub) &&
             keyConfirmation.contentEquals(other.keyConfirmation) && encryptedName.contentEquals(other.encryptedName)
     }
 
     override fun hashCode(): Int {
         var h = protocolVersion
-        h = 31 * h + token.contentHashCode()
+        h = 31 * h + ekPub.contentHashCode()
         return h
     }
 }

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/InviteLimitTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/InviteLimitTest.kt
@@ -33,7 +33,6 @@ class InviteLimitTest {
         val result = manager.processKeyExchangeInit(
             payload = KeyExchangeInitPayload(
                 v = 1,
-                token = "00".repeat(32),
                 ekPub = ByteArray(32),
                 keyConfirmation = ByteArray(32),
                 suggestedName = "Bob"

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
@@ -48,7 +48,6 @@ class KeyExchangeTest {
 
         val (msg, _) = KeyExchange.bobProcessQr(qr, "Bob")
 
-        assertEquals(16, msg.token.size)
         assertEquals(32, msg.ekPub.size)
         assertEquals(32, msg.keyConfirmation.size)
         // nonce(12) + tag(16) + nameLength(3) = 31
@@ -153,18 +152,6 @@ class KeyExchangeTest {
                 true
             }
         assertTrue(threw)
-    }
-
-    @Test
-    fun `aliceProcessInit ignores token field`() {
-        // token is deprecated and ignored by Alice — a wrong or absent value must not
-        // cause rejection; key_confirmation is the authoritative check.
-        val (qr, aliceEkPriv) = KeyExchange.aliceCreateQrPayload("Alice")
-        val (msg, _) = KeyExchange.bobProcessQr(qr, "Bob")
-        val badTokenMsg = msg.copy(token = ByteArray(16) { 0x42.toByte() })
-        // Should succeed despite the wrong token value.
-        val session = KeyExchange.aliceProcessInit(badTokenMsg, aliceEkPriv, qr.ekPub)
-        assertNotNull(session)
     }
 
     @Test
@@ -422,9 +409,6 @@ class KeyExchangeTest {
 
         // Attacker constructs a tampered KeyExchangeInitMessage with EK_M.pub and a keyConfirmation
         // correctly computed over (SK_AM, EK_A.pub, EK_M.pub) using KeyExchange.buildKeyConfirmation.
-        // token is deprecated/ignored, so the attacker does not need to forge it.
-        val aliceFp = fingerprint(qr.ekPub)
-        val attackerFp = fingerprint(ekM.pub)
 
         // Encrypt name under SK_AM
         val kName = hkdfSha256(skAM, null, "Where-v1-SuggestedName".encodeToByteArray(), 32)
@@ -433,7 +417,6 @@ class KeyExchangeTest {
 
         val tamperedMsg =
             KeyExchangeInitMessage(
-                token = deriveRoutingToken(skAM, aliceFp, attackerFp),
                 ekPub = ekM.pub.copyOf(),
                 keyConfirmation = KeyExchange.buildKeyConfirmation(skAM, qr.ekPub, ekM.pub),
                 encryptedName = nonce + ct,

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/KeyExchangeTest.kt
@@ -23,7 +23,6 @@ class KeyExchangeTest {
         val (qr, ekPriv) = KeyExchange.aliceCreateQrPayload("Alice")
 
         assertEquals(32, qr.ekPub.size)
-        assertEquals(40, qr.fingerprint?.length) // hex(SHA-256(ekPub)[0:20]); still sent by Alice
 
         // ekPriv is 32 bytes and non-zero.
         assertEquals(32, ekPriv.size)

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/MailboxMessageTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/MailboxMessageTest.kt
@@ -52,7 +52,6 @@ class MailboxMessageTest {
             listOf(
                 EncryptedMessagePayload(envelope = ByteArray(77), ct = ByteArray(32)),
                 KeyExchangeInitPayload(
-                    token = "deadbeef",
                     ekPub = ByteArray(32),
                     keyConfirmation = ByteArray(32),
                     encryptedName = ByteArray(31) { 0xFF.toByte() },
@@ -69,7 +68,6 @@ class MailboxMessageTest {
     @Test
     fun `KeyExchangeInitPayload suggestedName is transient`() {
         val payload = KeyExchangeInitPayload(
-            token = "deadbeef",
             ekPub = ByteArray(32),
             keyConfirmation = ByteArray(32),
             encryptedName = ByteArray(31) { 0xAA.toByte() },


### PR DESCRIPTION
Removes the pubkey fingerprint and routing token from the session init QR code. These have been unnecessary since cd435fe72c11adcc2dbe2c036e9076c3fb888328 and ac37f8cc9ee00e5bc3d371b8ee833571c44a2763; the pubkey fingerprint just bloats the QR code, and the routing token is a minor metadata leak.