### PR TITLE
fix: degrade loc on unknown precision / missing coords instead of throwing

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/Session.kt
@@ -485,7 +485,7 @@ object Session {
         runCatching {
             val obj = Json.decodeFromString<JsonObject>(bytes.decodeToString())
             when (obj["type"]?.jsonPrimitive?.content) {
-                "loc" -> decodeLocation(obj)
+                "loc" -> decodeLocation(obj) ?: MessagePlaintext.Keepalive()
                 "ka" -> MessagePlaintext.Keepalive()
                 "stop" -> {
                     // Lenient: a malformed "stop" missing/invalid ts degrades to a
@@ -496,7 +496,7 @@ object Session {
                 }
                 null -> {
                     // Legacy emitter: sniff for "lat" → Location, else Keepalive.
-                    if (obj.containsKey("lat")) decodeLocation(obj) else MessagePlaintext.Keepalive()
+                    if (obj.containsKey("lat")) decodeLocation(obj) ?: MessagePlaintext.Keepalive() else MessagePlaintext.Keepalive()
                 }
                 else -> {
                     // Unknown future variant — treat as Keepalive (safe no-op).
@@ -505,15 +505,22 @@ object Session {
             }
         }.getOrElse { e -> throw DecryptionException("malformed message plaintext", e) }
 
-    private fun decodeLocation(obj: JsonObject): MessagePlaintext.Location =
-        MessagePlaintext.Location(
-            lat = obj["lat"]!!.jsonPrimitive.double,
-            lng = obj["lng"]!!.jsonPrimitive.double,
-            acc = obj["acc"]!!.jsonPrimitive.double,
-            ts = obj["ts"]!!.jsonPrimitive.long,
-            precision = obj["precision"]?.jsonPrimitive?.content?.let { LocationPrecision.valueOf(it) } ?: LocationPrecision.FINE,
+    private fun decodeLocation(obj: JsonObject): MessagePlaintext.Location? {
+        // Missing required coordinates → degrade to Keepalive (§5.7.3 leniency, mirrors "stop" handling).
+        val lat = obj["lat"]?.jsonPrimitive?.content?.toDoubleOrNull() ?: return null
+        val lng = obj["lng"]?.jsonPrimitive?.content?.toDoubleOrNull() ?: return null
+        val acc = obj["acc"]?.jsonPrimitive?.content?.toDoubleOrNull() ?: return null
+        val ts = obj["ts"]?.jsonPrimitive?.longOrNull ?: return null
+        // Unknown precision string (e.g. a future "MEDIUM") falls back to FINE for forward-compat.
+        val precision = obj["precision"]?.jsonPrimitive?.content
+            ?.let { runCatching { LocationPrecision.valueOf(it) }.getOrNull() }
+            ?: LocationPrecision.FINE
+        return MessagePlaintext.Location(
+            lat = lat, lng = lng, acc = acc, ts = ts,
+            precision = precision,
             stationary = obj["stationary"]?.jsonPrimitive?.booleanOrNull ?: false,
         )
+    }
 
     internal fun padToFixedSize(
         data: ByteArray,

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/MessagePlaintextCodecTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/MessagePlaintextCodecTest.kt
@@ -80,4 +80,21 @@ class MessagePlaintextCodecTest {
         val decoded = Session.decodeMessage(malformed.encodeToByteArray())
         assertTrue(decoded is MessagePlaintext.Keepalive)
     }
+
+    // Regression tests for issue #325: loc forward-compat / ratchet-wedge fixes.
+
+    @Test
+    fun forwardCompatLocUnknownPrecisionDecodesToFine() {
+        val future = """{"type":"loc","lat":1.0,"lng":2.0,"acc":5.0,"ts":1000,"precision":"MEDIUM"}"""
+        val decoded = Session.decodeMessage(future.encodeToByteArray()) as MessagePlaintext.Location
+        assertEquals(LocationPrecision.FINE, decoded.precision)
+        assertEquals(1.0, decoded.lat)
+    }
+
+    @Test
+    fun forwardCompatLocMissingLatDegradesToKeepalive() {
+        val incomplete = """{"type":"loc","lng":2.0,"acc":5.0,"ts":1000}"""
+        val decoded = Session.decodeMessage(incomplete.encodeToByteArray())
+        assertTrue(decoded is MessagePlaintext.Keepalive)
+    }
 }


### PR DESCRIPTION
## Summary

- `LocationPrecision.valueOf(unknownString)` threw `IllegalArgumentException` on any unrecognised precision value (e.g. a future `"MEDIUM"`), breaking the §5.7.3 forward-compat contract
- Missing `lat`/`lng`/`acc`/`ts` fields in a `"loc"` frame caused `NullPointerException` via `!!`, which could wedge the ratchet since the receive chain advances before `decodeMessage` runs
- `decodeLocation` is now nullable — returns `null` (surfaced as `Keepalive`) when any required coordinate is absent, mirroring existing `"stop"` leniency
- Unknown precision strings fall back to `FINE` via `runCatching { LocationPrecision.valueOf(it) }.getOrNull()`

Fixes #325

## Test plan

- [ ] `MessagePlaintextCodecTest.forwardCompatLocUnknownPrecisionDecodesToFine` — `"MEDIUM"` precision decodes to `FINE` without throwing
- [ ] `MessagePlaintextCodecTest.forwardCompatLocMissingLatDegradesToKeepalive` — missing `lat` degrades to `Keepalive` without throwing
- [ ] All existing `MessagePlaintextCodecTest` cases still pass
- [ ] Full `:shared:jvmTest` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)