### PR TITLE
fix: send location immediately on per-friend unpause

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationViewModel.kt
@@ -267,9 +267,9 @@ class LocationViewModel(
         val wasPaused = id in userStore.pausedFriendIds.value
         userStore.togglePauseFriend(id)
         // On transition into paused, give the peer the same positive "stopped" signal
-        // that master-off and per-friend-timer-expiry produce. Un-pause has no wire
-        // message: the next outgoing Location is itself the implicit "I'm back" signal,
-        // and the recipient clears stoppedAtTs on receipt.
+        // that master-off and per-friend-timer-expiry produce. On transition out of
+        // paused, immediately broadcast our current location so the peer doesn't have
+        // to wait up to a full heartbeat interval for the implicit "I'm back" update.
         if (!wasPaused) {
             viewModelScope.launch {
                 try {
@@ -278,6 +278,13 @@ class LocationViewModel(
                     Log.w(TAG, "sendStoppedSharingToFriend($id) failed: ${e.message}")
                 }
             }
+        } else {
+            val intent =
+                Intent(getApplication(), LocationService::class.java).apply {
+                    action = LocationService.ACTION_FORCE_PUBLISH
+                    putExtra(LocationService.EXTRA_FRIEND_ID, id)
+                }
+            getApplication<Application>().startForegroundService(intent)
         }
     }
 

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -363,15 +363,23 @@ final class LocationSyncService: ObservableObject {
             repo.pausedFriendIds.insert(id)
         }
         // On transition into paused, give the peer the same positive "stopped" signal
-        // that master-off and per-friend-timer-expiry produce. Un-pause has no wire
-        // message: the next outgoing Location is itself the implicit "I'm back" signal,
-        // and the recipient clears stoppedAtTs on receipt.
+        // that master-off and per-friend-timer-expiry produce. On transition out of
+        // paused, immediately broadcast our current location so the peer doesn't have
+        // to wait up to a full heartbeat interval for the implicit "I'm back" update.
         if !wasPaused {
             Task {
                 do {
                     try await locationClient.sendStoppedSharingToFriend(friendId: id)
                 } catch {
                     logger.warning("sendStoppedSharingToFriend(\(id)) failed: \(error.localizedDescription)")
+                }
+            }
+        } else if let last = locationProvider.lastLocation, isSharingLocation {
+            Task {
+                do {
+                    try await locationClient.sendLocationToFriend(friendId: id, lat: last.coordinate.latitude, lng: last.coordinate.longitude, stationary: locationProvider.isStationary)
+                } catch {
+                    logger.warning("sendLocationToFriend(\(id)) on unpause failed: \(error.localizedDescription)")
                 }
             }
         }


### PR DESCRIPTION
## Summary

- On un-pause of a per-friend share, both Android and iOS now immediately broadcast the current location to that friend instead of waiting for the next scheduled heartbeat or location tick (up to a full heartbeat interval away)
- **Android**: fires `ACTION_FORCE_PUBLISH` with `EXTRA_FRIEND_ID` in `LocationViewModel.togglePauseFriend` — the service already handles this path, including graceful no-location queuing via `pendingFriendSends`
- **iOS**: calls `sendLocationToFriend` directly in `LocationSyncService.togglePauseFriend` if a location is available and sharing is active; no-location case is silently skipped (same as the pairing path)

Fixes #318.

## Test plan

- [ ] Android: pause a friend, move to a new location, un-pause — friend's pin should update immediately without waiting for the next heartbeat
- [ ] iOS: same scenario
- [ ] Android: un-pause while stationary/backgrounded — location should be sent immediately
- [ ] Both: un-pause while master sharing is off — no spurious send (both paths guard on `isSharingLocation`)
- [ ] Both: un-pause when no cached location is available — no crash, graceful skip/queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)