### PR TITLE
feat: add Open Source Licenses screen and remove unused BouncyCastle dep

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
@@ -474,6 +474,7 @@ private val LICENSES = listOf(
     License("ZXing", "Copyright (c) 2007 Sean Owen", "Apache-2.0"),
     License("SQLDelight", "Copyright (c) 2016 Square, Inc.", "Apache-2.0"),
     License("MOKO Resources", "Copyright (c) 2019 IceRock Development", "Apache-2.0"),
+    License("MapLibre Native", "Copyright (c) 2021-2024 MapLibre Contributors", "BSD-2-Clause"),
     License(
         "Accompanist",
         "Copyright (c) 2020 The Android Open Source Project",

--- a/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/FriendsSheet.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
@@ -75,6 +77,7 @@ fun FriendsSheet(
     var pastedUrl by remember { mutableStateOf("") }
     var debugExpandedFriendId by remember { mutableStateOf<String?>(null) }
     var showDiagnosticLog by remember { mutableStateOf(false) }
+    var showAcknowledgements by remember { mutableStateOf(false) }
 
     // Live countdown for any active per-friend timer. Recomposing rows that read
     // [nowSecTicker] re-evaluate their "Sharing for Xh Ym" labels each minute.
@@ -320,7 +323,22 @@ fun FriendsSheet(
                     }
                 }
             }
+
+            TextButton(
+                onClick = { showAcknowledgements = true },
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            ) {
+                Text(
+                    stringResource(MR.strings.open_source_licenses),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
+    }
+
+    if (showAcknowledgements) {
+        AcknowledgementsDialog(onDismiss = { showAcknowledgements = false })
     }
 
     confirmDeleteFriend?.let { friend ->
@@ -436,4 +454,62 @@ private fun FriendOverflowMenu(
             onClick = { expanded = false; onRemove() },
         )
     }
+}
+
+private data class License(val name: String, val copyright: String, val spdx: String)
+
+private val LICENSES = listOf(
+    License("libsodium", "Copyright (c) 2013-2024 Frank Denis", "ISC"),
+    License(
+        "multiplatform-crypto-libsodium-bindings",
+        "Copyright (c) 2020 Ugljesa Jovanovic",
+        "Apache-2.0",
+    ),
+    License("Ktor", "Copyright (c) JetBrains s.r.o.", "Apache-2.0"),
+    License(
+        "Kotlin Coroutines / Serialization",
+        "Copyright (c) JetBrains s.r.o.",
+        "Apache-2.0",
+    ),
+    License("ZXing", "Copyright (c) 2007 Sean Owen", "Apache-2.0"),
+    License("SQLDelight", "Copyright (c) 2016 Square, Inc.", "Apache-2.0"),
+    License("MOKO Resources", "Copyright (c) 2019 IceRock Development", "Apache-2.0"),
+    License(
+        "Accompanist",
+        "Copyright (c) 2020 The Android Open Source Project",
+        "Apache-2.0",
+    ),
+)
+
+@Composable
+private fun AcknowledgementsDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(MR.strings.open_source_licenses)) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                LICENSES.forEach { lib ->
+                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        Text(lib.name, style = MaterialTheme.typography.labelMedium)
+                        Text(
+                            lib.copyright,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            lib.spdx,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(MR.strings.close)) }
+        },
+    )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-bouncycastle = "1.80"
 kotlin = "2.1.20"
 kmp-plugin = "2.1.20"
 agp = "8.9.0"
@@ -71,7 +70,6 @@ zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }
 zxing-android-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxing-android" }
 
 # Crypto
-bouncycastle = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
 libsodium-kmp = { module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings", version.ref = "libsodium" }
 libsodium-kmp-jvm = { module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings-jvm", version.ref = "libsodium" }
 security-crypto = { module = "androidx.security:security-crypto", version.ref = "security-crypto" }

--- a/ios/Sources/Where/AcknowledgementsView.swift
+++ b/ios/Sources/Where/AcknowledgementsView.swift
@@ -1,0 +1,41 @@
+import Shared
+import SwiftUI
+
+private struct LibraryLicense: Identifiable {
+    let id = UUID()
+    let name: String
+    let copyright: String
+    let spdx: String
+}
+
+private let licenses: [LibraryLicense] = [
+    .init(name: "libsodium",                              copyright: "Copyright © 2013–2024 Frank Denis",            spdx: "ISC"),
+    .init(name: "multiplatform-crypto-libsodium-bindings", copyright: "Copyright © 2020 Ugljesa Jovanovic",          spdx: "Apache-2.0"),
+    .init(name: "Ktor",                                   copyright: "Copyright © JetBrains s.r.o.",                 spdx: "Apache-2.0"),
+    .init(name: "Kotlin Coroutines / Serialization",      copyright: "Copyright © JetBrains s.r.o.",                 spdx: "Apache-2.0"),
+    .init(name: "SQLDelight",                             copyright: "Copyright © 2016 Square, Inc.",                spdx: "Apache-2.0"),
+    .init(name: "MOKO Resources",                         copyright: "Copyright © 2019 IceRock Development",         spdx: "Apache-2.0"),
+]
+
+struct AcknowledgementsView: View {
+    var body: some View {
+        List(licenses) { lib in
+            VStack(alignment: .leading, spacing: 2) {
+                Text(lib.name)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Text(lib.copyright)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(lib.spdx)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 4)
+        }
+        .navigationTitle(MR.strings().open_source_licenses.localized())
+        #if !os(macOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+}

--- a/ios/Sources/Where/FriendsSheet.swift
+++ b/ios/Sources/Where/FriendsSheet.swift
@@ -144,6 +144,13 @@ struct FriendsSheet: View {
                         }
                     }
                 }
+                Section {
+                    NavigationLink(destination: AcknowledgementsView()) {
+                        Text(MR.strings().open_source_licenses.localized())
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
             }
             .navigationTitle(MR.strings().friends.localized())
             .navigationBarTitleDisplayMode(.inline)

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -86,4 +86,6 @@
     <string name="share_indefinitely">Share indefinitely</string>
     <string name="sharing_for_remaining">Sharing for %s</string>
     <string name="more_options">More options</string>
+    <string name="open_source_licenses">Open Source Licenses</string>
+    <string name="close">Close</string>
 </resources>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -86,4 +86,6 @@
     <string name="share_indefinitely">Unbegrenzt teilen</string>
     <string name="sharing_for_remaining">Noch %s</string>
     <string name="more_options">Weitere Optionen</string>
+    <string name="open_source_licenses">Open-Source-Lizenzen</string>
+    <string name="close">Schließen</string>
 </resources>


### PR DESCRIPTION
Adds an acknowledgements screen reachable from the bottom of FriendsSheet on both iOS and Android, listing all open-source libraries bundled in the app binary. Removes the BouncyCastle entry from the version catalog (it was never referenced in any build.gradle.kts). Strings are localized into German alongside the existing translations.