### PR TITLE
Log diagnostic events on silent poll failure paths

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -110,6 +110,7 @@ open class LocationClient(
                 try {
                     store.listFriends()
                 } catch (e: Exception) {
+                    store.addDiagnosticEvent("listFriends() failed, skipping poll cycle: ${e.message}")
                     emptyList()
                 }
 
@@ -247,6 +248,7 @@ open class LocationClient(
                     try {
                         service.poll(currentToken)
                     } catch (e: Exception) {
+                        store.addDiagnosticEvent("poll($friendId) failed on $currentToken: ${e.message}")
                         emptyList()
                     }
 
@@ -259,6 +261,7 @@ open class LocationClient(
                 try {
                     val result = store.processBatch(friendId, currentToken, messages)
                     if (result == null) {
+                        store.addDiagnosticEvent("processBatch($friendId) rejected ${messages.size} message(s) on $currentToken")
                         stopPolling = true
                         continue
                     }
@@ -315,6 +318,7 @@ open class LocationClient(
                         }
                     }
                 } catch (e: Exception) {
+                    store.addDiagnosticEvent("pollFriend($friendId) failed processing batch on $currentToken: ${e.message}")
                     stopPolling = true
                 }
             }


### PR DESCRIPTION
## Summary
- `pollFriend()`/`poll()` had four exception/failure paths (`listFriends()` throwing, `service.poll()` throwing, `processBatch()` returning null, and the outer per-friend catch) that swallowed the error with no trace.
- This left the iOS debug Events panel empty during exactly the scenario it's meant to diagnose: a stuck/repeatedly-failing poll cycle with `caughtUp` stuck at "no" and `poll` timestamp not advancing.
- Each of the four paths now emits a `store.addDiagnosticEvent(...)` describing the failure.

## Test plan
- [x] `./gradlew :shared:jvmTest` passes
- [ ] Manual repro on iOS: force a poll failure and confirm the Events tab now shows the failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dABVPAT1KSEurZQ4puiXx