### PR TITLE
Fix iOS Events log never refreshing on poll failure or sheet open

### DIFF
--- a/ios/Sources/Where/ContentView.swift
+++ b/ios/Sources/Where/ContentView.swift
@@ -120,6 +120,13 @@ struct ContentView: View {
                 },
                 diagnosticLog: syncService.repo.diagnosticLog
             )
+            .onAppear {
+                // diagnosticLog otherwise only refreshes after a poll cycle completes (success
+                // or, since the fix above, failure) - opening the sheet shouldn't have to wait
+                // for the next one, especially right after a stall when there may not be one
+                // for a while.
+                Task { try? await syncService.repo.refreshFromStore() }
+            }
         }
         .fullScreenCover(isPresented: $showScanner, onDismiss: {
             if let url = scannedUrl {

--- a/ios/Sources/Where/LocationSyncService.swift
+++ b/ios/Sources/Where/LocationSyncService.swift
@@ -687,6 +687,11 @@ final class LocationSyncService: ObservableObject {
         } catch {
             logger.error("Poll failed: \(error.localizedDescription)")
             updateStatus(error)
+            // The success path above is the only other place this refreshes - without this,
+            // a poll failure (the case you most want visibility into) leaves the Events log
+            // frozen on whatever it last showed, even though the underlying store just
+            // recorded a new diagnostic event for this exact failure.
+            repo.diagnosticLog = e2eeManager.diagnosticLogSnapshot()
         }
     }
 


### PR DESCRIPTION
## Summary

- `repo.diagnosticLog` (the array backing the Friends sheet's "Events" section) was only ever set in one place: the success path of `pollAll()`'s poll cycle, gated behind `e2eeManager.listFriends()` also succeeding. The `catch` block never touched it — so a poll failure, the moment you most want visibility into what's going wrong, left the Events log frozen on stale data even though the underlying store had just recorded a new diagnostic event for that exact failure.
- `FriendSyncRepository.refreshFromStore()` exists specifically to refresh `friends`/`pendingInvites`/`diagnosticLog` together, but was never called anywhere in the app — dead code.

## Fix

- Also refresh `diagnosticLog` in `pollAll()`'s `catch` block.
- Call `refreshFromStore()` when the Friends sheet appears, so it doesn't have to wait on any poll cycle completing at all (relevant right after a sync stall, when there may not be a next successful poll for a while).

## Test plan

- [ ] CI: Swift compilation (`ios`)
- [ ] Manual: open the Friends sheet after a poll failure and confirm the Events log (long-press a friend row to reveal it) shows the latest entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BovRYX2jstmE1q67MUSyf

---
_Generated by [Claude Code](https://claude.ai/code/session_013BovRYX2jstmE1q67MUSyf)_