### PR TITLE
LocationClient: propagate real send failures instead of swallowing them

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -357,17 +357,23 @@ open class LocationClient(
         }
     }
 
+    /**
+     * Delivers everything queued for [friendId], stopping (and letting the exception propagate)
+     * on the first failure to preserve delivery order - a later message must never be delivered
+     * before an earlier one that's still stuck. Deliberately doesn't catch here: callers that
+     * only care about best-effort delivery (e.g. [processOutboxes]) catch around their own call
+     * site instead, so a caller that DOES care whether delivery actually happened (e.g.
+     * [sendMessageToFriendInternal], and transitively `LocationService.sendLocationIfNeeded`'s
+     * retry/backoff and connection-status reporting) can see real failures instead of a silent
+     * false success. See https://github.com/danmarg/where/issues/343.
+     */
     private suspend fun processOutbox(friendId: String) {
         val outbox = store.getOutbox(friendId)
         if (outbox.isEmpty()) return
 
         for (outboxMsg in outbox) {
-            try {
-                service.post(outboxMsg.token, outboxMsg.payload)
-                store.removeFromOutbox(friendId, outboxMsg.msgId)
-            } catch (e: Exception) {
-                break // Stop on first failure to preserve order
-            }
+            service.post(outboxMsg.token, outboxMsg.payload)
+            store.removeFromOutbox(friendId, outboxMsg.msgId)
         }
     }
 
