### PR TITLE
Push secondary delete failures to Loki alongside drain mismatches

### DIFF
--- a/server/src/main/kotlin/net/af0/where/Server.kt
+++ b/server/src/main/kotlin/net/af0/where/Server.kt
@@ -942,6 +942,12 @@ class DualWriteMailboxState(
     // correctness-neutral - only the row cleanup itself needs a much coarser cadence.
     private val secondaryEvictIntervalMs: Long = 30 * 60 * 1000L,
     private val onMismatch: ((MismatchEvent) -> Unit)? = null,
+    // Deletes against the secondary are best-effort like every other mirrored write here, but
+    // unlike a failed post/evict, a failed delete leaves a permanent ghost row behind (nothing
+    // ever retries it), which is exactly what drives the drain() shadow-comparison's mismatch
+    // rate - surfaced separately so that rate is visible without conflating it with genuine
+    // primary/secondary divergence.
+    private val onSecondaryDeleteFailure: ((op: String, tokenHash: String, error: Throwable) -> Unit)? = null,
 ) : MailboxStore {
     private val lastSecondaryEvictAt = java.util.concurrent.atomic.AtomicLong(0)
 
@@ -980,7 +986,11 @@ class DualWriteMailboxState(
         val result = primary.deleteById(token, msgId)
         scope.launch {
             runCatching { secondary.deleteById(token, msgId) }
-                .onFailure { migrationLog.warn("secondary deleteById failed token={}", tokenHash(token), it) }
+                .onFailure {
+                    migrationLog.warn("secondary deleteById failed token={}", tokenHash(token), it)
+                    runCatching { onSecondaryDeleteFailure?.invoke("deleteById", tokenHash(token), it) }
+                        .onFailure { cbError -> migrationLog.warn("onSecondaryDeleteFailure callback failed", cbError) }
+                }
         }
         return result
     }
@@ -993,7 +1003,11 @@ class DualWriteMailboxState(
         if (msgIds.isNotEmpty()) {
             scope.launch {
                 runCatching { secondary.deleteByIds(token, msgIds) }
-                    .onFailure { migrationLog.warn("secondary deleteByIds failed token={}", tokenHash(token), it) }
+                    .onFailure {
+                        migrationLog.warn("secondary deleteByIds failed token={}", tokenHash(token), it)
+                        runCatching { onSecondaryDeleteFailure?.invoke("deleteByIds", tokenHash(token), it) }
+                            .onFailure { cbError -> migrationLog.warn("onSecondaryDeleteFailure callback failed", cbError) }
+                    }
             }
         }
         return result
@@ -1049,6 +1063,13 @@ class DualWriteMailboxState(
 private val auditLog = LoggerFactory.getLogger("MismatchAuditLog")
 
 @Serializable
+data class SecondaryDeleteFailureEvent(
+    val op: String,
+    val tokenHash: String,
+    val error: String,
+)
+
+@Serializable
 private data class LokiStream(val stream: Map<String, String>, val values: List<List<String>>)
 
 @Serializable
@@ -1090,6 +1111,17 @@ class MismatchAuditLog(
 
     fun record(event: MismatchEvent) {
         pushLine("shadow_mismatch", Json.encodeToString(event))
+    }
+
+    fun recordSecondaryDeleteFailure(
+        op: String,
+        tokenHash: String,
+        error: Throwable,
+    ) {
+        pushLine(
+            "secondary_delete_failure",
+            Json.encodeToString(SecondaryDeleteFailureEvent(op, tokenHash, error.message ?: error.toString())),
+        )
     }
 
     private fun pushLine(
@@ -1147,6 +1179,7 @@ private fun buildMailboxStore(
     dynamoClient: DynamoDbClient?,
     storeMode: String,
     onMismatch: ((MismatchEvent) -> Unit)? = null,
+    onSecondaryDeleteFailure: ((op: String, tokenHash: String, error: Throwable) -> Unit)? = null,
 ): MailboxStore {
     val redisStore = redisUrl?.let { RedisMailboxState(JedisPooled(it)) }
     val dynamoStore = dynamoClient?.let { DynamoMailboxState(it) }
@@ -1166,7 +1199,12 @@ private fun buildMailboxStore(
             requireNotNull(redisStore) { "REDIS_URL is required for dual-write-redis-primary" }
             requireNotNull(dynamoStore) { "AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_REGION are required for dual-write-redis-primary" }
             println("Using dual-write store (Redis primary, DynamoDB shadow)")
-            DualWriteMailboxState(primary = redisStore, secondary = dynamoStore, onMismatch = onMismatch)
+            DualWriteMailboxState(
+                primary = redisStore,
+                secondary = dynamoStore,
+                onMismatch = onMismatch,
+                onSecondaryDeleteFailure = onSecondaryDeleteFailure,
+            )
         }
         "dual-write-dynamodb-primary" -> {
             requireNotNull(redisStore) { "REDIS_URL is required for dual-write-dynamodb-primary" }
@@ -1174,7 +1212,12 @@ private fun buildMailboxStore(
                 dynamoStore,
             ) { "AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_REGION are required for dual-write-dynamodb-primary" }
             println("Using dual-write store (DynamoDB primary, Redis shadow)")
-            DualWriteMailboxState(primary = dynamoStore, secondary = redisStore, onMismatch = onMismatch)
+            DualWriteMailboxState(
+                primary = dynamoStore,
+                secondary = redisStore,
+                onMismatch = onMismatch,
+                onSecondaryDeleteFailure = onSecondaryDeleteFailure,
+            )
         }
         else -> error("Unknown MAILBOX_STORE_MODE: $storeMode")
     }
@@ -1208,7 +1251,13 @@ fun main() {
             null
         }
     val mailbox =
-        buildMailboxStore(System.getenv("REDIS_URL"), dynamoClient, storeMode, mismatchAuditLog?.let { it::record })
+        buildMailboxStore(
+            System.getenv("REDIS_URL"),
+            dynamoClient,
+            storeMode,
+            onMismatch = mismatchAuditLog?.let { it::record },
+            onSecondaryDeleteFailure = mismatchAuditLog?.let { it::recordSecondaryDeleteFailure },
+        )
     val state = ServerState(mailbox = mailbox, mismatchAuditLog = mismatchAuditLog)
 
     embeddedServer(Netty, port = port, host = "0.0.0.0") {

--- a/server/src/test/kotlin/net/af0/where/DualWriteMailboxStateTest.kt
+++ b/server/src/test/kotlin/net/af0/where/DualWriteMailboxStateTest.kt
@@ -225,6 +225,70 @@ class DualWriteMailboxStateTest {
     }
 
     @Test
+    fun `onSecondaryDeleteFailure fires with the op and token hash on a secondary deleteById failure`() {
+        val primary = FakeMailboxStore()
+        val secondary = FakeMailboxStore()
+        val failures = mutableListOf<Triple<String, String, Throwable>>()
+        val dual =
+            DualWriteMailboxState(
+                primary,
+                secondary,
+                testScope,
+                onSecondaryDeleteFailure = { op, tokenHash, error -> failures.add(Triple(op, tokenHash, error)) },
+            )
+        dual.post("token", JsonPrimitive("hi"), "msg-1")
+        secondary.failNext()
+
+        dual.deleteById("token", "msg-1")
+
+        assertEquals(1, failures.size)
+        val (op, tokenHash, error) = failures.single()
+        assertEquals("deleteById", op)
+        assertTrue(tokenHash.isNotBlank())
+        assertEquals("simulated failure", error.message)
+    }
+
+    @Test
+    fun `onSecondaryDeleteFailure fires on a secondary deleteByIds failure`() {
+        val primary = FakeMailboxStore()
+        val secondary = FakeMailboxStore()
+        val failures = mutableListOf<Triple<String, String, Throwable>>()
+        val dual =
+            DualWriteMailboxState(
+                primary,
+                secondary,
+                testScope,
+                onSecondaryDeleteFailure = { op, tokenHash, error -> failures.add(Triple(op, tokenHash, error)) },
+            )
+        dual.post("token", JsonPrimitive("hi"), "msg-1")
+        secondary.failNext()
+
+        dual.deleteByIds("token", listOf("msg-1"))
+
+        assertEquals(1, failures.size)
+        assertEquals("deleteByIds", failures.single().first)
+    }
+
+    @Test
+    fun `onSecondaryDeleteFailure is not invoked when the secondary delete succeeds`() {
+        val primary = FakeMailboxStore()
+        val secondary = FakeMailboxStore()
+        val failures = mutableListOf<Triple<String, String, Throwable>>()
+        val dual =
+            DualWriteMailboxState(
+                primary,
+                secondary,
+                testScope,
+                onSecondaryDeleteFailure = { op, tokenHash, error -> failures.add(Triple(op, tokenHash, error)) },
+            )
+        dual.post("token", JsonPrimitive("hi"), "msg-1")
+
+        dual.deleteById("token", "msg-1")
+
+        assertTrue(failures.isEmpty())
+    }
+
+    @Test
     fun `mirrored deletes prevent false-positive mismatches`() {
         // Regression guard: if deletes were only applied to primary (not mirrored to secondary),
         // every subsequent drain() comparison would show a permanent false-positive mismatch once

--- a/server/src/test/kotlin/net/af0/where/MismatchAuditLogTest.kt
+++ b/server/src/test/kotlin/net/af0/where/MismatchAuditLogTest.kt
@@ -98,6 +98,31 @@ class MismatchAuditLogTest {
     }
 
     @Test
+    fun `successfully pushes a secondary delete failure event to Loki`() {
+        val latch = CountDownLatch(1)
+        var captured: HttpRequestData? = null
+        val engine =
+            MockEngine { request ->
+                captured = request
+                latch.countDown()
+                respond("", HttpStatusCode.NoContent)
+            }
+        val log = MismatchAuditLog("https://logs.example.com", "user-1", "key-1", engine = engine, pushStartupHeartbeat = false)
+
+        log.recordSecondaryDeleteFailure("deleteById", "abc123", RuntimeException("boom"))
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "push should complete")
+        val request = captured!!
+        val stream = Json.parseToJsonElement((request.body as TextContent).text).jsonObject["streams"]!!.jsonArray.single().jsonObject
+        assertEquals("secondary_delete_failure", stream["stream"]!!.jsonObject["event"]!!.jsonPrimitive.content)
+        val line = Json.parseToJsonElement(stream["values"]!!.jsonArray.single().jsonArray[1].jsonPrimitive.content).jsonObject
+        assertEquals("deleteById", line["op"]!!.jsonPrimitive.content)
+        assertEquals("abc123", line["tokenHash"]!!.jsonPrimitive.content)
+        assertEquals("boom", line["error"]!!.jsonPrimitive.content)
+        log.close()
+    }
+
+    @Test
     fun `logs a warning and does not throw when Loki returns a non-2xx status`() {
         val engine = MockEngine { respondError(HttpStatusCode.Unauthorized) }
         val log = MismatchAuditLog("https://logs.example.com", "user-1", "bad-key", engine = engine, pushStartupHeartbeat = false)


### PR DESCRIPTION
## Summary
- Live prod logs showed a `drain mismatch` where Redis (primary) had 0 messages for a token but DynamoDB (shadow) had 2 — traced to `DualWriteMailboxState.deleteById()`/`deleteByIds()` treating the secondary delete as best-effort: a failed secondary delete is logged via `migrationLog.warn` and never retried, leaving a permanent ghost row.
- Those failures had no historical record (not pushed to Loki, unlike drain mismatches), so there was no way to tell how often this happens or whether it's the dominant source of the shadow-comparison's mismatch rate.
- Adds an `onSecondaryDeleteFailure` hook on `DualWriteMailboxState`, wired to a new `MismatchAuditLog.recordSecondaryDeleteFailure()` that pushes a `secondary_delete_failure` event to the same Grafana Cloud Loki stream as `shadow_mismatch`.

## Test plan
- [x] `./gradlew :server:test --tests DualWriteMailboxStateTest --tests MismatchAuditLogTest` passes
- [x] `./gradlew :server:ktlintCheck` passes
- [ ] Confirm the new `secondary_delete_failure` events show up in Grafana Cloud once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dABVPAT1KSEurZQ4puiXx