### PR TITLE
Bump where-api VM memory to stop OOM crash loops

### DIFF
--- a/server/fly.toml
+++ b/server/fly.toml
@@ -32,4 +32,4 @@ primary_region = 'fra'
 
 [[vm]]
   cpus = 1
-  memory_mb = 256
+  memory_mb = 512


### PR DESCRIPTION
## Summary
- `fly machine status -a where-api` showed repeated `exit_code=137, oom_killed=true` restarts today. 256MB is tight for this JVM (Ktor/Netty + AWS SDK v2 DynamoDB client + Redis client, currently both live under `MAILBOX_STORE_MODE = 'dual-write-redis-primary'`) - metaspace, thread stacks, and Netty's off-heap direct buffers sit outside any `-Xmx` heap ceiling, so RSS can exceed the container limit even with a conservative heap.
- Each OOM kill is a full-machine outage until restart, which explains client-reported *correlated* poll/send failures across multiple friends at the same moments (a dead machine fails every in-flight request at once, not just one client's).
- Bumped `server/fly.toml`'s `[[vm]] memory_mb` from 256 to 512.
- Already applied the same bump live via `fly scale memory 512 -a where-api` as an immediate mitigation; this PR makes it durable across future deploys.

## Follow-ups (not in this PR)
- Revisit shrinking memory back down once the Redis->DynamoDB mailbox migration finishes and the Redis client is dropped (dual-write mode is likely a meaningful chunk of the current footprint).
- Uptime/crash-loop monitoring is being added separately in #357.

## Test plan
- [x] Live machine confirmed healthy at 512MB (`fly status`, `/health` returns 200) after applying the scale change
- [ ] Watch `fly machine status` over the next day for further OOM kills at the new memory size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fhxLvxeDk58yGRxZUBQSA