### PR TITLE
build.sh: skip server build/test for single-platform builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -141,14 +141,17 @@ fi
 echo "Building with server URL: $SERVER_URL"
 echo ""
 
-# Build server
-echo "=== Building server ==="
-if ! run ./gradlew :server:build; then
-  echo "Server build failed."
-  exit 1
+# Build server (skipped for single-platform builds: neither app consumes server
+# build output, only the SERVER_URL string configured below).
+if ! $SKIP_ANDROID && ! $SKIP_IOS; then
+  echo "=== Building server ==="
+  if ! run ./gradlew :server:build; then
+    echo "Server build failed."
+    exit 1
+  fi
+  echo "✓ Server built"
+  echo ""
 fi
-echo "✓ Server built"
-echo ""
 
 # Configure local.properties with SERVER_HTTP_URL
 if [ ! -f local.properties ]; then


### PR DESCRIPTION
## Summary
- `--ios-only` / `--android-only` (and `--skip-android` / `--skip-ios`) still ran `./gradlew :server:build` unconditionally at the top of `build.sh`, even though neither app consumes server build output — only the `SERVER_URL` string configured later in the script.
- This blocked local iOS-only builds on machines without Docker running, since `:server:test` now spins up a Testcontainers-backed local DynamoDB (added in #340).
- Made the server build/test step conditional: it only runs for full builds (both platforms), which still serves as a sanity check when doing a complete build.

## Test plan
- [x] `./build.sh --flavor release --ios-only` now builds successfully end-to-end without touching the server, on a machine with no Docker daemon running
- [x] Confirmed no other build step depends on server build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)