### PR TITLE
Improve poll-failure diagnostics and fix cancellation-swallowing bug

### DIFF
--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeMailboxClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/E2eeMailboxClient.kt
@@ -54,6 +54,16 @@ interface MailboxClient {
 }
 
 object KtorMailboxClient : MailboxClient {
+    /**
+     * Coarse suspension-recovery backstop for mailbox requests. Must stay comfortably above
+     * the underlying Ktor HttpClient's requestTimeoutMillis/socketTimeoutMillis (30s, see
+     * HttpClientFactory.kt) so that a genuine slow network trips the client's own, more specific
+     * timeout exception first. If this value is too close to the Ktor timeout, ordinary jitter
+     * races both timers to the same deadline and this generic wall-clock timeout wins instead,
+     * masking the real cause.
+     */
+    private const val MAILBOX_WALL_CLOCK_TIMEOUT_MS = 60_000L
+
     private val json =
         Json {
             classDiscriminator = "type"
@@ -75,7 +85,7 @@ object KtorMailboxClient : MailboxClient {
         payload: MailboxPayload,
     ) {
         try {
-            withWallClockTimeout(30_000) {
+            withWallClockTimeout(MAILBOX_WALL_CLOCK_TIMEOUT_MS) {
                 val url = "$baseUrl/inbox/$token/${payload.msgId}"
                 val response =
                     client.put(url) {
@@ -102,7 +112,7 @@ object KtorMailboxClient : MailboxClient {
         token: String,
     ): List<MailboxPayload> {
         try {
-            return withWallClockTimeout(30_000) {
+            return withWallClockTimeout(MAILBOX_WALL_CLOCK_TIMEOUT_MS) {
                 val response = client.get("$baseUrl/inbox/$token")
                 if (response.status != HttpStatusCode.OK) {
                     throw ServerException(response.status.value, "Failed to poll mailbox")
@@ -120,7 +130,7 @@ object KtorMailboxClient : MailboxClient {
         msgId: String,
     ) {
         try {
-            withWallClockTimeout(30_000) {
+            withWallClockTimeout(MAILBOX_WALL_CLOCK_TIMEOUT_MS) {
                 val response = client.delete("$baseUrl/inbox/$token/$msgId")
                 if (!response.status.isSuccess()) {
                     throw ServerException(response.status.value, "ACK failed for msgId $msgId")
@@ -138,7 +148,7 @@ object KtorMailboxClient : MailboxClient {
     ) {
         if (msgIds.isEmpty()) return
         try {
-            withWallClockTimeout(30_000) {
+            withWallClockTimeout(MAILBOX_WALL_CLOCK_TIMEOUT_MS) {
                 val response =
                     client.delete("$baseUrl/inbox/$token") {
                         parameter("ids", msgIds.joinToString(","))

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -248,7 +248,20 @@ open class LocationClient(
                 val messages =
                     try {
                         service.poll(currentToken)
+                    } catch (e: WallClockTimeoutCancellationException) {
+                        // A wall-clock timeout is an ordinary, expected request failure (same role
+                        // as any other network exception) even though it's implemented as a
+                        // CancellationException - it must NOT propagate like a real structured-
+                        // concurrency cancellation would, or every routine timeout would skip this
+                        // friend's updateLastPollTs/processOutbox/keepalive-backstop check below.
+                        val elapsedMs = currentTimeMillis() - pollStartMs
+                        store.addDiagnosticEvent(
+                            "poll($friendId) failed on $currentToken after ${elapsedMs}ms: ${e.message}",
+                        )
+                        stopPolling = true
+                        continue
                     } catch (e: CancellationException) {
+                        // Any OTHER cancellation is a genuine outer shutdown signal - must propagate.
                         throw e
                     } catch (e: Exception) {
                         val elapsedMs = currentTimeMillis() - pollStartMs

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -244,12 +244,19 @@ open class LocationClient(
                 val friend = store.getFriend(friendId) ?: break
                 val currentToken = friend.session.recvToken.toHex()
 
+                val pollStartMs = currentTimeMillis()
                 val messages =
                     try {
                         service.poll(currentToken)
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
-                        store.addDiagnosticEvent("poll($friendId) failed on $currentToken: ${e.message}")
-                        emptyList()
+                        val elapsedMs = currentTimeMillis() - pollStartMs
+                        store.addDiagnosticEvent(
+                            "poll($friendId) failed on $currentToken after ${elapsedMs}ms: ${e.message}",
+                        )
+                        stopPolling = true
+                        continue
                     }
 
                 if (messages.isEmpty()) {

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -138,6 +138,8 @@ open class LocationClient(
                                     val isPaused = !sharingEnabled || friend.id in pausedFriendIds
                                     val updates = pollFriend(friend.id, isPaused)
                                     Pair(updates, null)
+                                } catch (e: CancellationException) {
+                                    throw e
                                 } catch (e: Exception) {
                                     Pair(emptyList<UserLocation>(), e)
                                 } finally {
@@ -146,6 +148,8 @@ open class LocationClient(
                                     }
                                 }
                             }
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             Pair(emptyList<UserLocation>(), e)
                         }
@@ -245,6 +249,13 @@ open class LocationClient(
                 val currentToken = friend.session.recvToken.toHex()
 
                 val pollStartMs = currentTimeMillis()
+                fun recordPollFailure(e: Throwable) {
+                    val elapsedMs = currentTimeMillis() - pollStartMs
+                    store.addDiagnosticEvent(
+                        "poll($friendId) failed on $currentToken after ${elapsedMs}ms: ${e.message}",
+                    )
+                    stopPolling = true
+                }
                 val messages =
                     try {
                         service.poll(currentToken)
@@ -254,21 +265,13 @@ open class LocationClient(
                         // CancellationException - it must NOT propagate like a real structured-
                         // concurrency cancellation would, or every routine timeout would skip this
                         // friend's updateLastPollTs/processOutbox/keepalive-backstop check below.
-                        val elapsedMs = currentTimeMillis() - pollStartMs
-                        store.addDiagnosticEvent(
-                            "poll($friendId) failed on $currentToken after ${elapsedMs}ms: ${e.message}",
-                        )
-                        stopPolling = true
+                        recordPollFailure(e)
                         continue
                     } catch (e: CancellationException) {
                         // Any OTHER cancellation is a genuine outer shutdown signal - must propagate.
                         throw e
                     } catch (e: Exception) {
-                        val elapsedMs = currentTimeMillis() - pollStartMs
-                        store.addDiagnosticEvent(
-                            "poll($friendId) failed on $currentToken after ${elapsedMs}ms: ${e.message}",
-                        )
-                        stopPolling = true
+                        recordPollFailure(e)
                         continue
                     }
 

--- a/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
+++ b/shared/src/commonMain/kotlin/net/af0/where/e2ee/LocationClient.kt
@@ -249,6 +249,7 @@ open class LocationClient(
                 val currentToken = friend.session.recvToken.toHex()
 
                 val pollStartMs = currentTimeMillis()
+
                 fun recordPollFailure(e: Throwable) {
                     val elapsedMs = currentTimeMillis() - pollStartMs
                     store.addDiagnosticEvent(
@@ -256,6 +257,7 @@ open class LocationClient(
                     )
                     stopPolling = true
                 }
+
                 val messages =
                     try {
                         service.poll(currentToken)

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/PollFailureHandlingTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/PollFailureHandlingTest.kt
@@ -1,0 +1,119 @@
+package net.af0.where.e2ee
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+
+/**
+ * Regression coverage for pollFriend()'s handling of a failed service.poll() call: it must not
+ * mark the friend as caught-up on a genuine failure, and it must let a real (non-wall-clock)
+ * CancellationException propagate instead of swallowing it and continuing as if nothing happened.
+ */
+class PollFailureHandlingTest {
+    /** Wraps a real MailboxClient but can be told to throw once (or always) from poll(). */
+    private class FaultInjectingMailboxClient(private val delegate: MailboxClient) : MailboxClient {
+        var pollExceptionOnce: Throwable? = null
+        var pollExceptionAlways: Throwable? = null
+
+        override suspend fun post(
+            baseUrl: String,
+            token: String,
+            payload: MailboxPayload,
+        ) = delegate.post(baseUrl, token, payload)
+
+        override suspend fun poll(
+            baseUrl: String,
+            token: String,
+        ): List<MailboxPayload> {
+            pollExceptionAlways?.let { throw it }
+            pollExceptionOnce?.let {
+                pollExceptionOnce = null
+                throw it
+            }
+            return delegate.poll(baseUrl, token)
+        }
+
+        override suspend fun ackId(
+            baseUrl: String,
+            token: String,
+            msgId: String,
+        ) = delegate.ackId(baseUrl, token, msgId)
+
+        override suspend fun ackIds(
+            baseUrl: String,
+            token: String,
+            msgIds: List<String>,
+        ) = delegate.ackIds(baseUrl, token, msgIds)
+    }
+
+    init {
+        initializeE2eeTests()
+    }
+
+    private suspend fun setupFriendship(mailbox: MailboxClient): Triple<E2eeManager, LocationClient, FriendEntry> {
+        val aliceDriver = createTestSqlDriver()
+        val aliceManager = testE2eeManager(aliceDriver)
+        val aliceClient = LocationClient("http://localhost", aliceManager, mailbox)
+        val qr = aliceManager.createInvite("Alice")
+
+        val bobDriver = createTestSqlDriver()
+        val bobManager = testE2eeManager(bobDriver)
+        val bobClient = LocationClient("http://localhost", bobManager, mailbox)
+
+        val (initPayload, bobEntry) = bobManager.processScannedQr(qr, "Bob")
+        bobClient.postKeyExchangeInit(bobEntry.id, qr, initPayload)
+        val pending = aliceClient.pollPendingInvites()
+        aliceManager.processKeyExchangeInit(pending[0].payload, "Bob", pending[0].inviteEkPub)
+
+        val aliceFriend = aliceManager.getFriend(bobEntry.id)!!
+        for (i in 1..5) {
+            val (msg, _) = bobManager.encryptAndAdvance(bobEntry.id, MessagePlaintext.Location(37.0 + i, -122.0, 0.0, 1000L + i))
+            mailbox.post("http://localhost", aliceFriend.session.recvToken.toHex(), msg)
+        }
+
+        return Triple(aliceManager, aliceClient, aliceFriend)
+    }
+
+    @Test
+    fun testCaughtUpNotSetOnPollFailure() =
+        runTest {
+            val realMailbox = MemoryMailboxClient()
+            val faultyMailbox = FaultInjectingMailboxClient(realMailbox)
+            val (aliceManager, aliceClient, aliceFriend) = setupFriendship(faultyMailbox)
+
+            assertFalse(aliceManager.getFriend(aliceFriend.id)!!.isCaughtUp, "Should not be caught up initially")
+
+            // First poll fails outright - should NOT be recorded as caught up.
+            faultyMailbox.pollExceptionOnce = NetworkException("Simulated network failure on POLL")
+            aliceClient.poll()
+            assertFalse(
+                aliceManager.getFriend(aliceFriend.id)!!.isCaughtUp,
+                "A failed poll must not be recorded as caught up",
+            )
+
+            // A subsequent successful poll should drain the mailbox and mark caught-up normally.
+            val updates = aliceClient.poll()
+            assertEquals(5, updates.size)
+            assertTrue(
+                aliceManager.getFriend(aliceFriend.id)!!.isCaughtUp,
+                "Should be caught up once the retry actually succeeds",
+            )
+        }
+
+    @Test
+    fun testGenuineCancellationPropagatesFromPollFriend() =
+        runTest {
+            val realMailbox = MemoryMailboxClient()
+            val faultyMailbox = FaultInjectingMailboxClient(realMailbox)
+            val (_, aliceClient, aliceFriend) = setupFriendship(faultyMailbox)
+
+            // A real (non-wall-clock) CancellationException represents genuine structured-
+            // concurrency cancellation, e.g. the app shutting down mid-poll - it must propagate
+            // out of pollFriend rather than being swallowed and treated as an ordinary failure.
+            faultyMailbox.pollExceptionAlways = CancellationException("simulated outer cancellation")
+
+            assertFailsWith<CancellationException> {
+                aliceClient.pollFriend(aliceFriend.id)
+            }
+        }
+}

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/PollFailureHandlingTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/PollFailureHandlingTest.kt
@@ -135,4 +135,36 @@ class PollFailureHandlingTest {
                 aliceClient.poll()
             }
         }
+
+    @Test
+    fun testWallClockTimeoutHandledAsOrdinaryFailureNotPropagated() =
+        runTest {
+            // WallClockTimeoutCancellationException IS a CancellationException, but it's a
+            // self-inflicted, expected "this one request timed out" signal (E2eeMailboxClient
+            // wraps every mailbox call in withWallClockTimeout) - not a genuine structured-
+            // concurrency shutdown. Unlike the real-cancellation cases above, it must NOT
+            // propagate out of pollFriend(): doing so would skip updateLastPollTs()/
+            // processOutbox()/the automated keepalive backstop check for every routine timeout,
+            // which is the opposite of what's wanted since timeouts are the common case this
+            // whole investigation started from.
+            val realMailbox = MemoryMailboxClient()
+            val faultyMailbox = FaultInjectingMailboxClient(realMailbox)
+            val (aliceManager, aliceClient, aliceFriend) = setupFriendship(faultyMailbox)
+
+            assertEquals(0L, aliceManager.getFriend(aliceFriend.id)!!.lastPollTs, "Sanity check: no poll recorded yet")
+
+            faultyMailbox.pollExceptionOnce = WallClockTimeoutCancellationException()
+
+            // Must return normally (not throw) - a timeout is handled like any other failure.
+            val updates = aliceClient.pollFriend(aliceFriend.id)
+            assertTrue(updates.isEmpty(), "A timed-out poll should yield no updates")
+
+            val friendAfter = aliceManager.getFriend(aliceFriend.id)!!
+            assertFalse(friendAfter.isCaughtUp, "A timed-out poll must not be recorded as caught up")
+            assertTrue(
+                friendAfter.lastPollTs > 0L,
+                "Per-friend housekeeping (updateLastPollTs/processOutbox/keepalive backstop) must " +
+                    "still run after an ordinary wall-clock timeout, unlike a genuine cancellation",
+            )
+        }
 }

--- a/shared/src/commonTest/kotlin/net/af0/where/e2ee/PollFailureHandlingTest.kt
+++ b/shared/src/commonTest/kotlin/net/af0/where/e2ee/PollFailureHandlingTest.kt
@@ -116,4 +116,23 @@ class PollFailureHandlingTest {
                 aliceClient.pollFriend(aliceFriend.id)
             }
         }
+
+    @Test
+    fun testGenuineCancellationPropagatesFromPoll() =
+        runTest {
+            // Same scenario as testGenuineCancellationPropagatesFromPollFriend, but through the
+            // real production call path (poll()'s per-friend async block) rather than calling
+            // pollFriend() directly - poll() has its own catch (e: Exception) around pollFriend()
+            // that would silently re-swallow a rethrown CancellationException if it weren't also
+            // narrowed to let CancellationException through.
+            val realMailbox = MemoryMailboxClient()
+            val faultyMailbox = FaultInjectingMailboxClient(realMailbox)
+            val (_, aliceClient, _) = setupFriendship(faultyMailbox)
+
+            faultyMailbox.pollExceptionAlways = CancellationException("simulated outer cancellation")
+
+            assertFailsWith<CancellationException> {
+                aliceClient.poll()
+            }
+        }
 }


### PR DESCRIPTION
## Summary
- **Correctness fix**: `pollFriend()`'s `catch (e: Exception)` around `service.poll()` was catching `CancellationException` too, silently absorbing it instead of letting a genuine outer cancellation propagate, and unconditionally set `caughtUp = true` even when the poll had actually failed (rather than succeeded with zero messages). Fixed both.
  - Refined during review: a blanket rethrow of every `CancellationException` was too broad, since `WallClockTimeoutCancellationException` is itself a `CancellationException` subtype but functions as an *ordinary, expected* request-timeout signal (same role as any other network exception), not a real structured-concurrency shutdown signal. Rethrowing it unconditionally would've made every routine poll timeout skip `updateLastPollTs`/`processOutbox`/the automated keepalive backstop check for that friend that cycle - the opposite of what's wanted when timeouts are common. Now only a genuine (non-wall-clock) `CancellationException` propagates; a wall-clock timeout is handled like any other failure, just without incorrectly marking the friend caught-up.
- **Diagnostics**: the poll-failure diagnostic event now logs actual elapsed wall-clock time around the call, so a future occurrence tells us directly whether it was a genuine multi-second stall or something else (e.g. a clock correction), instead of just a generic message.
- **Minor timeout-layering cleanup**: the mailbox client's outer `withWallClockTimeout` (a coarse suspension-recovery backstop) was set to the same 30s value as the inner Ktor `HttpTimeout`'s `requestTimeoutMillis`/`socketTimeoutMillis`, so both timers raced to an identical deadline and the generic outer exception could mask Ktor's own more specific one. Raised to 60s so Ktor's timeout (and its specific exception type) surfaces first under normal conditions.
- **Tests**: added `PollFailureHandlingTest` with two regression cases - a failed poll must not mark `isCaughtUp`, and a real (non-wall-clock) `CancellationException` must propagate out of `pollFriend()` rather than being swallowed. Both verified to fail against the pre-fix code (confirmed by manually reverting to `origin/main`'s version and re-running) before being fixed.

**Note:** investigation into a real-world instance of repeated "Wall-clock timeout exceeded" poll failures (2 friends failing together, 3x within tens of seconds, on Wi-Fi, in the foreground) did not conclusively identify a root cause via client-side theories (OS suspension, connection-pool exhaustion, a cancellation-swallowing amplification loop were each checked against the evidence and ruled out) - the actual root cause turned out to be the production server OOM-crash-looping (fixed separately in #356). None of the changes in this PR are claimed to fix that specific symptom; they're independently-correct bugs/tests/diagnostics found along the way.

## Test plan
- [x] `./gradlew :shared:jvmTest` passes, including the two new regression tests
- [x] Both new tests confirmed to fail against the pre-fix code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fhxLvxeDk58yGRxZUBQSA