### PR TITLE
Revert mailbox store to plain Redis, stop paying for Neon

### DIFF
--- a/server/fly.toml
+++ b/server/fly.toml
@@ -7,9 +7,11 @@ app = 'where-api'
 primary_region = 'fra'
 
 [env]
-  # Phase A of the Redis -> Postgres mailbox migration: Redis stays authoritative, Postgres
-  # mirrors every write and gets shadow-read-compared on drain(). See DualWriteMailboxState.
-  MAILBOX_STORE_MODE = 'dual-write-redis-primary'
+  # The Redis -> Postgres/Neon migration was abandoned on cost grounds: Neon bills per
+  # wall-clock CU-hour of compute awake time, and this app's poll-heavy traffic pattern
+  # keeps it awake almost continuously, making it no cheaper than Redis. Back to plain
+  # Redis while a DynamoDB migration (pure per-request billing) is evaluated instead.
+  MAILBOX_STORE_MODE = 'redis'
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
## Summary

One-line config revert to stop an active cost bleed: flips `MAILBOX_STORE_MODE` back to `redis`, ending the dual-write to Neon Postgres from the abandoned migration attempt.

Neon bills per wall-clock CU-hour the compute is awake (5-min autosuspend timeout). This app's poll-heavy traffic pattern (clients poll every 10s-30min depending on state) keeps arrivals closer together than that timeout almost continuously, so the database never actually suspends - measured 6 CU-hr/day = 24 awake-hours/day, projecting to roughly the same yearly cost as the Redis bill this migration was meant to reduce. A DynamoDB migration (pure per-request billing, no idle/compute charge - a better structural fit for this traffic shape) is in progress on a separate branch.

No code changes, config only. `PostgresMailboxState`/`DualWriteMailboxState`/the `postgresql`/`hikaricp` dependencies will be removed in a follow-up once the DynamoDB swap lands, rather than in this urgent-fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)