### PR TITLE
Bound unbounded rapid-polling for stuck invites/friend-exchanges

### DIFF
--- a/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
+++ b/android/src/androidMain/kotlin/net/af0/where/LocationService.kt
@@ -696,7 +696,12 @@ class LocationService : Service() {
         val isSheetShowing = uiStateStore.isInviteSheetShowing.value
         // Also check if Bob is on the naming screen.
         val isNaming = uiStateStore.pendingQrForNaming.value != null
-        return isSheetShowing || locationSource.pendingInitPayload.value != null || recentlyTriggered || isNaming
+        // Bounded: an incoming invite that's never confirmed or cancelled (app backgrounded,
+        // notification ignored, etc.) must not pin the client at the 2s rapid interval forever.
+        val setAt = locationSource.pendingInitPayloadSetAt.value
+        val hasFreshPendingInit =
+            locationSource.pendingInitPayload.value != null && setAt != 0L && now - setAt < PENDING_INIT_RAPID_TIMEOUT_MS
+        return isSheetShowing || hasFreshPendingInit || recentlyTriggered || isNaming
     }
 
     @VisibleForTesting
@@ -1010,5 +1015,12 @@ class LocationService : Service() {
 
         private const val CHANNEL_ID = "where_location"
         private const val NOTIFICATION_ID = 1
+
+        /**
+         * How long an unconfirmed incoming invite keeps the client in rapid (2s) polling.
+         * Bounds the impact of an invite the user never acts on (see #336) - long enough
+         * to notice and respond to a notification, short enough not to run rapid mode forever.
+         */
+        internal const val PENDING_INIT_RAPID_TIMEOUT_MS = 5 * 60 * 1000L
     }
 }

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationServiceTest.kt
@@ -61,6 +61,9 @@ class ServiceFakeLocationSource : LocationSource {
     private val _pendingInitPayload = MutableStateFlow<KeyExchangeInitPayload?>(null)
     override val pendingInitPayload: StateFlow<KeyExchangeInitPayload?> = _pendingInitPayload.asStateFlow()
 
+    private val _pendingInitPayloadSetAt = MutableStateFlow(0L)
+    override val pendingInitPayloadSetAt: StateFlow<Long> = _pendingInitPayloadSetAt.asStateFlow()
+
     private val _pendingInitAliceEkPub = MutableStateFlow<ByteArray?>(null)
     override val pendingInitAliceEkPub: StateFlow<ByteArray?> = _pendingInitAliceEkPub.asStateFlow()
 
@@ -125,6 +128,7 @@ class ServiceFakeLocationSource : LocationSource {
         aliceEkPub: ByteArray?,
     ) {
         _pendingInitPayload.value = payload
+        _pendingInitPayloadSetAt.value = if (payload != null) LocationService.clock() else 0L
         _pendingInitAliceEkPub.value = aliceEkPub
     }
 
@@ -343,6 +347,40 @@ class LocationServiceTest {
                 // 8. Verify rapid poll IS reset now
                 assertFalse(service.isRapidPolling(), "Rapid poll should be reset after all new friends have sent updates")
                 assertEquals(0L, fakeLocationSource.lastRapidPollTrigger.value)
+            } finally {
+                controller.destroy()
+            }
+        }
+
+    @Test
+    fun testPendingInitPayloadStopsForcingRapidPollAfterTimeout() =
+        runTest {
+            // Regression test for #336: an incoming invite the user never confirms or cancels
+            // must not pin the client at the 2s rapid interval forever.
+            var currentTime = 1_000_000_000L
+            LocationService.clock = { currentTime }
+
+            val controller = Robolectric.buildService(LocationService::class.java)
+            val service = controller.get()
+            service.locationSourceOverride = fakeLocationSource
+            controller.create()
+
+            try {
+                val payload = io.mockk.mockk<KeyExchangeInitPayload>(relaxed = true)
+                fakeLocationSource.onPendingInit(payload, aliceEkPub = byteArrayOf(0))
+                assertTrue(service.isRapidPolling(), "An unconfirmed pending invite should force rapid polling")
+
+                currentTime += LocationService.PENDING_INIT_RAPID_TIMEOUT_MS - 1
+                assertTrue(
+                    service.isRapidPolling(),
+                    "Rapid polling should still hold just under the timeout",
+                )
+
+                currentTime += 2
+                assertFalse(
+                    service.isRapidPolling(),
+                    "An invite pending past the timeout must stop forcing rapid polling",
+                )
             } finally {
                 controller.destroy()
             }

--- a/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
+++ b/android/src/androidUnitTest/kotlin/net/af0/where/LocationViewModelTest.kt
@@ -82,6 +82,9 @@ class TestFakeLocationSource : LocationSource {
     private val _pendingInitPayload = MutableStateFlow<KeyExchangeInitPayload?>(null)
     override val pendingInitPayload: StateFlow<KeyExchangeInitPayload?> = _pendingInitPayload.asStateFlow()
 
+    private val _pendingInitPayloadSetAt = MutableStateFlow(0L)
+    override val pendingInitPayloadSetAt: StateFlow<Long> = _pendingInitPayloadSetAt.asStateFlow()
+
     private val _pendingInitAliceEkPub = MutableStateFlow<ByteArray?>(null)
     override val pendingInitAliceEkPub: StateFlow<ByteArray?> = _pendingInitAliceEkPub.asStateFlow()
 
@@ -142,6 +145,7 @@ class TestFakeLocationSource : LocationSource {
         aliceEkPub: ByteArray?,
     ) {
         _pendingInitPayload.value = payload
+        _pendingInitPayloadSetAt.value = if (payload != null) System.currentTimeMillis() else 0L
         _pendingInitAliceEkPub.value = aliceEkPub
     }
 

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -118,6 +118,10 @@ final class LocationSyncService: ObservableObject {
     private static let locationSendThrottle: TimeInterval = 30.0
     static let minimumReportingDistanceMeters: CLLocationDistance = 200
     private static let rapidPollDuration: TimeInterval = 60.0
+    /// How long a newly-added friend who hasn't sent their first location update keeps the
+    /// client in rapid (2s) polling. Bounds the impact of a friend who never shares (see #336) -
+    /// long enough for a normal first exchange, short enough not to run rapid mode forever.
+    private static let awaitingFirstUpdateTimeout: TimeInterval = 5 * 60
     var locationFixTimeout: TimeInterval = 10.0  // internal for testing
     /// Fixes with horizontalAccuracy above this threshold are cell/WiFi network fixes too noisy
     /// to broadcast; only sub-200m GPS fixes are sent to friends or used for heartbeats.
@@ -157,7 +161,10 @@ final class LocationSyncService: ObservableObject {
     // Initialized in init() to capture motionActivityManager/motionQueue without
     // a self reference, avoiding actor-isolation issues in the closure.
     var isStationaryQuery: () async -> Bool = { false }  // overridden in init
-    private var awaitingFirstUpdateIds: Set<String> = []
+    /// Friend IDs awaiting their first location update, keyed to when they were added so
+    /// isRapidPolling() can stop treating a stale entry as a reason to keep rapid mode on.
+    /// internal (not private) for testing, mirroring lastRapidPollTrigger below.
+    var awaitingFirstUpdateIds: [String: Date] = [:]
     // Monotonically increasing counter used to prevent stale task cleanup from
     // clearing a newer task's state. Incremented each time a new send task is created.
     private var sendTaskGeneration: Int = 0
@@ -518,7 +525,9 @@ final class LocationSyncService: ObservableObject {
 
     @MainActor
     func isRapidPolling() -> Bool {
-        if !awaitingFirstUpdateIds.isEmpty { return true }
+        if awaitingFirstUpdateIds.values.contains(where: { Date().timeIntervalSince($0) < Self.awaitingFirstUpdateTimeout }) {
+            return true
+        }
         if isInviteSheetShowing { return true }
         return Date().timeIntervalSince(lastRapidPollTrigger) < Self.rapidPollDuration
     }
@@ -555,7 +564,7 @@ final class LocationSyncService: ObservableObject {
     }
 
     private func onFriendLocationReceived(friendId: String) {
-        if awaitingFirstUpdateIds.remove(friendId) != nil {
+        if awaitingFirstUpdateIds.removeValue(forKey: friendId) != nil {
             if awaitingFirstUpdateIds.isEmpty {
                 resetRapidPoll()
             }
@@ -775,7 +784,7 @@ final class LocationSyncService: ObservableObject {
             await clearInvite()
             // Insert AFTER clearInvite: clearInvite calls resetRapidPoll which clears
             // awaitingFirstUpdateIds, so inserting before it is a no-op.
-            awaitingFirstUpdateIds.insert(bobEntry.id)
+            awaitingFirstUpdateIds[bobEntry.id] = Date()
             repo.friends = try await e2eeManager.listFriends()
             updateVisibleUsers()
 
@@ -829,7 +838,7 @@ final class LocationSyncService: ObservableObject {
             let result = try await e2eeManager.processKeyExchangeInit(payload: payload, aliceSuggestedName: name, aliceEkPub: kotlinByteArray(from: aliceEkPub))
 
             if let entry = result ?? nil {
-                awaitingFirstUpdateIds.insert(entry.id)
+                awaitingFirstUpdateIds[entry.id] = Date()
                 repo.friends = try await e2eeManager.listFriends()
                 updateVisibleUsers()
 

--- a/ios/Tests/WhereTests/LocationSyncServiceTests.swift
+++ b/ios/Tests/WhereTests/LocationSyncServiceTests.swift
@@ -601,6 +601,16 @@ class LocationSyncServiceTests: XCTestCase {
         XCTAssertFalse(isRapid2)
     }
 
+    func testAwaitingFirstUpdateStopsForcingRapidPollAfterTimeout() async throws {
+        // Regression test for #336: a friend who never sends a first location update must not
+        // pin the client at rapid polling forever.
+        service.awaitingFirstUpdateIds = ["stale_friend": Date(timeIntervalSinceNow: -301)]
+        XCTAssertFalse(service.isRapidPolling(), "An awaiting-first-update entry past the timeout must stop forcing rapid polling")
+
+        service.awaitingFirstUpdateIds = ["fresh_friend": Date(timeIntervalSinceNow: -10)]
+        XCTAssertTrue(service.isRapidPolling(), "A recently-added awaiting-first-update entry should still force rapid polling")
+    }
+
     class SendCountBox: @unchecked Sendable {
         private let lock = NSLock()
         private var count = 0

--- a/shared/src/commonMain/kotlin/net/af0/where/LocationRepository.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/LocationRepository.kt
@@ -25,6 +25,8 @@ interface LocationSource {
     val connectionStatus: StateFlow<ConnectionStatus>
     val isAppInForeground: StateFlow<Boolean>
     val pendingInitPayload: StateFlow<KeyExchangeInitPayload?>
+    /** Wall-clock time [pendingInitPayload] was last set to a non-null value; 0 when null. */
+    val pendingInitPayloadSetAt: StateFlow<Long>
     val pendingInitAliceEkPub: StateFlow<ByteArray?>
     val friends: StateFlow<List<FriendEntry>>
     val allPendingInvites: StateFlow<List<PendingInviteView>>
@@ -106,6 +108,9 @@ class LocationRepository(
     internal val _pendingInitPayload = MutableStateFlow<KeyExchangeInitPayload?>(null)
     override val pendingInitPayload: StateFlow<KeyExchangeInitPayload?> = _pendingInitPayload.asStateFlow()
 
+    private val _pendingInitPayloadSetAt = MutableStateFlow(0L)
+    override val pendingInitPayloadSetAt: StateFlow<Long> = _pendingInitPayloadSetAt.asStateFlow()
+
     private val _pendingInitAliceEkPub = MutableStateFlow<ByteArray?>(null)
     override val pendingInitAliceEkPub: StateFlow<ByteArray?> = _pendingInitAliceEkPub.asStateFlow()
 
@@ -179,6 +184,7 @@ class LocationRepository(
         aliceEkPub: ByteArray?,
     ) {
         _pendingInitPayload.value = payload
+        _pendingInitPayloadSetAt.value = if (payload != null) net.af0.where.e2ee.currentTimeMillis() else 0L
         _pendingInitAliceEkPub.value = aliceEkPub
     }
 
@@ -243,6 +249,7 @@ class LocationRepository(
         _connectionStatus.value = ConnectionStatus.Ok
         _isAppInForeground.value = false
         _pendingInitPayload.value = null
+        _pendingInitPayloadSetAt.value = 0L
         _pendingInitAliceEkPub.value = null
         _friends.value = emptyList()
         _allPendingInvites.value = emptyList()


### PR DESCRIPTION
## Summary

Fixes #336. Both clients have a rapid-polling mode (2s interval) intended to speed up initial key-exchange/friend-pairing, and on both platforms one of its trigger conditions had no timeout:

- **Android**: `pendingInitPayload.value != null` (an unconfirmed incoming invite) was checked directly in `isRapidPolling()` with no decay.
- **iOS**: `awaitingFirstUpdateIds` (friends who completed key exchange but haven't sent a first location) was only cleared when that first update arrived, never on a timer.

In both cases, if the stuck condition never resolves (invite ignored, friend never shares), the client stays pinned at 2s polling indefinitely, in the foreground or background - bypassing the normal 10s/5min/30min tiers entirely. This was found while investigating unexpectedly high production API load relative to the current user count.

## Changes

- Android: `LocationRepository` now tracks `pendingInitPayloadSetAt`; `LocationService.isRapidPolling()` only treats a pending invite as rapid-triggering while under `PENDING_INIT_RAPID_TIMEOUT_MS` (5 min) old.
- iOS: `awaitingFirstUpdateIds` changed from `Set<String>` to `[String: Date]`; `isRapidPolling()` only counts entries under 5 minutes old.
- Both platforms fall back to their normal polling tier once the timeout elapses, rather than requiring explicit user action to clear the stuck state.

## Test plan

- [x] `:android:testStandardFdroidDebugUnitTest` (`LocationServiceTest`, `LocationViewModelTest`) - passing locally, includes new regression test `testPendingInitPayloadStopsForcingRapidPollAfterTimeout`
- [x] `:shared:jvmTest` - passing locally
- [ ] iOS `LocationSyncServiceTests` (`testAwaitingFirstUpdateStopsForcingRapidPollAfterTimeout`) - not run locally (no Xcode/Swift toolchain in this environment); relying on CI

Follow-up server-side hardening tracked separately in #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)