### PR TITLE
Log diagnostic event when sendLocation reaches zero recipients (#347)

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -456,7 +456,21 @@ open class LocationClient(
             // Sequential: each friend's eligibility check is a local-DB read serialized behind
             // E2eeStore's single storeLock anyway, so fanning these out via async/awaitAll (like
             // the network send phase below) buys no real concurrency, just dispatch overhead.
-            val activeFriends = store.listFriends().filter { isSendEligible(it, pausedFriendIds, now) }
+            val active = store.listFriends().filter { isActiveFriend(it, pausedFriendIds) }
+            val activeFriends = active.filter { isSendEligible(it, pausedFriendIds, now) }
+
+            // Distinct from "no active friends" (paused/no friends yet - expected, not worth a
+            // diagnostic event): every active friend was individually eligible for OUTBOUND
+            // traffic but got filtered out by the unresponsive-friend throttle. sendLocation()
+            // otherwise returns normally in this case (see below), which previously meant
+            // LocationService.sendLocationIfNeeded logged "OK" and cleared its status for a send
+            // that reached nobody - see #347.
+            if (active.isNotEmpty() && activeFriends.isEmpty()) {
+                store.addDiagnosticEvent(
+                    "sendLocation: all ${active.size} active friend(s) throttled as unresponsive - nothing sent",
+                    coalesceKey = "sendLocation: all",
+                )
+            }
 
             // Parallel send to all active friends to minimize radio wake time.
             // Exceptions are caught per-friend so one failure doesn't block updates to others.

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/UnresponsiveFriendThrottleTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/UnresponsiveFriendThrottleTest.kt
@@ -313,4 +313,56 @@ class UnresponsiveFriendThrottleTest {
             val delivered = bobClient.poll(isForeground = true, pausedFriendIds = emptySet())
             assertEquals(1, delivered.size, "must resume full cadence right away once the friend is heard from again")
         }
+
+    @Test
+    fun `sendLocation logs a diagnostic event when every active friend is throttled, not a silent no-op`() =
+        runTest {
+            // Regression test for #347: sendLocation() returns normally (no exception) when
+            // activeFriends is empty, so LocationService.sendLocationIfNeeded previously logged
+            // "OK" and cleared its status for a send that reached nobody. A friend being paused
+            // or there being no friends yet is expected and must stay silent; a friend being
+            // throttled as unresponsive is operationally interesting and must be visible.
+            val mailbox = MemoryMailboxClient()
+            setVirtualTime(1_700_000_000_000L)
+
+            val aliceDriver = createTestSqlDriver()
+            val aliceManager = testE2eeManager(aliceDriver)
+            val aliceClient = LocationClient("http://localhost", aliceManager, mailbox)
+            val bobClient = pairNewFriend(aliceManager, aliceClient, mailbox, "Bob")
+
+            bobClient.sendLocation(0.0, 0.0, emptySet())
+            aliceClient.poll(isForeground = true, pausedFriendIds = emptySet())
+
+            // Nothing logged yet - Bob is still responsive.
+            assertTrue(aliceManager.diagnosticLog.value.none { it.contains("throttled as unresponsive") })
+
+            advanceTimeBy(250_000L) // t=250s: still responsive, sets lastSentTs=250.
+            aliceClient.sendLocation(1.0, 1.0, emptySet())
+            assertTrue(aliceManager.diagnosticLog.value.none { it.contains("throttled as unresponsive") })
+
+            advanceTimeBy(60_000L) // t=310s: unresponsive, and not yet due for a throttled retry.
+            aliceClient.sendLocation(2.0, 2.0, emptySet())
+            assertTrue(
+                aliceManager.diagnosticLog.value.any { it.contains("throttled as unresponsive") },
+                "must surface that this send reached nobody, not report a silent success",
+            )
+        }
+
+    @Test
+    fun `sendLocation stays silent when there are simply no active friends`() =
+        runTest {
+            val mailbox = MemoryMailboxClient()
+            setVirtualTime(1_700_000_000_000L)
+
+            val aliceDriver = createTestSqlDriver()
+            val aliceManager = testE2eeManager(aliceDriver)
+            val aliceClient = LocationClient("http://localhost", aliceManager, mailbox)
+            val bobClient = pairNewFriend(aliceManager, aliceClient, mailbox, "Bob")
+            bobClient.sendLocation(0.0, 0.0, emptySet())
+            aliceClient.poll(isForeground = true, pausedFriendIds = emptySet())
+
+            // Bob is explicitly paused, not unresponsive - this is a normal, expected no-op.
+            aliceClient.sendLocation(1.0, 1.0, pausedFriendIds = aliceManager.listFriends().map { it.id }.toSet())
+            assertTrue(aliceManager.diagnosticLog.value.none { it.contains("throttled as unresponsive") })
+        }
 }


### PR DESCRIPTION
## Summary
- `sendLocation()` returned normally when every active friend was throttled as unresponsive, so `LocationService` logged a successful send and cleared error status for a send that reached nobody.
- Adds a diagnostic-log breadcrumb distinguishing "all active friends throttled" (surfaced) from "no active friends at all" (paused/none yet — stays silent, expected).
- Note: this is observability-only. It does not change what `sendLocationIfNeeded` reports to the caller/UI status — a fuller fix would need to change that return-value contract.

## Test plan
- [x] New unit tests: diagnostic event fires when all active friends are throttled; stays silent when friends are just paused
- [ ] Manual verification in app once merged

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_015dABVPAT1KSEurZQ4puiXx