@@ -481,21 +487,15 @@ open class LocationClient(
     ) {
         // WAL Safety: If the outbox is not empty, we MUST NOT generate a new message.
         // We instead retry the existing outbox. This bounds the queue and prevents nonce reuse.
-        var currentOutbox = store.getOutbox(friendId)
-        if (currentOutbox.isNotEmpty()) {
-            try {
-                processOutbox(friendId)
-            } catch (e: Exception) {
-                // Ignore
-            }
-
-            // Re-check: if still not empty (e.g. network fail), THEN we must stop to maintain order.
-            if (store.getOutbox(friendId).isNotEmpty()) {
-                return
-            }
+        // processOutbox() now throws on failure instead of swallowing it (see its doc), so a
+        // still-stuck message propagates straight out of this function - callers (ultimately
+        // LocationService.sendLocationIfNeeded) see the real failure instead of a silent
+        // false success, and we never reach encryptAndAdvance() below for a new payload.
+        if (store.getOutbox(friendId).isNotEmpty()) {
+            processOutbox(friendId)
         }
 
-        val (message, session) = store.encryptAndAdvance(friendId, payload)
+        store.encryptAndAdvance(friendId, payload)
 
         // We trigger sequential outbox processing for this friend.
         // This ensures messages are sent in order (0, 1, 2...) even if multiple calls happen rapidly.

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/OutboxFailurePropagationTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/OutboxFailurePropagationTest.kt
@@ -1,0 +1,133 @@
+package net.af0.where.e2ee
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for https://github.com/danmarg/where/issues/343: processOutbox() used to
+ * swallow every exception from a failed post(), so LocationClient.sendLocation() could never
+ * observe (and therefore never report) a real delivery failure - it always looked like success
+ * to callers such as LocationService.sendLocationIfNeeded, whose retry/backoff logic and
+ * connection-status reporting depend on the exception actually propagating.
+ */
+class OutboxFailurePropagationTest {
+    private class MemoryMailboxClient : MailboxClient {
+        val mailboxes = mutableMapOf<String, MutableList<MailboxPayload>>()
+
+        override suspend fun post(
+            baseUrl: String,
+            token: String,
+            payload: MailboxPayload,
+        ) {
+            mailboxes.getOrPut(token) { mutableListOf() }.add(payload)
+        }
+
+        override suspend fun poll(
+            baseUrl: String,
+            token: String,
+        ): List<MailboxPayload> = mailboxes[token] ?: emptyList()
+
+        override suspend fun ackId(
+            baseUrl: String,
+            token: String,
+            msgId: String,
+        ) {
+            mailboxes[token]?.removeAll { it.msgId == msgId }
+        }
+
+        override suspend fun ackIds(
+            baseUrl: String,
+            token: String,
+            msgIds: List<String>,
+        ) {
+            mailboxes[token]?.removeAll { it.msgId in msgIds }
+        }
+    }
+
+    init {
+        initializeE2eeTests()
+    }
+
+    private suspend fun pairedClients(): Triple<LocationClient, LocationClient, ChaosMailboxClient> {
+        val realMailbox = MemoryMailboxClient()
+        val chaosMailbox = ChaosMailboxClient(realMailbox)
+
+        val aliceDriver = createTestSqlDriver()
+        val aliceManager = testE2eeManager(aliceDriver)
+        val aliceClient = LocationClient("http://localhost", aliceManager, chaosMailbox)
+        val qr = aliceManager.createInvite("Alice")
+
+        val bobDriver = createTestSqlDriver()
+        val bobManager = testE2eeManager(bobDriver)
+        val bobClient = LocationClient("http://localhost", bobManager, chaosMailbox)
+
+        val (initPayload, bobEntry) = bobManager.processScannedQr(qr, "Bob")
+        bobClient.postKeyExchangeInit(bobEntry.id, qr, initPayload)
+
+        val pending = aliceClient.pollPendingInvites()
+        aliceManager.processKeyExchangeInit(pending[0].payload, "Bob", pending[0].inviteEkPub)
+
+        return Triple(aliceClient, bobClient, chaosMailbox)
+    }
+
+    @Test
+    fun `sendLocation propagates a real post failure instead of swallowing it`() =
+        runTest {
+            val (aliceClient, _, chaosMailbox) = pairedClients()
+
+            chaosMailbox.failNextPost = true
+
+            // Before the fix, this call would return normally (no exception) even though the
+            // underlying POST failed - processOutbox()'s catch-and-break swallowed it silently.
+            assertFailsWith<NetworkException> {
+                aliceClient.sendLocation(37.0, -122.0, emptySet())
+            }
+        }
+
+    @Test
+    fun `a subsequent send after the failure still delivers the original stuck message first`() =
+        runTest {
+            val (aliceClient, bobClient, chaosMailbox) = pairedClients()
+
+            chaosMailbox.failNextPost = true
+            assertFailsWith<NetworkException> {
+                // Location A never actually leaves the device - it's stuck in the outbox.
+                aliceClient.sendLocation(37.0, -122.0, emptySet())
+            }
+
+            // Network "recovers". WAL safety means this call must first retry (and this time
+            // succeed at) flushing the stuck location A, THEN generate and send a genuinely new
+            // location B - not silently drop A, and not skip sending B either.
+            aliceClient.sendLocation(38.0, -123.0, emptySet())
+
+            val locations = bobClient.poll(isForeground = true, pausedFriendIds = emptySet())
+            assertEquals(2, locations.size, "both the recovered stuck message and the new one must be delivered")
+            assertEquals(37.0, locations[0].lat, "the originally stuck message must be delivered first, in order")
+            assertEquals(38.0, locations[1].lat)
+        }
+
+    @Test
+    fun `processOutboxes still absorbs per-friend failures for its best-effort callers`() =
+        runTest {
+            val (aliceClient, _, chaosMailbox) = pairedClients()
+
+            chaosMailbox.failNextPost = true
+            assertFailsWith<NetworkException> {
+                aliceClient.sendLocation(37.0, -122.0, emptySet())
+            }
+
+            // poll() calls processOutboxes() internally and must not blow up just because a
+            // friend's outbox is (still) stuck - only the single-friend send path should surface
+            // the failure to its caller.
+            var threw = false
+            try {
+                aliceClient.poll(isForeground = true, pausedFriendIds = emptySet())
+            } catch (e: Exception) {
+                threw = true
+            }
+            assertTrue(!threw, "poll()/processOutboxes() must remain best-effort, not propagate per-friend failures")
+        }
+}


### PR DESCRIPTION
## Summary
- `processOutbox()` caught every exception from `service.post()` and swallowed it after breaking out of the loop, so `sendMessageToFriendInternal()`/`LocationClient.sendLocation()` could never observe a real send failure - a network outage looked identical to success at every layer above the outbox.
- That silently broke `LocationService.sendLocationIfNeeded`'s retry/backoff loop (`SEND_RETRY_DELAYS_MS`, which could never engage) and its connection-status reporting - the green/orange status dot + error banner on the main map screen, plus the user-visible `diagnosticLog`, reported success during real outages.
- Fix: let the failure propagate. Still stops at the first failed item to preserve delivery order (now via the exception unwinding the loop instead of an explicit catch+break). `sendMessageToFriendInternal()` no longer swallows-and-repolls the outbox state; it lets a still-stuck retry propagate directly, preserving the same "never generate a new message while one is undelivered" WAL-safety invariant, just observably now. `processOutboxes()` (plural, used by `poll()`'s best-effort background flush) is unchanged and still absorbs per-friend failures, which is correct there.

Fixes #343.

## Test plan
- [x] `OutboxFailurePropagationTest.kt` (new): a real post failure now throws instead of being swallowed; a subsequent send after recovery still delivers the originally-stuck message first, in order, without duplicating or dropping it; `processOutboxes()` still stays best-effort for its own callers.
- [x] `./gradlew :shared:jvmTest` - full suite passes, including the pre-existing chaos/handshake/catch-up tests that exercise this code indirectly.
- [x] `./gradlew :android:compileDebugKotlin` - compiles against the changed shared module; the existing `testSendLocationRetriesOnTransientFailure` (which mocks a throw directly) is unaffected and still validates the retry logic given a real exception - this PR is what makes that exception real in production instead of mock-only.