### PR TITLE
Add Healthchecks.io ping for where-api uptime monitoring

### DIFF
--- a/server/src/main/kotlin/net/af0/where/Server.kt
+++ b/server/src/main/kotlin/net/af0/where/Server.kt
@@ -5,6 +5,7 @@ import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.basicAuth
+import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.*
@@ -1206,7 +1207,17 @@ data class ServerState(
     val trustProxy: Boolean = System.getenv("TRUST_PROXY")?.toBoolean() ?: false,
     val debug: Boolean = false,
     val mismatchAuditLog: MismatchAuditLog? = null,
+    val healthcheckPingUrl: String? = null,
 )
+
+/**
+ * How often the process pings HEALTHCHECK_PING_URL (a Healthchecks.io-style dead-man's-switch
+ * URL) while it's alive and its event loop is responsive. Deliberately much shorter than
+ * whatever period/grace the check itself is configured with in Healthchecks.io (e.g. a 5min
+ * period / 2min grace) so a couple of missed pings from transient blips don't false-positive,
+ * while a real sustained outage (crash loop, hung process) is still caught within a few minutes.
+ */
+private const val HEALTHCHECK_PING_INTERVAL_MS = 60_000L
 
 /**
  * "redis" / "dynamodb": that store alone.
@@ -1298,7 +1309,11 @@ fun main() {
             onMismatch = mismatchAuditLog?.let { it::record },
             onSecondaryDeleteFailure = mismatchAuditLog?.let { it::recordSecondaryDeleteFailure },
         )
-    val state = ServerState(mailbox = mailbox, mismatchAuditLog = mismatchAuditLog)
+    val healthcheckPingUrl = System.getenv("HEALTHCHECK_PING_URL")
+    if (healthcheckPingUrl == null) {
+        auditLog.warn("HEALTHCHECK_PING_URL not set; no external uptime monitoring configured")
+    }
+    val state = ServerState(mailbox = mailbox, mismatchAuditLog = mismatchAuditLog, healthcheckPingUrl = healthcheckPingUrl)
 
     embeddedServer(Netty, port = port, host = "0.0.0.0") {
         module(state)
@@ -1317,6 +1332,24 @@ fun Application.module(state: ServerState = ServerState()) {
         while (isActive) {
             delay(RATE_LIMIT_WINDOW_MS)
             state.mailbox.evict()
+        }
+    }
+
+    if (state.healthcheckPingUrl != null) {
+        val healthcheckClient =
+            HttpClient(CIO) {
+                install(HttpTimeout) {
+                    requestTimeoutMillis = 10_000
+                    connectTimeoutMillis = 10_000
+                }
+            }
+        monitor.subscribe(ApplicationStopped) { healthcheckClient.close() }
+        launch(Dispatchers.Default) {
+            while (isActive) {
+                runCatching { healthcheckClient.get(state.healthcheckPingUrl) }
+                    .onFailure { auditLog.warn("Healthchecks.io ping failed", it) }
+                delay(HEALTHCHECK_PING_INTERVAL_MS)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- The server had no external monitoring for crash loops or outages: Fly's own `/health` check only drives its internal routing/restart behavior and never notifies a human, and the existing Loki wiring only covers one narrow shadow-write audit-log path (unrelated to general uptime).
- Adds a periodic (60s) background ping to `HEALTHCHECK_PING_URL` while the server's event loop is alive and responsive - a Healthchecks.io-style dead-man's-switch URL. A sustained outage or crash loop shows up as missed pings once the check's configured period/grace is exceeded, triggering whatever alerting is already set up on that Healthchecks.io check.
- `HEALTHCHECK_PING_URL` is optional, same pattern as the existing `LOKI_URL`/`LOKI_USER`/`LOKI_API_KEY` handling - unset, it just logs a warning and skips the ping loop entirely (safe default for local dev/tests).
- Set `HEALTHCHECK_PING_URL` as a Fly secret on `where-api` separately (not in this diff, since it's a value, not code).

**Known limitation:** this only catches sustained downtime (ping interval vs. the check's period/grace). A brief crash-and-auto-restart cycle that recovers faster than the ping cadence (e.g. the OOM-kill-and-restart pattern fixed in #356) won't trip this - that class of problem needs something reading Fly's own machine event log instead, which is out of scope here.

## Test plan
- [x] `./gradlew :server:compileKotlin` succeeds
- [x] `./gradlew :server:test` - same 21 pre-existing failures as on `main` (local JDK/DynamoDB-local reflection issue, unrelated to this change), no new failures
- [ ] Set `HEALTHCHECK_PING_URL` fly secret and deploy; confirm the Healthchecks.io check goes green and stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fhxLvxeDk58yGRxZUBQSA